### PR TITLE
fix: paginate assignable users to show all org members

### DIFF
--- a/pkg/jira/client.go
+++ b/pkg/jira/client.go
@@ -626,9 +626,20 @@ func (c *Client) GetMyself(ctx context.Context) (*User, error) {
 
 func (c *Client) GetUsers(ctx context.Context, projectKey string) ([]User, error) {
 	var raw []userResponse
-	err := c.do(ctx, http.MethodGet, "/user/assignable/search?project="+projectKey+"&maxResults=100", nil, &raw)
-	if err != nil {
-		return nil, fmt.Errorf("get users for project %s: %w", projectKey, err)
+	startAt := 0
+	const pageSize = 100
+	for {
+		var page []userResponse
+		path := fmt.Sprintf("/user/assignable/search?project=%s&startAt=%d&maxResults=%d",
+			projectKey, startAt, pageSize)
+		if err := c.do(ctx, http.MethodGet, path, nil, &page); err != nil {
+			return nil, fmt.Errorf("get users for project %s: %w", projectKey, err)
+		}
+		raw = append(raw, page...)
+		if len(page) < pageSize {
+			break
+		}
+		startAt += len(page)
 	}
 	users := make([]User, len(raw))
 	for i, ru := range raw {


### PR DESCRIPTION
## Summary

`GetUsers` in `pkg/jira/client.go` was hardcoded to fetch at most 100 assignable users. For large organizations, this cut off the list before reaching many team members.

Now fetches pages of 100 in a loop (same pattern as `GetProjects`), appending results until a page returns fewer than 100 items. The `/user/assignable/search` endpoint returns a flat array, so pagination uses `startAt` offset increments.

## Changes

- `pkg/jira/client.go`: `GetUsers()` now loops with `startAt` pagination instead of a single request with `maxResults=100`

## Testing

- `go build ./...` passes
- `go test ./pkg/jira/...` passes
- Pre-existing failure in `TestOverlayStack_RenderFirstVisible` is unrelated (UI overlay test)

Fixes #31

This contribution was developed with AI assistance (Claude Code).