### PR TITLE
Make maxResults configurable globally and per tab

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -203,9 +203,29 @@ issueTabs:
     jql: "project = {{.ProjectKey}} AND assignee=currentUser() ORDER BY priority DESC"
   - name: "Recent"
     jql: "project = {{.ProjectKey}} AND updated >= -7d ORDER BY updated DESC"
+    maxResults: 100
 ```
 
 You can also create temporary JQL tabs at runtime with the `s` key.
+
+Per-tab page size can be set via `maxResults` on the tab entry — see [Page size](#page-size-maxresults) below.
+
+## Page size (`maxResults`)
+
+The number of issues fetched per query. Can be set globally and overridden per tab:
+
+```yaml
+maxResults: 75          # global default for all tabs and ad-hoc JQL searches
+issueTabs:
+  - name: "All"
+    jql: "project = {{.ProjectKey}} ORDER BY updated DESC"
+    maxResults: 200     # per-tab override
+  - name: "Assigned"
+    jql: "project = {{.ProjectKey}} AND assignee=currentUser()"
+                        # inherits global 75
+```
+
+Resolution order: per-tab `maxResults` → global `maxResults` → built-in default (50). Values `<= 0` are treated as unset. Note that the Jira server may enforce its own upper bound and silently return fewer issues than requested.
 
 ## Keybindings
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -13,6 +13,7 @@ type Config struct {
 	GUI              GUIConfig             `yaml:"gui"`
 	Keybinding       KeybindingConfig      `yaml:"keybinding"`
 	IssueTabs        []IssueTabConfig      `yaml:"issueTabs"`
+	MaxResults       *int                  `yaml:"maxResults"`
 	Cache            CacheConfig           `yaml:"cache"`
 	Refresh          RefreshConfig         `yaml:"refresh"`
 	Fields           []FieldConfig         `yaml:"fields"`
@@ -51,8 +52,9 @@ type BranchFormatCondition struct {
 }
 
 type IssueTabConfig struct {
-	Name string `yaml:"name"`
-	JQL  string `yaml:"jql"`
+	Name       string `yaml:"name"`
+	JQL        string `yaml:"jql"`
+	MaxResults *int   `yaml:"maxResults"`
 }
 
 type FieldConfig struct {
@@ -212,6 +214,33 @@ func DefaultConfig() *Config {
 			Interval:    "30s",
 		},
 	}
+}
+
+// DefaultMaxResults is the fallback page size used when neither the global
+// `maxResults` nor a tab-specific override is set. Note that the Jira server
+// may enforce its own upper bound and silently return fewer issues than
+// requested.
+const DefaultMaxResults = 50
+
+// ResolveGlobalMaxResults returns the effective page size for queries that
+// are not tied to a configured tab (ad-hoc JQL searches, JQL tabs): global
+// config value if set and positive, otherwise the compile-time default.
+// A nil or non-positive pointer is treated as "unset".
+func (c *Config) ResolveGlobalMaxResults() int {
+	if c.MaxResults != nil && *c.MaxResults > 0 {
+		return *c.MaxResults
+	}
+	return DefaultMaxResults
+}
+
+// ResolveMaxResults returns the effective page size for a given tab:
+// per-tab override first, then the global/default chain. A nil or
+// non-positive pointer is treated as "unset".
+func (c *Config) ResolveMaxResults(tab IssueTabConfig) int {
+	if tab.MaxResults != nil && *tab.MaxResults > 0 {
+		return *tab.MaxResults
+	}
+	return c.ResolveGlobalMaxResults()
 }
 
 // DefaultIssueTabs returns the default issue tab configuration

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -87,3 +87,61 @@ func TestLoad_InvalidCustomCommandTemplate(t *testing.T) {
 		t.Errorf("error = %q, want it to mention template parse error", err)
 	}
 }
+
+func ptr[T any](v T) *T { return &v }
+
+func TestResolveMaxResults(t *testing.T) {
+	tests := []struct {
+		name   string
+		global *int
+		tab    IssueTabConfig
+		want   int
+	}{
+		{"all unset → default", nil, IssueTabConfig{}, DefaultMaxResults},
+		{"global only", ptr(25), IssueTabConfig{}, 25},
+		{"tab overrides global", ptr(25), IssueTabConfig{MaxResults: ptr(75)}, 75},
+		{"negative global ignored", ptr(-5), IssueTabConfig{}, DefaultMaxResults},
+		{"zero tab falls back to global", ptr(40), IssueTabConfig{MaxResults: ptr(0)}, 40},
+		{"large global not clamped", ptr(500), IssueTabConfig{}, 500},
+		{"large tab override not clamped", ptr(50), IssueTabConfig{MaxResults: ptr(1000)}, 1000},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			c := &Config{MaxResults: tc.global}
+			if got := c.ResolveMaxResults(tc.tab); got != tc.want {
+				t.Errorf("ResolveMaxResults = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestResolveGlobalMaxResults(t *testing.T) {
+	tests := []struct {
+		name   string
+		global *int
+		want   int
+	}{
+		{"nil → default", nil, DefaultMaxResults},
+		{"zero → default", ptr(0), DefaultMaxResults},
+		{"negative → default", ptr(-1), DefaultMaxResults},
+		{"set", ptr(125), 125},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			c := &Config{MaxResults: tc.global}
+			if got := c.ResolveGlobalMaxResults(); got != tc.want {
+				t.Errorf("ResolveGlobalMaxResults = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDefaultConfig_MaxResults(t *testing.T) {
+	cfg := DefaultConfig()
+	if cfg.MaxResults != nil {
+		t.Errorf("default MaxResults should be nil (unset), got %d", *cfg.MaxResults)
+	}
+	if got := cfg.ResolveGlobalMaxResults(); got != DefaultMaxResults {
+		t.Errorf("ResolveGlobalMaxResults on defaults = %d, want %d", got, DefaultMaxResults)
+	}
+}

--- a/pkg/tui/app.go
+++ b/pkg/tui/app.go
@@ -960,7 +960,7 @@ func (a *App) fetchActiveTab() tea.Cmd {
 		}
 		tabIdx := a.issuesList.GetTabIndex()
 		*a.logFlag = true
-		return fetchIssuesByJQL(a.client, jql, tabIdx)
+		return fetchIssuesByJQL(a.client, jql, tabIdx, a.cfg.ResolveGlobalMaxResults())
 	}
 	if a.projectKey == "" {
 		return nil
@@ -972,7 +972,7 @@ func (a *App) fetchActiveTab() tea.Cmd {
 	tabIdx := a.issuesList.GetTabIndex()
 	jql := resolveTabJQL(tab, a.projectKey, a.cfg.Jira.Email)
 	*a.logFlag = true
-	return fetchIssuesByJQL(a.client, jql, tabIdx)
+	return fetchIssuesByJQL(a.client, jql, tabIdx, a.cfg.ResolveMaxResults(tab))
 }
 
 func (a *App) updateFocusState() {

--- a/pkg/tui/commands.go
+++ b/pkg/tui/commands.go
@@ -54,9 +54,9 @@ func gitCheckoutTracking(repoPath, remoteBranch string) tea.Cmd {
 }
 
 
-func fetchIssuesByJQL(client jira.ClientInterface, jql string, tab int) tea.Cmd {
+func fetchIssuesByJQL(client jira.ClientInterface, jql string, tab, maxResults int) tea.Cmd {
 	return func() tea.Msg {
-		result, err := client.SearchIssues(context.Background(), jql, 0, 50)
+		result, err := client.SearchIssues(context.Background(), jql, 0, maxResults)
 		if err != nil {
 			return errorMsg{err: err}
 		}
@@ -170,9 +170,9 @@ type jqlSearchErrorMsg struct{ err string }
 type jqlFieldsLoadedMsg struct{ fields []jira.AutocompleteField }
 type jqlSuggestionsMsg struct{ suggestions []jira.AutocompleteSuggestion }
 
-func fetchJQLSearch(client jira.ClientInterface, jql string) tea.Cmd {
+func fetchJQLSearch(client jira.ClientInterface, jql string, maxResults int) tea.Cmd {
 	return func() tea.Msg {
-		result, err := client.SearchIssues(context.Background(), jql, 0, 50)
+		result, err := client.SearchIssues(context.Background(), jql, 0, maxResults)
 		if err != nil {
 			return jqlSearchErrorMsg{err: err.Error()}
 		}

--- a/pkg/tui/handlers_jql.go
+++ b/pkg/tui/handlers_jql.go
@@ -10,7 +10,7 @@ import (
 func (a *App) handleJQLSubmit(msg components.JQLSubmitMsg) (tea.Model, tea.Cmd) {
 	*a.logFlag = true
 	a.jqlModal.SetLoading(true)
-	return a, fetchJQLSearch(a.client, msg.Query)
+	return a, fetchJQLSearch(a.client, msg.Query, a.cfg.ResolveGlobalMaxResults())
 }
 
 // handleJQLSearchResult processes JQL search results.


### PR DESCRIPTION
Closes #44

Top-level `maxResults` sets the page size for all queries; individual
`issueTabs` entries can override it.

```yaml
maxResults: 75
issueTabs:
  - name: "All"
    jql: "project = {{.ProjectKey}} ORDER BY updated DESC"
    maxResults: 100
```

Resolution order: per-tab, then global, then the built-in default of
50. Values `<= 0` are treated as unset.