### PR TITLE
Add configurable custom commands

### DIFF
--- a/cmd/lazyjira/main.go
+++ b/cmd/lazyjira/main.go
@@ -55,7 +55,11 @@ func run() error {
 	if *demo {
 		cfg = config.DefaultConfig()
 	} else {
-		cfg, _ = config.Load()
+		var err error
+		cfg, err = config.Load()
+		if err != nil {
+			return fmt.Errorf("loading config: %w", err)
+		}
 	}
 
 	var client jira.ClientInterface
@@ -100,6 +104,7 @@ func run() error {
 
 	tui.Version = version
 	app := tui.NewAppWithAuth(cfg, client, authMethod)
+	defer app.Shutdown()
 
 	p := tea.NewProgram(app, tea.WithAltScreen(), tea.WithMouseCellMotion())
 	_, err := p.Run()
@@ -321,8 +326,12 @@ func runAuth(args []string) {
 	authFlags := flag.NewFlagSet("auth", flag.ExitOnError)
 	_ = authFlags.Parse(args)
 
-	cfg, _ := config.Load()
-	_, err := runSetupWizard(cfg)
+	cfg, err := config.Load()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error loading config: %v\n", err)
+		os.Exit(1)
+	}
+	_, err = runSetupWizard(cfg)
 	if err != nil {
 		os.Exit(1)
 	}

--- a/docs/Config.md
+++ b/docs/Config.md
@@ -292,6 +292,101 @@ Template variables.
 | `{{.Type}}` | Issue type name (e.g. Bug, Story, Task) |
 | `{{.ParentKey}}` | Parent issue key (empty if no parent) |
 
+## Custom commands
+
+Bind shell commands to keys, with Go template access to the focused issue, project, or comment. Custom bindings take precedence over built-in keys, so they can be used to override any action.
+
+```yaml
+customCommands:
+  - key: "ctrl+y"
+    name: "Copy issue key"
+    command: "printf %s {{.Key}} | wl-copy"
+    suspend: false
+  - key: "ctrl+l"
+    name: "Copy comment link"
+    command: "printf '%s?focusedCommentId=%s' {{.URL}} {{.CommentID}} | wl-copy"
+    contexts: [detail.comments]
+    suspend: false
+  - key: "ctrl+w"
+    name: "Log work"
+    command: "jira issue worklog add {{.Key}}"
+```
+
+Each command has:
+
+| Field | Description |
+|-------|-------------|
+| `key` | Key binding. Supports single letters, modifiers (`ctrl+x`, `alt+x`), and special keys (`tab`, `enter`). |
+| `name` | Label shown in the help overlay and help bar. |
+| `command` | Shell command string. Rendered as a Go template before execution. |
+| `contexts` | Optional list of UI contexts the command fires in. Defaults to `[issues, info, detail]`. |
+| `suspend` | Optional. `true` (default) hands the terminal to the child process; set `false` for background commands like clipboard copies or notifications. |
+
+### Contexts
+
+A command fires when one of its declared contexts matches the current UI state.
+
+| Context | Active when |
+|---------|-------------|
+| `issues` | Issues list panel is focused. |
+| `info` | Info panel is focused (any sub-tab). |
+| `projects` | Projects list panel is focused. |
+| `detail` | Right detail panel is showing an issue, on any tab. |
+| `detail.comments` | Right detail panel is on the Comments tab with a comment selected. |
+
+When more than one context matches at the same time (`detail` and `detail.comments` in the Comments tab), the more specific context wins.
+
+### Template variables
+
+The fields available to the template depend on the command's contexts.
+
+**Issue scope** (`issues`, `info`, `detail`):
+
+| Variable | Description |
+|----------|-------------|
+| `{{.Key}}` | Issue key like `PROJ-123`. |
+| `{{.ProjectKey}}` | Project prefix extracted from the key. |
+| `{{.ParentKey}}` | Parent issue key (empty if no parent). |
+| `{{.Summary}}` | Issue summary. |
+| `{{.Type}}` | Issue type name. |
+| `{{.Status}}` | Status name. |
+| `{{.Assignee}}` | Assignee display name. |
+| `{{.Priority}}` | Priority name. |
+| `{{.URL}}` | Fully qualified issue URL. |
+
+**Project scope** (`projects`):
+
+| Variable | Description |
+|----------|-------------|
+| `{{.ProjectKey}}` | Project key. |
+| `{{.ProjectName}}` | Project name. |
+
+**Comment scope** (`detail.comments`):
+
+Exposes the Issue scope fields above plus the focused comment:
+
+| Variable | Description |
+|----------|-------------|
+| `{{.CommentID}}` | Comment ID. |
+| `{{.CommentAuthor}}` | Comment author display name. |
+| `{{.CommentBody}}` | Comment body. |
+
+### Shared fields
+
+Available in every scope:
+
+| Variable | Description |
+|----------|-------------|
+| `{{.JiraHost}}` | Jira host from the Jira config. |
+| `{{.GitBranch}}` | Current git branch, if lazyjira was started in a git repo. |
+| `{{.GitRepoPath}}` | Git repository path. |
+
+### Template helpers
+
+| Helper | Description |
+|--------|-------------|
+| `{{.X \| shellescape}}` | Wraps the value in single quotes with inner quotes escaped. Use for any template value that could contain shell metacharacters. |
+
 ## Files
 
 | File | Description |

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -8,16 +8,31 @@ import (
 )
 
 type Config struct {
-	Jira             JiraConfig       `yaml:"jira"`
-	Projects         []ProjectConfig  `yaml:"projects"`
-	GUI              GUIConfig        `yaml:"gui"`
-	Keybinding       KeybindingConfig `yaml:"keybinding"`
-	IssueTabs        []IssueTabConfig `yaml:"issueTabs"`
-	Cache            CacheConfig      `yaml:"cache"`
-	Refresh          RefreshConfig    `yaml:"refresh"`
-	Fields           []FieldConfig    `yaml:"fields"`
-	DeprecatedFields []FieldConfig    `yaml:"customFields,omitempty"`
-	Git              GitConfig        `yaml:"git"`
+	Jira             JiraConfig            `yaml:"jira"`
+	Projects         []ProjectConfig       `yaml:"projects"`
+	GUI              GUIConfig             `yaml:"gui"`
+	Keybinding       KeybindingConfig      `yaml:"keybinding"`
+	IssueTabs        []IssueTabConfig      `yaml:"issueTabs"`
+	Cache            CacheConfig           `yaml:"cache"`
+	Refresh          RefreshConfig         `yaml:"refresh"`
+	Fields           []FieldConfig         `yaml:"fields"`
+	DeprecatedFields []FieldConfig         `yaml:"customFields,omitempty"`
+	Git              GitConfig             `yaml:"git"`
+	CustomCommands   []CustomCommandConfig `yaml:"customCommands"`
+}
+
+type CustomCommandConfig struct {
+	Key      string   `yaml:"key"`
+	Name     string   `yaml:"name"`
+	Command  string   `yaml:"command"`
+	Suspend  *bool    `yaml:"suspend,omitempty"` // default: true
+	Refresh  bool     `yaml:"refresh,omitempty"` // default: false
+	Contexts []string `yaml:"contexts,omitempty"`
+}
+
+// ShouldSuspend returns true when the TUI should be suspended for this command (default: true)
+func (c CustomCommandConfig) ShouldSuspend() bool {
+	return c.Suspend == nil || *c.Suspend
 }
 
 type GitConfig struct {
@@ -276,6 +291,10 @@ func Load() (*Config, error) {
 	}
 	if v := os.Getenv("JIRA_TLS_INSECURE"); v == "1" || v == "true" {
 		cfg.Jira.TLS.Insecure = true
+	}
+
+	if _, err := cfg.ResolveCustomCommands(); err != nil {
+		return nil, err
 	}
 
 	return cfg, nil

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,8 +1,14 @@
 package config
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
 
 func TestLoad_TLSEnvVars(t *testing.T) {
+	t.Setenv("CONFIG_DIR", t.TempDir())
 	t.Setenv("JIRA_SERVER_TYPE", "server")
 	t.Setenv("JIRA_TLS_CERT", "/tmp/cert.pem")
 	t.Setenv("JIRA_TLS_KEY", "/tmp/key.pem")
@@ -27,5 +33,57 @@ func TestLoad_TLSEnvVars(t *testing.T) {
 	}
 	if !cfg.Jira.TLS.Insecure {
 		t.Error("Insecure should be true")
+	}
+}
+
+func TestLoad_CustomCommandRefreshFromYAML(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("CONFIG_DIR", dir)
+
+	cfgYAML := `customCommands:
+  - key: "y"
+    name: "copy"
+    command: "echo {{.Key}}"
+    suspend: false
+  - key: "w"
+    name: "log work"
+    command: "echo {{.Key}}"
+    refresh: true
+`
+	if err := os.WriteFile(filepath.Join(dir, "config.yml"), []byte(cfgYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.CustomCommands[0].Refresh {
+		t.Error("first command: Refresh should default to false")
+	}
+	if !cfg.CustomCommands[1].Refresh {
+		t.Error("second command: Refresh should be true")
+	}
+}
+
+func TestLoad_InvalidCustomCommandTemplate(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("CONFIG_DIR", dir)
+
+	cfgYAML := `customCommands:
+  - key: "y"
+    name: "broken"
+    command: "echo {{.Unclosed"
+`
+	if err := os.WriteFile(filepath.Join(dir, "config.yml"), []byte(cfgYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := Load()
+	if err == nil {
+		t.Fatal("expected error for invalid template, got nil")
+	}
+	if !strings.Contains(err.Error(), "template parse error") {
+		t.Errorf("error = %q, want it to mention template parse error", err)
 	}
 }

--- a/pkg/config/custom_commands.go
+++ b/pkg/config/custom_commands.go
@@ -1,0 +1,129 @@
+package config
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+	"text/template"
+)
+
+// Context identifies a UI state in which a custom command may fire.
+type Context string
+
+const (
+	CtxIssues         Context = "issues"
+	CtxInfo           Context = "info"
+	CtxProjects       Context = "projects"
+	CtxDetail         Context = "detail"
+	CtxDetailComments Context = "detail.comments"
+)
+
+// DefaultCommandContexts is applied when a command omits `contexts:`.
+var DefaultCommandContexts = []Context{CtxIssues, CtxInfo, CtxDetail}
+
+// ScopeMask is a bitmask of data scopes a command expects.
+type ScopeMask uint8
+
+const (
+	ScopeIssue ScopeMask = 1 << iota
+	ScopeProject
+	ScopeComment
+)
+
+var contextScopes = map[Context]ScopeMask{
+	CtxIssues:         ScopeIssue,
+	CtxInfo:           ScopeIssue,
+	CtxProjects:       ScopeProject,
+	CtxDetail:         ScopeIssue,
+	CtxDetailComments: ScopeIssue | ScopeComment,
+}
+
+// ResolvedCustomCommand is a validated, pre-computed custom command.
+type ResolvedCustomCommand struct {
+	Key      string
+	Name     string
+	Command  string
+	Suspend  *bool
+	Refresh  bool
+	Contexts []Context
+	Scopes   ScopeMask
+	Template *template.Template
+}
+
+// ShouldSuspend mirrors CustomCommandConfig.ShouldSuspend.
+func (r ResolvedCustomCommand) ShouldSuspend() bool {
+	return r.Suspend == nil || *r.Suspend
+}
+
+// HasContext reports whether the command is bound to the given context.
+func (r ResolvedCustomCommand) HasContext(c Context) bool {
+	return slices.Contains(r.Contexts, c)
+}
+
+func shellescape(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'"
+}
+
+var commandFuncMap = template.FuncMap{
+	"shellescape": shellescape,
+}
+
+// ResolveCustomCommands validates the flat CustomCommands list and returns
+// pre-computed entries with typed contexts, scope mask and parsed template.
+func (c *Config) ResolveCustomCommands() ([]ResolvedCustomCommand, error) {
+	out := make([]ResolvedCustomCommand, 0, len(c.CustomCommands))
+	type keyCtx struct {
+		key string
+		ctx Context
+	}
+	seen := make(map[keyCtx]bool)
+
+	for i, entry := range c.CustomCommands {
+		if entry.Key == "" || entry.Name == "" || entry.Command == "" {
+			return nil, fmt.Errorf("customCommands[%d] (%q): key, name and command must all be non-empty", i, entry.Name)
+		}
+
+		var ctxs []Context
+		if len(entry.Contexts) == 0 {
+			ctxs = append(ctxs, DefaultCommandContexts...)
+		} else {
+			for _, raw := range entry.Contexts {
+				ctx := Context(raw)
+				if _, ok := contextScopes[ctx]; !ok {
+					return nil, fmt.Errorf("customCommands[%d] (%q): unknown context %q", i, entry.Key, raw)
+				}
+				ctxs = append(ctxs, ctx)
+			}
+		}
+
+		var scopes ScopeMask
+		for _, ctx := range ctxs {
+			scopes |= contextScopes[ctx]
+			k := keyCtx{entry.Key, ctx}
+			if seen[k] {
+				return nil, fmt.Errorf("customCommands: duplicate key %q in context %q", entry.Key, ctx)
+			}
+			seen[k] = true
+		}
+
+		tmpl, err := template.New("customCommand").
+			Option("missingkey=error").
+			Funcs(commandFuncMap).
+			Parse(entry.Command)
+		if err != nil {
+			return nil, fmt.Errorf("customCommands[%d] (%q): template parse error: %w", i, entry.Key, err)
+		}
+
+		out = append(out, ResolvedCustomCommand{
+			Key:      entry.Key,
+			Name:     entry.Name,
+			Command:  entry.Command,
+			Suspend:  entry.Suspend,
+			Refresh:  entry.Refresh,
+			Contexts: ctxs,
+			Scopes:   scopes,
+			Template: tmpl,
+		})
+	}
+	return out, nil
+}

--- a/pkg/config/custom_commands_test.go
+++ b/pkg/config/custom_commands_test.go
@@ -1,0 +1,194 @@
+package config
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestResolveCustomCommands_Defaults(t *testing.T) {
+	cfg := &Config{
+		CustomCommands: []CustomCommandConfig{
+			{Key: "y", Name: "Copy", Command: "echo {{.Key}}"},
+		},
+	}
+	resolved, err := cfg.ResolveCustomCommands()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(resolved) != 1 {
+		t.Fatalf("len = %d, want 1", len(resolved))
+	}
+	got := resolved[0]
+	if len(got.Contexts) != len(DefaultCommandContexts) {
+		t.Errorf("Contexts = %v, want %v", got.Contexts, DefaultCommandContexts)
+	}
+	if got.Scopes != ScopeIssue {
+		t.Errorf("Scopes = %d, want %d", got.Scopes, ScopeIssue)
+	}
+}
+
+func TestResolveCustomCommands_SingleContextProjects(t *testing.T) {
+	cfg := &Config{
+		CustomCommands: []CustomCommandConfig{
+			{Key: "n", Name: "Notes", Command: "echo {{.ProjectKey}}", Contexts: []string{"projects"}},
+		},
+	}
+	resolved, err := cfg.ResolveCustomCommands()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := resolved[0]
+	if got.Scopes != ScopeProject {
+		t.Errorf("Scopes = %d, want %d", got.Scopes, ScopeProject)
+	}
+}
+
+func TestResolveCustomCommands_DetailComments(t *testing.T) {
+	cfg := &Config{
+		CustomCommands: []CustomCommandConfig{
+			{Key: "c", Name: "Comment", Command: "echo {{.Key}}-{{.CommentID}}", Contexts: []string{"detail.comments"}},
+		},
+	}
+	resolved, err := cfg.ResolveCustomCommands()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := resolved[0]
+	if got.Scopes != ScopeIssue|ScopeComment {
+		t.Errorf("Scopes = %d, want %d", got.Scopes, ScopeIssue|ScopeComment)
+	}
+}
+
+func TestResolveCustomCommands_MixedScopes(t *testing.T) {
+	cfg := &Config{
+		CustomCommands: []CustomCommandConfig{
+			{Key: "x", Name: "Mixed", Command: "echo x", Contexts: []string{"issues", "detail.comments"}},
+		},
+	}
+	resolved, err := cfg.ResolveCustomCommands()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resolved[0].Scopes != ScopeIssue|ScopeComment {
+		t.Errorf("Scopes = %d, want %d", resolved[0].Scopes, ScopeIssue|ScopeComment)
+	}
+}
+
+func TestResolveCustomCommands_EmptyFieldsError(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		cmd  CustomCommandConfig
+	}{
+		{"empty key", CustomCommandConfig{Name: "x", Command: "echo"}},
+		{"empty name", CustomCommandConfig{Key: "a", Command: "echo"}},
+		{"empty command", CustomCommandConfig{Key: "a", Name: "x"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &Config{CustomCommands: []CustomCommandConfig{tc.cmd}}
+			if _, err := cfg.ResolveCustomCommands(); err == nil {
+				t.Error("expected error")
+			}
+		})
+	}
+}
+
+func TestResolveCustomCommands_UnknownContextError(t *testing.T) {
+	cfg := &Config{
+		CustomCommands: []CustomCommandConfig{
+			{Key: "a", Name: "x", Command: "echo", Contexts: []string{"bogus"}},
+		},
+	}
+	_, err := cfg.ResolveCustomCommands()
+	if err == nil || !strings.Contains(err.Error(), "bogus") {
+		t.Errorf("expected unknown context error, got %v", err)
+	}
+}
+
+func TestResolveCustomCommands_DuplicateKeySameContextError(t *testing.T) {
+	cfg := &Config{
+		CustomCommands: []CustomCommandConfig{
+			{Key: "a", Name: "first", Command: "echo 1", Contexts: []string{"issues"}},
+			{Key: "a", Name: "second", Command: "echo 2", Contexts: []string{"issues"}},
+		},
+	}
+	if _, err := cfg.ResolveCustomCommands(); err == nil {
+		t.Error("expected duplicate key error")
+	}
+}
+
+func TestResolveCustomCommands_DuplicateKeyDisjointContextsAllowed(t *testing.T) {
+	cfg := &Config{
+		CustomCommands: []CustomCommandConfig{
+			{Key: "a", Name: "first", Command: "echo 1", Contexts: []string{"issues"}},
+			{Key: "a", Name: "second", Command: "echo 2", Contexts: []string{"projects"}},
+		},
+	}
+	if _, err := cfg.ResolveCustomCommands(); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestResolveCustomCommands_RefreshDefault(t *testing.T) {
+	cfg := &Config{
+		CustomCommands: []CustomCommandConfig{
+			{Key: "y", Name: "Copy", Command: "echo {{.Key}}"},
+		},
+	}
+	resolved, err := cfg.ResolveCustomCommands()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resolved[0].Refresh {
+		t.Error("Refresh should default to false")
+	}
+}
+
+func TestResolveCustomCommands_RefreshTrue(t *testing.T) {
+	cfg := &Config{
+		CustomCommands: []CustomCommandConfig{
+			{Key: "w", Name: "Log work", Command: "echo {{.Key}}", Refresh: true},
+		},
+	}
+	resolved, err := cfg.ResolveCustomCommands()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !resolved[0].Refresh {
+		t.Error("Refresh should be true when set")
+	}
+}
+
+func TestResolveCustomCommands_InvalidTemplateError(t *testing.T) {
+	cfg := &Config{
+		CustomCommands: []CustomCommandConfig{
+			{Key: "a", Name: "x", Command: "echo {{.Unclosed"},
+		},
+	}
+	if _, err := cfg.ResolveCustomCommands(); err == nil {
+		t.Error("expected template parse error")
+	}
+}
+
+func TestResolveCustomCommands_ShellescapeFunc(t *testing.T) {
+	cfg := &Config{
+		CustomCommands: []CustomCommandConfig{
+			{Key: "s", Name: "Shellescape", Command: "echo {{.Key | shellescape}}"},
+		},
+	}
+	resolved, err := cfg.ResolveCustomCommands()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var buf bytes.Buffer
+	data := struct{ Key string }{Key: "what's up"}
+	if err := resolved[0].Template.Execute(&buf, data); err != nil {
+		t.Fatalf("template execute error: %v", err)
+	}
+
+	want := `echo 'what'\''s up'`
+	if got := buf.String(); got != want {
+		t.Errorf("output = %q, want %q", got, want)
+	}
+}

--- a/pkg/tui/app.go
+++ b/pkg/tui/app.go
@@ -1,9 +1,11 @@
 package tui
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"strings"
+	"sync"
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -157,6 +159,8 @@ type App struct {
 	gitBranch      string
 	gitDetectedKey string
 
+	customCmds []config.ResolvedCustomCommand
+
 	panelSideW     int
 	panelStatusH   int
 	panelIssuesH   int
@@ -164,6 +168,10 @@ type App struct {
 	panelProjectsH int
 	panelDetailH   int
 	panelLogH      int
+
+	ctx    context.Context
+	cancel context.CancelFunc
+	cmdWg  sync.WaitGroup
 
 	width  int
 	height int
@@ -274,11 +282,19 @@ func NewAppWithAuth(cfg *config.Config, client jira.ClientInterface, authMethod 
 		issueCache:      make(map[string]*jira.Issue),
 		createMetaCache: make(map[string][]jira.CreateMetaField),
 	}
+	app.ctx, app.cancel = context.WithCancel(context.Background()) //nolint:gosec // cancel is called in Shutdown()
 	navResolver := app.keymap.MatchNav
 	app.issuesList.ResolveNav = navResolver
 	app.infoPanel.ResolveNav = navResolver
 	app.projectList.ResolveNav = navResolver
 	app.detailView.ResolveNav = navResolver
+
+	app.initCustomCommands()
+
+	if warning := quitReachableWarning(app.keymap, app.customCmds); warning != "" {
+		fmt.Fprintln(os.Stderr, "lazyjira:", warning)
+		app.statusPanel.SetError(warning)
+	}
 
 	isCloud := cfg.Jira.IsCloud()
 	app.createForm.SetDescRenderer(func(text string, width int) []string {
@@ -308,6 +324,24 @@ func NewAppWithAuth(cfg *config.Config, client jira.ClientInterface, authMethod 
 
 	app.helpBar.SetItems(app.helpBarItems())
 	return app
+}
+
+// Shutdown cancels the app-lifetime context, signalling any background
+// processes spawned with a.ctx to terminate, and waits for them to exit.
+// Safe to call multiple times.
+func (a *App) Shutdown() {
+	if a.cancel != nil {
+		a.cancel()
+	}
+	// Wait for background custom commands to finish (they receive the
+	// cancel signal via exec.CommandContext). Give up after 3 seconds
+	// so we never hang on exit.
+	done := make(chan struct{})
+	go func() { a.cmdWg.Wait(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+	}
 }
 
 func (a *App) Init() tea.Cmd {
@@ -437,6 +471,8 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case editorFinishedMsg:
 		return a.handleEditorFinished(msg)
+	case customCommandFinishedMsg:
+		return a.handleCustomCommandFinished(msg)
 	case components.DiffConfirmedMsg:
 		return a.handleDiffConfirmed(msg)
 	case components.DiffCancelledMsg:

--- a/pkg/tui/custom_commands.go
+++ b/pkg/tui/custom_commands.go
@@ -1,0 +1,386 @@
+package tui
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"syscall"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/textfuel/lazyjira/pkg/config"
+	"github.com/textfuel/lazyjira/pkg/jira"
+	"github.com/textfuel/lazyjira/pkg/tui/components"
+	"github.com/textfuel/lazyjira/pkg/tui/views"
+)
+
+// customCommandFinishedMsg is sent when a custom command exits.
+// output is populated for background commands; suspended commands write
+// directly to the terminal.
+type customCommandFinishedMsg struct {
+	err     error
+	output  string
+	refresh bool
+}
+
+// issueScopeData holds template variables for issue-scoped commands.
+type issueScopeData struct {
+	Key         string
+	ProjectKey  string
+	ParentKey   string
+	Summary     string
+	Type        string
+	Status      string
+	Assignee    string
+	Priority    string
+	URL         string
+	GitBranch   string
+	GitRepoPath string
+	JiraHost    string
+}
+
+// projectScopeData holds template variables for project-scoped commands.
+type projectScopeData struct {
+	ProjectKey  string
+	ProjectName string
+	JiraHost    string
+	GitBranch   string
+	GitRepoPath string
+}
+
+// commentScopeData holds template variables for comment-scoped commands.
+type commentScopeData struct {
+	CommentID     string
+	CommentAuthor string
+	CommentBody   string
+}
+
+// detailCommentsScopeData is used for commands active in the detail.comments
+// context, exposing both Issue and Comment fields at the top level. Issue and
+// Comment field names do not collide, so struct embedding is unambiguous.
+type detailCommentsScopeData struct {
+	issueScopeData
+	commentScopeData
+}
+
+// initCustomCommands resolves the custom commands from config at startup.
+// Resolution errors are surfaced on the status panel; the slice is left empty.
+func (a *App) initCustomCommands() {
+	resolved, err := a.cfg.ResolveCustomCommands()
+	if err != nil {
+		a.statusPanel.SetError(fmt.Sprintf("custom commands: %v", err))
+		a.customCmds = nil
+		return
+	}
+	a.customCmds = resolved
+}
+
+// activeContexts returns the contexts that currently apply, ordered by
+// descending specificity. First match wins in handleCustomCommand.
+func (a *App) activeContexts() []config.Context {
+	var out []config.Context
+	switch a.side {
+	case sideRight:
+		switch a.detailView.Mode() {
+		case views.ModeIssue:
+			if a.detailView.ActiveTab() == views.TabComments {
+				out = append(out, config.CtxDetailComments)
+			}
+			out = append(out, config.CtxDetail)
+		case views.ModeProject:
+			out = append(out, config.CtxProjects)
+		case views.ModeSplash:
+			// no custom command contexts on splash
+		}
+	case sideLeft:
+		switch a.leftFocus {
+		case focusIssues:
+			out = append(out, config.CtxIssues)
+		case focusInfo:
+			out = append(out, config.CtxInfo)
+		case focusProjects:
+			out = append(out, config.CtxProjects)
+		case focusStatus:
+			// none
+		}
+	}
+	return out
+}
+
+// handleCustomCommand checks if keyStr matches a custom command bound to an
+// active context and executes it. Returns (model, cmd, true) if handled.
+func (a *App) handleCustomCommand(keyStr string) (tea.Model, tea.Cmd, bool) {
+	for _, ctx := range a.activeContexts() {
+		for _, rc := range a.customCmds {
+			if rc.Key != keyStr {
+				continue
+			}
+			if !rc.HasContext(ctx) {
+				continue
+			}
+			data, ok := a.buildCommandData(rc)
+			if !ok {
+				a.helpBar.SetStatusMsg(fmt.Sprintf("%s: no %s selected", rc.Name, scopeNoun(rc.Scopes)))
+				return a, nil, true
+			}
+			return a, a.executeCustomCommand(rc, data), true
+		}
+	}
+	return nil, nil, false
+}
+
+// scopeNoun returns a human-readable noun for the selection a scope requires.
+func scopeNoun(s config.ScopeMask) string {
+	switch s {
+	case config.ScopeIssue:
+		return "issue"
+	case config.ScopeProject:
+		return "project"
+	case config.ScopeIssue | config.ScopeComment:
+		return "comment"
+	default:
+		return "selection"
+	}
+}
+
+// buildCommandData returns the template data for a resolved command.
+// The second return is false when a required selection is missing.
+func (a *App) buildCommandData(rc config.ResolvedCustomCommand) (any, bool) {
+	switch rc.Scopes {
+	case config.ScopeIssue:
+		if a.issuesList.SelectedIssue() == nil {
+			return nil, false
+		}
+		return a.buildIssueScopeData(), true
+	case config.ScopeProject:
+		p := a.projectList.SelectedProject()
+		if p == nil {
+			return nil, false
+		}
+		return a.buildProjectScopeData(p), true
+	case config.ScopeComment:
+		cmt := a.detailView.SelectedComment()
+		if cmt == nil {
+			return nil, false
+		}
+		return a.buildCommentScopeData(cmt), true
+	case config.ScopeIssue | config.ScopeComment:
+		if a.issuesList.SelectedIssue() == nil {
+			return nil, false
+		}
+		cmt := a.detailView.SelectedComment()
+		if cmt == nil {
+			return nil, false
+		}
+		return detailCommentsScopeData{
+			issueScopeData:   a.buildIssueScopeData(),
+			commentScopeData: a.buildCommentScopeData(cmt),
+		}, true
+	}
+	return nil, false
+}
+
+func (a *App) buildIssueScopeData() issueScopeData {
+	sel := a.issuesList.SelectedIssue()
+	data := issueScopeData{
+		GitBranch:   a.gitBranch,
+		GitRepoPath: a.gitRepoPath,
+		JiraHost:    a.cfg.Jira.Host,
+	}
+	if sel == nil {
+		return data
+	}
+
+	data.Key = sel.Key
+	data.Summary = sel.Summary
+
+	if parts := strings.SplitN(sel.Key, "-", 2); len(parts) == 2 {
+		data.ProjectKey = parts[0]
+	}
+
+	if sel.Parent != nil {
+		data.ParentKey = sel.Parent.Key
+	}
+	if sel.IssueType != nil {
+		data.Type = sel.IssueType.Name
+	}
+	if sel.Status != nil {
+		data.Status = sel.Status.Name
+	}
+	if sel.Assignee != nil {
+		data.Assignee = sel.Assignee.DisplayName
+	}
+	if sel.Priority != nil {
+		data.Priority = sel.Priority.Name
+	}
+
+	if a.cfg.Jira.Host != "" {
+		data.URL = fmt.Sprintf("https://%s/browse/%s", a.cfg.Jira.Host, sel.Key)
+	}
+
+	return data
+}
+
+func (a *App) buildProjectScopeData(p *jira.Project) projectScopeData {
+	return projectScopeData{
+		ProjectKey:  p.Key,
+		ProjectName: p.Name,
+		JiraHost:    a.cfg.Jira.Host,
+		GitBranch:   a.gitBranch,
+		GitRepoPath: a.gitRepoPath,
+	}
+}
+
+func (a *App) buildCommentScopeData(c *jira.Comment) commentScopeData {
+	data := commentScopeData{
+		CommentID:   c.ID,
+		CommentBody: c.Body,
+	}
+	if c.Author != nil {
+		data.CommentAuthor = c.Author.DisplayName
+	}
+	return data
+}
+
+func (a *App) executeCustomCommand(rc config.ResolvedCustomCommand, data any) tea.Cmd {
+	var buf bytes.Buffer
+	if err := rc.Template.Execute(&buf, data); err != nil {
+		return func() tea.Msg {
+			return customCommandFinishedMsg{err: fmt.Errorf("template error: %w", err)}
+		}
+	}
+	cmdStr := buf.String()
+
+	shell := os.Getenv("SHELL")
+	if shell == "" {
+		shell = "sh"
+	}
+
+	refresh := rc.Refresh
+
+	if rc.ShouldSuspend() {
+		c := exec.CommandContext(a.ctx, shell, "-c", cmdStr) //nolint:gosec // user-configured custom commands are intentionally arbitrary shell commands
+		c.Stdin = os.Stdin
+		c.Stdout = os.Stdout
+		c.Stderr = os.Stderr
+		return tea.ExecProcess(c, func(err error) tea.Msg {
+			return customCommandFinishedMsg{err: err, refresh: refresh}
+		})
+	}
+
+	// Background execution: capture output and report via the tea message loop.
+	// The WaitGroup ensures Shutdown blocks until this goroutine finishes, so
+	// the child process is not orphaned on app exit.
+	a.cmdWg.Add(1)
+	return func() tea.Msg {
+		defer a.cmdWg.Done()
+		c := exec.CommandContext(a.ctx, shell, "-c", cmdStr) //nolint:gosec // user-configured custom commands are intentionally arbitrary shell commands
+		c.Cancel = func() error {
+			return c.Process.Signal(syscall.SIGTERM)
+		}
+		c.WaitDelay = 3 * time.Second
+		out, err := c.CombinedOutput()
+		return customCommandFinishedMsg{err: err, output: string(out), refresh: refresh}
+	}
+}
+
+func (a *App) handleCustomCommandFinished(msg customCommandFinishedMsg) (tea.Model, tea.Cmd) {
+	cmds := []tea.Cmd{tea.EnableMouseCellMotion}
+	if msg.err != nil {
+		errText := msg.err.Error()
+		if tail := lastNonEmptyLine(msg.output); tail != "" {
+			errText = tail + ": " + errText
+		}
+		a.statusPanel.SetError(errText)
+		return a, tea.Batch(cmds...)
+	}
+	if tail := lastNonEmptyLine(msg.output); tail != "" {
+		a.helpBar.SetStatusMsg(tail)
+	}
+	// Refresh the selected issue only when the command declares refresh: true.
+	if msg.refresh {
+		if sel := a.issuesList.SelectedIssue(); sel != nil {
+			cmds = append(cmds, fetchIssueDetail(a.client, sel.Key))
+		}
+	}
+	return a, tea.Batch(cmds...)
+}
+
+// lastNonEmptyLine returns the last non-empty line of s, trimmed. Used to
+// surface a single concise message from arbitrary command output.
+func lastNonEmptyLine(s string) string {
+	lines := strings.Split(s, "\n")
+	for i := len(lines) - 1; i >= 0; i-- {
+		if line := strings.TrimSpace(lines[i]); line != "" {
+			return line
+		}
+	}
+	return ""
+}
+
+// allUIContexts is the universe of UI contexts for shadowing analysis.
+var allUIContexts = []config.Context{
+	config.CtxIssues,
+	config.CtxInfo,
+	config.CtxProjects,
+	config.CtxDetail,
+	config.CtxDetailComments,
+}
+
+// quitReachableWarning returns a warning string if every keybinding for
+// ActQuit is shadowed by custom commands across every UI context, leaving
+// the user no way to quit. Empty string means quit is still reachable.
+func quitReachableWarning(km Keymap, cmds []config.ResolvedCustomCommand) string {
+	keys := km[ActQuit]
+	if len(keys) == 0 {
+		return ""
+	}
+	for _, key := range keys {
+		for _, ctx := range allUIContexts {
+			if !keyShadowsContext(key, ctx, cmds) {
+				return ""
+			}
+		}
+	}
+	return fmt.Sprintf(
+		"essential action %q is unreachable: keys %v are shadowed by custom commands in every UI context",
+		ActQuit, keys,
+	)
+}
+
+func keyShadowsContext(key string, ctx config.Context, cmds []config.ResolvedCustomCommand) bool {
+	for _, rc := range cmds {
+		if rc.Key == key && rc.HasContext(ctx) {
+			return true
+		}
+	}
+	return false
+}
+
+// customCommandHelpItems returns HelpItem entries for the help bar in the given context.
+func (a *App) customCommandHelpItems(ctx config.Context) []components.HelpItem {
+	items := make([]components.HelpItem, 0)
+	for _, rc := range a.customCmds {
+		if rc.HasContext(ctx) {
+			items = append(items, components.HelpItem{Key: rc.Key, Description: rc.Name})
+		}
+	}
+	return items
+}
+
+// customCommandBindings returns Binding entries for the help overlay in the given context.
+func (a *App) customCommandBindings(ctx config.Context) []Binding {
+	bindings := make([]Binding, 0)
+	for _, rc := range a.customCmds {
+		if rc.HasContext(ctx) {
+			bindings = append(bindings, Binding{
+				Key:         rc.Key,
+				Description: rc.Name,
+			})
+		}
+	}
+	return bindings
+}

--- a/pkg/tui/custom_commands_test.go
+++ b/pkg/tui/custom_commands_test.go
@@ -1,0 +1,328 @@
+package tui
+
+import (
+	"bytes"
+	"testing"
+	"text/template"
+
+	"github.com/textfuel/lazyjira/pkg/config"
+	"github.com/textfuel/lazyjira/pkg/jira"
+	"github.com/textfuel/lazyjira/pkg/tui/views"
+)
+
+func newTestApp() *App {
+	return &App{
+		cfg:         &config.Config{Jira: config.JiraConfig{Host: "example.atlassian.net"}},
+		issuesList:  views.NewIssuesList(),
+		projectList: views.NewProjectList(),
+		detailView:  views.NewDetailView(),
+		side:        sideLeft,
+		leftFocus:   focusIssues,
+	}
+}
+
+func TestActiveContexts(t *testing.T) {
+	cases := []struct {
+		name  string
+		setup func(a *App)
+		want  []config.Context
+	}{
+		{
+			"left issues",
+			func(a *App) { a.side = sideLeft; a.leftFocus = focusIssues },
+			[]config.Context{config.CtxIssues},
+		},
+		{
+			"left info",
+			func(a *App) { a.side = sideLeft; a.leftFocus = focusInfo },
+			[]config.Context{config.CtxInfo},
+		},
+		{
+			"left projects",
+			func(a *App) { a.side = sideLeft; a.leftFocus = focusProjects },
+			[]config.Context{config.CtxProjects},
+		},
+		{
+			"left status",
+			func(a *App) { a.side = sideLeft; a.leftFocus = focusStatus },
+			nil,
+		},
+		{
+			"right detail details",
+			func(a *App) {
+				a.side = sideRight
+				a.detailView.SetIssue(&jira.Issue{Key: "X-1"})
+				a.detailView.SetActiveTab(views.TabDetails)
+			},
+			[]config.Context{config.CtxDetail},
+		},
+		{
+			"right detail comments",
+			func(a *App) {
+				a.side = sideRight
+				a.detailView.SetIssue(&jira.Issue{Key: "X-1"})
+				a.detailView.SetActiveTab(views.TabComments)
+			},
+			[]config.Context{config.CtxDetailComments, config.CtxDetail},
+		},
+		{
+			"right project mode",
+			func(a *App) {
+				a.side = sideRight
+				a.detailView.SetProject(&jira.Project{Key: "P"})
+			},
+			[]config.Context{config.CtxProjects},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			a := newTestApp()
+			tc.setup(a)
+			got := a.activeContexts()
+			if len(got) != len(tc.want) {
+				t.Fatalf("len = %d (%v), want %d (%v)", len(got), got, len(tc.want), tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Errorf("[%d] = %q, want %q", i, got[i], tc.want[i])
+				}
+			}
+		})
+	}
+}
+
+func parseTmpl(t *testing.T, s string) *template.Template {
+	t.Helper()
+	tmpl, err := template.New("t").Option("missingkey=error").Parse(s)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	return tmpl
+}
+
+func TestBuildCommandData_SingleScopeFlat(t *testing.T) {
+	a := newTestApp()
+	a.issuesList.SetIssues([]jira.Issue{{Key: "ABC-1", Summary: "hi"}})
+	rc := config.ResolvedCustomCommand{
+		Key:      "y",
+		Scopes:   config.ScopeIssue,
+		Contexts: []config.Context{config.CtxIssues},
+		Template: parseTmpl(t, "{{.Key}}|{{.Summary}}"),
+	}
+	data, ok := a.buildCommandData(rc)
+	if !ok {
+		t.Fatal("expected ok")
+	}
+	var buf bytes.Buffer
+	if err := rc.Template.Execute(&buf, data); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if got := buf.String(); got != "ABC-1|hi" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestBuildCommandData_DetailCommentsFlat(t *testing.T) {
+	a := newTestApp()
+	issue := jira.Issue{Key: "ABC-1", Comments: []jira.Comment{{ID: "10", Body: "hello"}}}
+	a.issuesList.SetIssues([]jira.Issue{issue})
+	a.detailView.SetIssue(&issue)
+	a.detailView.SetActiveTab(views.TabComments)
+
+	rc := config.ResolvedCustomCommand{
+		Key:      "c",
+		Scopes:   config.ScopeIssue | config.ScopeComment,
+		Contexts: []config.Context{config.CtxDetailComments},
+		Template: parseTmpl(t, "{{.Key}}-{{.CommentID}}"),
+	}
+	data, ok := a.buildCommandData(rc)
+	if !ok {
+		t.Fatal("expected ok")
+	}
+	var buf bytes.Buffer
+	if err := rc.Template.Execute(&buf, data); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if got := buf.String(); got != "ABC-1-10" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestBuildCommandData_SharedFieldsProjectScope(t *testing.T) {
+	a := newTestApp()
+	a.gitBranch = "feature/x"
+	a.gitRepoPath = "/tmp/repo"
+	a.projectList.SetProjects([]jira.Project{{Key: "P", Name: "Proj"}})
+	a.side = sideLeft
+	a.leftFocus = focusProjects
+
+	rc := config.ResolvedCustomCommand{
+		Key:      "p",
+		Scopes:   config.ScopeProject,
+		Contexts: []config.Context{config.CtxProjects},
+		Template: parseTmpl(t, "{{.ProjectKey}}|{{.JiraHost}}|{{.GitBranch}}|{{.GitRepoPath}}"),
+	}
+	data, ok := a.buildCommandData(rc)
+	if !ok {
+		t.Fatal("expected ok")
+	}
+	var buf bytes.Buffer
+	if err := rc.Template.Execute(&buf, data); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if got, want := buf.String(), "P|example.atlassian.net|feature/x|/tmp/repo"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestBuildCommandData_SharedFieldsDetailComments(t *testing.T) {
+	a := newTestApp()
+	a.gitBranch = "feature/y"
+	a.gitRepoPath = "/tmp/repo2"
+	issue := jira.Issue{Key: "ABC-1", Comments: []jira.Comment{{ID: "10", Body: "hello"}}}
+	a.issuesList.SetIssues([]jira.Issue{issue})
+	a.detailView.SetIssue(&issue)
+	a.detailView.SetActiveTab(views.TabComments)
+
+	rc := config.ResolvedCustomCommand{
+		Key:      "c",
+		Scopes:   config.ScopeIssue | config.ScopeComment,
+		Contexts: []config.Context{config.CtxDetailComments},
+		Template: parseTmpl(t, "{{.Key}}|{{.CommentID}}|{{.JiraHost}}|{{.GitBranch}}|{{.GitRepoPath}}"),
+	}
+	data, ok := a.buildCommandData(rc)
+	if !ok {
+		t.Fatal("expected ok")
+	}
+	var buf bytes.Buffer
+	if err := rc.Template.Execute(&buf, data); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if got, want := buf.String(), "ABC-1|10|example.atlassian.net|feature/y|/tmp/repo2"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestBuildCommandData_MissingSelectionSwallows(t *testing.T) {
+	a := newTestApp()
+	a.side = sideLeft
+	a.leftFocus = focusProjects
+	rc := config.ResolvedCustomCommand{
+		Key:      "n",
+		Scopes:   config.ScopeProject,
+		Contexts: []config.Context{config.CtxProjects},
+		Template: parseTmpl(t, "{{.ProjectKey}}"),
+	}
+	if _, ok := a.buildCommandData(rc); ok {
+		t.Error("expected ok=false with no selected project")
+	}
+}
+
+func TestHandleCustomCommand_SpecificityDispatch(t *testing.T) {
+	a := newTestApp()
+	issue := jira.Issue{Key: "ABC-1", Comments: []jira.Comment{{ID: "9", Body: "b"}}}
+	a.issuesList.SetIssues([]jira.Issue{issue})
+	a.detailView.SetIssue(&issue)
+	a.detailView.SetActiveTab(views.TabComments)
+	a.side = sideRight
+
+	detailCmd := config.ResolvedCustomCommand{
+		Key: "x", Name: "detail-one", Scopes: config.ScopeIssue,
+		Contexts: []config.Context{config.CtxDetail},
+		Template: parseTmpl(t, "echo detail"),
+	}
+	commentsCmd := config.ResolvedCustomCommand{
+		Key: "x", Name: "comments-one", Scopes: config.ScopeIssue | config.ScopeComment,
+		Contexts: []config.Context{config.CtxDetailComments},
+		Template: parseTmpl(t, "echo comments"),
+	}
+	a.customCmds = []config.ResolvedCustomCommand{detailCmd, commentsCmd}
+
+	// The specificity-ordered contexts should dispatch to detail.comments first.
+	ctxs := a.activeContexts()
+	if len(ctxs) == 0 || ctxs[0] != config.CtxDetailComments {
+		t.Fatalf("activeContexts = %v, want detail.comments first", ctxs)
+	}
+	// Walk the dispatch logic manually to assert selection without exec.
+	var chosen string
+	for _, ctx := range ctxs {
+		for _, rc := range a.customCmds {
+			if rc.Key == "x" && rc.HasContext(ctx) {
+				chosen = rc.Name
+				goto done
+			}
+		}
+	}
+done:
+	if chosen != "comments-one" {
+		t.Errorf("chose %q, want comments-one", chosen)
+	}
+}
+
+func TestQuitReachableWarning(t *testing.T) {
+	allCtxs := []config.Context{
+		config.CtxIssues,
+		config.CtxInfo,
+		config.CtxProjects,
+		config.CtxDetail,
+		config.CtxDetailComments,
+	}
+	defaultKm := Keymap{ActQuit: {"q", "ctrl+c"}}
+
+	cases := []struct {
+		name     string
+		km       Keymap
+		cmds     []config.ResolvedCustomCommand
+		wantWarn bool
+	}{
+		{
+			name:     "no custom commands",
+			km:       defaultKm,
+			cmds:     nil,
+			wantWarn: false,
+		},
+		{
+			name: "custom command on unrelated key",
+			km:   defaultKm,
+			cmds: []config.ResolvedCustomCommand{
+				{Key: "y", Contexts: allCtxs},
+			},
+			wantWarn: false,
+		},
+		{
+			name: "shadows q in issues only",
+			km:   defaultKm,
+			cmds: []config.ResolvedCustomCommand{
+				{Key: "q", Contexts: []config.Context{config.CtxIssues}},
+			},
+			wantWarn: false,
+		},
+		{
+			name: "shadows q and ctrl+c everywhere",
+			km:   defaultKm,
+			cmds: []config.ResolvedCustomCommand{
+				{Key: "q", Contexts: allCtxs},
+				{Key: "ctrl+c", Contexts: allCtxs},
+			},
+			wantWarn: true,
+		},
+		{
+			name: "user remapped quit to alt+q, q shadowed everywhere",
+			km:   Keymap{ActQuit: {"alt+q"}},
+			cmds: []config.ResolvedCustomCommand{
+				{Key: "q", Contexts: allCtxs},
+			},
+			wantWarn: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			warning := quitReachableWarning(tc.km, tc.cmds)
+			got := warning != ""
+			if got != tc.wantWarn {
+				t.Errorf("got warning=%q, want warn=%v", warning, tc.wantWarn)
+			}
+		})
+	}
+}

--- a/pkg/tui/handlers_keys.go
+++ b/pkg/tui/handlers_keys.go
@@ -19,6 +19,12 @@ func (a *App) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return a.handleHelpKeys(msg)
 	}
 
+	// Custom commands take precedence over built-in keybindings so users
+	// can override any action they want.
+	if m, cmd, ok := a.handleCustomCommand(msg.String()); ok {
+		return m, cmd
+	}
+
 	action := a.keymap.Match(msg.String())
 
 	switch action { //nolint:exhaustive

--- a/pkg/tui/keybindings.go
+++ b/pkg/tui/keybindings.go
@@ -3,6 +3,7 @@ package tui
 import (
 	"slices"
 
+	"github.com/textfuel/lazyjira/pkg/config"
 	"github.com/textfuel/lazyjira/pkg/tui/components"
 	"github.com/textfuel/lazyjira/pkg/tui/views"
 )
@@ -56,7 +57,7 @@ func (a *App) ContextBindings() []Binding {
 	switch {
 	case a.side == sideLeft && a.leftFocus == focusIssues:
 		bindings := slices.Concat(global, a.navBindings(), a.detailScrollBindings())
-		return append(bindings,
+		bindings = append(bindings,
 			a.bind(ActOpen, "open issue detail"),
 			a.bind(ActFocusRight, "open issue detail"),
 			a.bind(ActTransition, "transition issue status"),
@@ -72,10 +73,12 @@ func (a *App) ContextBindings() []Binding {
 			a.bind(ActCloseJQLTab, "close JQL tab"),
 			Binding{"[]", "switch tab"},
 		)
+		bindings = append(bindings, a.customCommandBindings(config.CtxIssues)...)
+		return bindings
 
 	case a.side == sideLeft && a.leftFocus == focusInfo:
 		bindings := slices.Concat(global, a.navBindings(), a.detailScrollBindings())
-		return append(bindings,
+		bindings = append(bindings,
 			Binding{"[]", "switch tab (Info/Lnk/Sub)"},
 			a.bind(ActEdit, "edit field"),
 			a.bind(ActTransition, "transition issue status"),
@@ -86,14 +89,18 @@ func (a *App) ContextBindings() []Binding {
 			a.bind(ActFocusRight, "next panel"),
 			a.bind(ActFocusLeft, "previous panel"),
 		)
+		bindings = append(bindings, a.customCommandBindings(config.CtxInfo)...)
+		return bindings
 
 	case a.side == sideLeft && a.leftFocus == focusProjects:
 		bindings := slices.Concat(global, a.navBindings())
-		return append(bindings,
+		bindings = append(bindings,
 			a.bind(ActSelect, "select project and load issues"),
 			a.bind(ActFocusRight, "next panel"),
 			a.bind(ActFocusLeft, "previous panel"),
 		)
+		bindings = append(bindings, a.customCommandBindings(config.CtxProjects)...)
+		return bindings
 
 	case a.side == sideLeft && a.leftFocus == focusStatus:
 		return append(global,
@@ -120,6 +127,10 @@ func (a *App) ContextBindings() []Binding {
 			bindings = append(bindings,
 				a.bind(ActEdit, "edit description"),
 			)
+		}
+		bindings = append(bindings, a.customCommandBindings(config.CtxDetail)...)
+		if a.detailView.ActiveTab() == views.TabComments {
+			bindings = append(bindings, a.customCommandBindings(config.CtxDetailComments)...)
 		}
 		return bindings
 	}
@@ -200,23 +211,30 @@ func (a *App) helpBarItems() []components.HelpItem {
 			components.HelpItem{Key: km.Keys(ActCreateBranch), Description: "branch"},
 			components.HelpItem{Key: km.Keys(ActNew), Description: "create"},
 			components.HelpItem{Key: km.Keys(ActJQLSearch), Description: "JQL search"},
-			components.HelpItem{Key: km.Keys(ActHelp), Description: "help"},
 		)
+		items = append(items, a.customCommandHelpItems(config.CtxIssues)...)
+		items = append(items, components.HelpItem{Key: km.Keys(ActHelp), Description: "help"})
 		return items
 	case a.side == sideLeft && a.leftFocus == focusInfo:
-		return []components.HelpItem{
-			{Key: km.Keys(ActEdit), Description: "edit"},
-			{Key: km.Keys(ActTransition), Description: "transition"},
-			{Key: km.Keys(ActPriority), Description: "priority"},
-			{Key: km.Keys(ActAssignee), Description: "assignee"},
-			{Key: km.Keys(ActHelp), Description: "help"},
-		}
+		items := make([]components.HelpItem, 0, 6)
+		items = append(items,
+			components.HelpItem{Key: km.Keys(ActEdit), Description: "edit"},
+			components.HelpItem{Key: km.Keys(ActTransition), Description: "transition"},
+			components.HelpItem{Key: km.Keys(ActPriority), Description: "priority"},
+			components.HelpItem{Key: km.Keys(ActAssignee), Description: "assignee"},
+		)
+		items = append(items, a.customCommandHelpItems(config.CtxInfo)...)
+		items = append(items, components.HelpItem{Key: km.Keys(ActHelp), Description: "help"})
+		return items
 	case a.side == sideLeft && a.leftFocus == focusProjects:
-		return []components.HelpItem{
-			{Key: km.Keys(ActSelect), Description: "select"},
-			{Key: km.Keys(ActOpen), Description: "preview"},
-			{Key: km.Keys(ActHelp), Description: "help"},
-		}
+		items := make([]components.HelpItem, 0, 4)
+		items = append(items,
+			components.HelpItem{Key: km.Keys(ActSelect), Description: "select"},
+			components.HelpItem{Key: km.Keys(ActOpen), Description: "preview"},
+		)
+		items = append(items, a.customCommandHelpItems(config.CtxProjects)...)
+		items = append(items, components.HelpItem{Key: km.Keys(ActHelp), Description: "help"})
+		return items
 	case a.side == sideLeft && a.leftFocus == focusStatus:
 		return []components.HelpItem{
 			{Key: km.Keys(ActSwitchPanel) + "/" + km.Keys(ActFocusRight), Description: "detail"},
@@ -241,8 +259,12 @@ func (a *App) helpBarItems() []components.HelpItem {
 			components.HelpItem{Key: km.Keys(ActPriority), Description: "priority"},
 			components.HelpItem{Key: km.Keys(ActAssignee), Description: "assignee"},
 			components.HelpItem{Key: km.Keys(ActFocusLeft), Description: "back"},
-			components.HelpItem{Key: km.Keys(ActHelp), Description: "help"},
 		)
+		items = append(items, a.customCommandHelpItems(config.CtxDetail)...)
+		if a.detailView.ActiveTab() == views.TabComments {
+			items = append(items, a.customCommandHelpItems(config.CtxDetailComments)...)
+		}
+		items = append(items, components.HelpItem{Key: km.Keys(ActHelp), Description: "help"})
 		return items
 	}
 	return nil

--- a/pkg/tui/views/detail.go
+++ b/pkg/tui/views/detail.go
@@ -81,6 +81,8 @@ func NewDetailView() *DetailView {
 	return &DetailView{theme: theme.Default, mode: ModeIssue}
 }
 
+func (d *DetailView) Mode() MainMode { return d.mode }
+
 // IssueKey returns the key of the currently displayed issue, or ""
 func (d *DetailView) IssueKey() string {
 	if d.issue != nil && d.mode == ModeIssue {


### PR DESCRIPTION
Closes #39

Let users bind shell commands to keys, with Go template access to
the focused issue, project, or comment. Each command declares the
UI contexts in which it fires (`issues`, `info`, `projects`,
`detail`, `detail.comments`); when `contexts:` is omitted, the
default is wherever an issue is focused.

```yaml
customCommands:
  - key: "ctrl+y"
    name: "Copy issue key"
    command: "printf %s {{.Key}} | wl-copy"
    suspend: false
  - key: "ctrl+w"
    name: "Log work"
    command: "jira issue worklog add {{.Key}}"
```

Custom bindings take precedence over built-in keys, so users can
override any action. A `suspend` flag controls TUI suspension for
the command's duration, and a `shellescape` template helper is
available for safe interpolation. Registered commands appear in the
help overlay.