### PR TITLE
Support ParentKey in branch name templates

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -242,6 +242,9 @@ git:
         type: "Bug"
       template: "bugfix/{{.Key}}-{{.Summary | slugify}}"
     - when:
+        type: "Sub-task"
+      template: "{{.ParentKey}}/{{.Key}}_{{.Summary | slugify}}"
+    - when:
         type: "*"
       template: "{{.Key}}-{{.Summary | slugify}}"
 ```
@@ -255,8 +258,12 @@ Template variables.
 | Variable | Description |
 |----------|-------------|
 | `{{.Key}}` | Issue key like PROJ-123 |
+| `{{.ProjectKey}}` | Project prefix extracted from key (e.g. PROJ) |
+| `{{.Number}}` | Issue number extracted from key (e.g. 123) |
 | `{{.Summary}}` | Issue summary |
 | `{{.Summary \| slugify}}` | Summary as a slug, lowercase with dashes |
+| `{{.Type}}` | Issue type name (e.g. Bug, Story, Task) |
+| `{{.ParentKey}}` | Parent issue key (empty if no parent) |
 
 ## Files
 

--- a/pkg/git/branchname.go
+++ b/pkg/git/branchname.go
@@ -15,6 +15,7 @@ type BranchTemplateData struct {
 	Number     string
 	Summary    string
 	Type       string
+	ParentKey  string
 }
 
 const defaultTemplate = "{{.Key}}-{{.Summary}}"
@@ -53,6 +54,7 @@ func GenerateBranchName(data BranchTemplateData, tmplStr string, asciiOnly bool)
 
 // Sanitize cleans a branch name to be a valid git ref
 func Sanitize(name string, asciiOnly bool) string {
+	name = strings.TrimLeft(name, "/")
 	name = strings.ReplaceAll(name, " ", "-")
 	name = invalidChars.ReplaceAllString(name, "")
 	name = strings.ReplaceAll(name, "..", ".")

--- a/pkg/git/branchname_test.go
+++ b/pkg/git/branchname_test.go
@@ -1,0 +1,125 @@
+package git
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGenerateBranchName(t *testing.T) {
+	tests := []struct {
+		name      string
+		data      BranchTemplateData
+		tmpl      string
+		asciiOnly bool
+		want      string
+	}{
+		{
+			name: "default template",
+			data: BranchTemplateData{
+				Key:     "PROJ-123",
+				Summary: "fix-login",
+			},
+			want: "PROJ-123-fix-login",
+		},
+		{
+			name: "with parent key",
+			data: BranchTemplateData{
+				Key:       "PROJ-142",
+				ParentKey: "PROJ-100",
+				Summary:   "fix-login-validation",
+			},
+			tmpl: "{{.ParentKey}}/{{.Key}}_{{.Summary}}",
+			want: "PROJ-100/PROJ-142_fix-login-validation",
+		},
+		{
+			name: "empty parent key strips leading slash",
+			data: BranchTemplateData{
+				Key:     "PROJ-142",
+				Summary: "fix-login",
+			},
+			tmpl: "{{.ParentKey}}/{{.Key}}_{{.Summary}}",
+			want: "PROJ-142_fix-login",
+		},
+		{
+			name: "all fields",
+			data: BranchTemplateData{
+				Key:        "PROJ-42",
+				ProjectKey: "PROJ",
+				Number:     "42",
+				Summary:    "add-feature",
+				Type:       "Story",
+				ParentKey:  "PROJ-10",
+			},
+			tmpl: "{{.Type}}/{{.ParentKey}}/{{.Key}}-{{.Summary}}",
+			want: "Story/PROJ-10/PROJ-42-add-feature",
+		},
+		{
+			name: "ascii only strips unicode from summary",
+			data: BranchTemplateData{
+				Key:       "PROJ-1",
+				ParentKey: "PROJ-2",
+				Summary:   "fix-\u00e4\u00f6\u00fc-bug",
+			},
+			tmpl:      "{{.ParentKey}}/{{.Key}}_{{.Summary}}",
+			asciiOnly: true,
+			want:      "PROJ-2/PROJ-1_fix-bug",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := GenerateBranchName(tt.data, tt.tmpl, tt.asciiOnly)
+			if got != tt.want {
+				t.Errorf("GenerateBranchName() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSanitize(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		asciiOnly bool
+		want      string
+	}{
+		{"spaces to hyphens", "hello world", false, "hello-world"},
+		{"multiple hyphens", "a---b", false, "a-b"},
+		{"trailing dot", "branch.", false, "branch"},
+		{"trailing slash", "branch/", false, "branch"},
+		{"max length truncation", "a-" + strings.Repeat("b", 100), false, "a-" + strings.Repeat("b", 58)},
+		{"slash preserved", "parent/child", false, "parent/child"},
+		{"leading slash stripped", "/child", false, "child"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Sanitize(tt.input, tt.asciiOnly)
+			if got != tt.want {
+				t.Errorf("Sanitize(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSanitizeSummary(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		asciiOnly bool
+		want      string
+	}{
+		{"basic", "Fix Login Bug", false, "fix-login-bug"},
+		{"special chars", "Add feature (v2) & test!", false, "add-feature-v2-test"},
+		{"ascii only", "Umlaut aeoeue", true, "umlaut-aeoeue"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := SanitizeSummary(tt.input, tt.asciiOnly)
+			if got != tt.want {
+				t.Errorf("SanitizeSummary(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/jira/client.go
+++ b/pkg/jira/client.go
@@ -248,7 +248,7 @@ func (c *Client) GetIssue(ctx context.Context, issueKey string) (*Issue, error) 
 }
 
 func (c *Client) SearchIssues(ctx context.Context, jql string, startAt, maxResults int) (*SearchResult, error) {
-	fields := "summary,description,status,priority,assignee,reporter,labels,components,sprint,issuetype,created,updated,subtasks,issuelinks"
+	fields := "summary,description,status,priority,assignee,reporter,labels,components,sprint,issuetype,created,updated,subtasks,issuelinks,parent"
 	if len(c.customFieldIDs) > 0 {
 		fields += "," + strings.Join(c.customFieldIDs, ",")
 	}
@@ -714,6 +714,7 @@ type issueFieldsResponse struct {
 	Components  []Component         `json:"components"`
 	Sprint      *Sprint             `json:"sprint"`
 	IssueType   *IssueType          `json:"issuetype"`
+	Parent      *issueResponse      `json:"parent"`
 	Created     JiraTime            `json:"created"`
 	Updated     JiraTime            `json:"updated"`
 	Subtasks    []issueResponse     `json:"subtasks"`
@@ -790,6 +791,11 @@ func (r *issueResponse) toIssue() Issue {
 	if r.Fields.Reporter != nil {
 		u := r.Fields.Reporter.toUser()
 		issue.Reporter = &u
+	}
+
+	if r.Fields.Parent != nil {
+		p := r.Fields.Parent.toIssue()
+		issue.Parent = &p
 	}
 
 	issue.Subtasks = make([]Issue, len(r.Fields.Subtasks))

--- a/pkg/jira/models.go
+++ b/pkg/jira/models.go
@@ -55,6 +55,7 @@ type Issue struct {
 	Components  []Component `json:"-"`
 	Sprint      *Sprint     `json:"-"`
 	IssueType   *IssueType  `json:"-"`
+	Parent      *Issue      `json:"-"`
 	Created     time.Time   `json:"-"`
 	Updated     time.Time   `json:"-"`
 	Subtasks    []Issue     `json:"-"`

--- a/pkg/tui/handlers_keys.go
+++ b/pkg/tui/handlers_keys.go
@@ -537,12 +537,17 @@ func (a *App) handleActionCreateBranch() (tea.Model, tea.Cmd) {
 	if sel.IssueType != nil {
 		typeName = sel.IssueType.Name
 	}
+	parentKey := ""
+	if sel.Parent != nil {
+		parentKey = sel.Parent.Key
+	}
 	data := git.BranchTemplateData{
 		Key:        sel.Key,
 		ProjectKey: projKey,
 		Number:     number,
 		Summary:    git.SanitizeSummary(sel.Summary, a.cfg.Git.AsciiOnly),
 		Type:       typeName,
+		ParentKey:  parentKey,
 	}
 	tmplStr := ""
 	for _, r := range a.cfg.Git.BranchFormat {


### PR DESCRIPTION
Closes #29

Adds `ParentKey` to `BranchTemplateData` so branch templates can
reference the parent issue key, e.g. `{{.ParentKey}}/{{.Key}}_{{.Summary}}`
for subtask workflows.

The implementation follows the existing `Subtasks` pattern: request the
`parent` field from the API, parse it in the response, and map it in
`toIssue()`. `Sanitize()` now strips leading slashes so an empty
`ParentKey` doesn't produce an invalid branch name.

Also documented `ProjectKey`, `Number`, and `Type` in the template
variables table. They were already available but missing from the docs.

**To test:** add a `Sub-task` branch format rule to your config, e.g.:

```yaml
git:
  branchFormat:
    - when:
        type: "Sub-task"
      template: "{{.ParentKey}}/{{.Key}}_{{.Summary}}"
    - when:
        type: "*"
      template: "{{.Key}}-{{.Summary}}"
```

Select a subtask, press `b`, check that the parent key appears in the
generated branch name. `go test ./pkg/git/...` covers the template
logic.