### PR TITLE
pkg/config: accept string shorthand for the projects list

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -151,6 +151,31 @@ type ProjectConfig struct {
 	BoardID int    `yaml:"boardId"` // TODO not yet wired up
 }
 
+// UnmarshalYAML lets `projects:` accept either the full mapping form
+//
+//	projects:
+//	  - key: ORCH
+//	    boardId: 42
+//
+// or the shorthand string form used in most personal configs:
+//
+//	projects:
+//	  - ORCH
+//
+// The bare-string form maps straight to Key with BoardID left at its zero
+// value. Without this, a list of bare strings unmarshals into a struct and
+// yaml.v3 returns "cannot unmarshal !!str into config.ProjectConfig", which
+// previously propagated as a nil *Config and a SIGSEGV (#41).
+func (p *ProjectConfig) UnmarshalYAML(node *yaml.Node) error {
+	if node.Kind == yaml.ScalarNode {
+		return node.Decode(&p.Key)
+	}
+	// Full form: decode into a type alias so we don't recurse into this
+	// UnmarshalYAML method.
+	type rawProjectConfig ProjectConfig
+	return node.Decode((*rawProjectConfig)(p))
+}
+
 type GUIConfig struct {
 	Theme                string            `yaml:"theme"`    // TODO not yet wired up
 	Language             string            `yaml:"language"` // TODO not yet wired up

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -145,3 +145,31 @@ func TestDefaultConfig_MaxResults(t *testing.T) {
 		t.Errorf("ResolveGlobalMaxResults on defaults = %d, want %d", got, DefaultMaxResults)
 	}
 }
+
+func TestLoad_ProjectsAcceptsStringShorthand(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("CONFIG_DIR", dir)
+
+	cfgYAML := `projects:
+  - ORCH
+  - key: DATA
+    boardId: 7
+`
+	if err := os.WriteFile(filepath.Join(dir, "config.yml"), []byte(cfgYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got := len(cfg.Projects); got != 2 {
+		t.Fatalf("len(Projects) = %d, want 2", got)
+	}
+	if cfg.Projects[0].Key != "ORCH" || cfg.Projects[0].BoardID != 0 {
+		t.Errorf("Projects[0] = %+v, want {Key:ORCH BoardID:0}", cfg.Projects[0])
+	}
+	if cfg.Projects[1].Key != "DATA" || cfg.Projects[1].BoardID != 7 {
+		t.Errorf("Projects[1] = %+v, want {Key:DATA BoardID:7}", cfg.Projects[1])
+	}
+}


### PR DESCRIPTION
### Problem

The config schema declares

```go
type Config struct {
    ...
    Projects []ProjectConfig `yaml:"projects"`
}

type ProjectConfig struct {
    Key     string `yaml:"key"`
    BoardID int    `yaml:"boardId"`
}
```

so the most natural form that users reach for:

```yaml
projects:
  - ORCH
  - PLAT
```

errors out of yaml.v3 with `cannot unmarshal !!str into config.ProjectConfig`.
On v2.8.1 this bubbled up through `cfg, _ := config.Load()` as a nil *Config
and crashed with a SIGSEGV the moment `resolveClient` touched `cfg.Jira.Host`
(#41). main.go already returns the error cleanly, so the crash itself is
gone, but the shorthand form still isn't accepted.

### Fix

Add `UnmarshalYAML` to `ProjectConfig` so it accepts either form:

```yaml
projects:
  - ORCH            # scalar: Key only, BoardID defaults to 0
  - key: DATA       # mapping: full form
    boardId: 7
```

Scalar nodes are decoded straight into `Key`. Mapping nodes go through a
local type alias so the method doesn't recurse into itself. Added a test
that covers both forms in the same list.

Refs #41
