### PR TITLE
Context-sensitive preview for Sub/Lnk tabs

### DIFF
--- a/pkg/jira/jiratest/fake.go
+++ b/pkg/jira/jiratest/fake.go
@@ -1,0 +1,458 @@
+// Package jiratest provides a FakeClient that implements jira.ClientInterface
+// for use in unit tests. By default every method calls t.Fatalf, so unexpected
+// calls surface immediately with a clear message. Tests opt-in by assigning a
+// *Func field for each method they expect to be called.
+package jiratest
+
+import (
+	"context"
+	"testing"
+
+	"github.com/textfuel/lazyjira/pkg/jira"
+)
+
+// Call-record structs. One per method that takes arguments worth asserting.
+
+type GetIssueCall struct {
+	Ctx context.Context
+	Key string
+}
+
+type SearchIssuesCall struct {
+	Ctx        context.Context
+	JQL        string
+	StartAt    int
+	MaxResults int
+}
+
+type GetTransitionsCall struct {
+	Ctx context.Context
+	Key string
+}
+
+type DoTransitionCall struct {
+	Ctx          context.Context
+	Key          string
+	TransitionID string
+}
+
+type AddCommentCall struct {
+	Ctx  context.Context
+	Key  string
+	Body any
+}
+
+type UpdateCommentCall struct {
+	Ctx       context.Context
+	Key       string
+	CommentID string
+	Body      any
+}
+
+type AssignIssueCall struct {
+	Ctx       context.Context
+	Key       string
+	AccountID string
+}
+
+type GetBoardIssuesCall struct {
+	Ctx     context.Context
+	BoardID int
+	JQL     string
+}
+
+type UpdateIssueCall struct {
+	Ctx    context.Context
+	Key    string
+	Fields map[string]any
+}
+
+type CreateIssueCall struct {
+	Ctx    context.Context
+	Fields map[string]any
+}
+
+type GetCreateMetaCall struct {
+	Ctx         context.Context
+	ProjectKey  string
+	IssueTypeID string
+}
+
+type GetCommentsCall struct {
+	Ctx context.Context
+	Key string
+}
+
+type GetUsersCall struct {
+	Ctx        context.Context
+	ProjectKey string
+}
+
+type GetSprintsCall struct {
+	Ctx     context.Context
+	BoardID int
+}
+
+type MoveToSprintCall struct {
+	Ctx      context.Context
+	SprintID int
+	Key      string
+}
+
+type GetChangelogCall struct {
+	Ctx context.Context
+	Key string
+}
+
+type GetComponentsCall struct {
+	Ctx        context.Context
+	ProjectKey string
+}
+
+type GetIssueTypesCall struct {
+	Ctx       context.Context
+	ProjectID string
+}
+
+type GetJQLAutocompleteSuggestionsCall struct {
+	Ctx        context.Context
+	FieldName  string
+	FieldValue string
+}
+
+// FakeClient is a strict-fail implementation of jira.ClientInterface.
+//
+// Usage:
+//
+//	fake := &jiratest.FakeClient{T: t}
+//	fake.GetIssueFunc = func(ctx context.Context, key string) (*jira.Issue, error) {
+//	    return &jira.Issue{Key: key}, nil
+//	}
+//	// ... use fake as jira.ClientInterface ...
+//	if len(fake.GetIssueCalls) != 1 || fake.GetIssueCalls[0].Key != "ABC-1" {
+//	    t.Errorf("unexpected calls: %+v", fake.GetIssueCalls)
+//	}
+type FakeClient struct {
+	T *testing.T
+
+	// Function-field overrides. Default (nil) -> t.Fatalf on call.
+	GetIssueFunc                      func(ctx context.Context, key string) (*jira.Issue, error)
+	SearchIssuesFunc                  func(ctx context.Context, jql string, startAt, maxResults int) (*jira.SearchResult, error)
+	GetMyIssuesFunc                   func(ctx context.Context) ([]jira.Issue, error)
+	GetTransitionsFunc                func(ctx context.Context, key string) ([]jira.Transition, error)
+	DoTransitionFunc                  func(ctx context.Context, key, transitionID string) error
+	AddCommentFunc                    func(ctx context.Context, key string, body any) (*jira.Comment, error)
+	UpdateCommentFunc                 func(ctx context.Context, key, commentID string, body any) error
+	AssignIssueFunc                   func(ctx context.Context, key, accountID string) error
+	GetProjectsFunc                   func(ctx context.Context) ([]jira.Project, error)
+	GetBoardsFunc                     func(ctx context.Context) ([]jira.Board, error)
+	GetBoardIssuesFunc                func(ctx context.Context, boardID int, jql string) ([]jira.Issue, error)
+	UpdateIssueFunc                   func(ctx context.Context, key string, fields map[string]any) error
+	GetPrioritiesFunc                 func(ctx context.Context) ([]jira.Priority, error)
+	CreateIssueFunc                   func(ctx context.Context, fields map[string]any) (*jira.Issue, error)
+	GetCreateMetaFunc                 func(ctx context.Context, projectKey, issueTypeID string) ([]jira.CreateMetaField, error)
+	GetCommentsFunc                   func(ctx context.Context, key string) ([]jira.Comment, error)
+	GetMyselfFunc                     func(ctx context.Context) (*jira.User, error)
+	GetUsersFunc                      func(ctx context.Context, projectKey string) ([]jira.User, error)
+	GetSprintsFunc                    func(ctx context.Context, boardID int) ([]jira.Sprint, error)
+	MoveToSprintFunc                  func(ctx context.Context, sprintID int, key string) error
+	GetChangelogFunc                  func(ctx context.Context, key string) ([]jira.ChangelogEntry, error)
+	GetLabelsFunc                     func(ctx context.Context) ([]string, error)
+	GetComponentsFunc                 func(ctx context.Context, projectKey string) ([]jira.Component, error)
+	GetIssueTypesFunc                 func(ctx context.Context, projectID string) ([]jira.IssueType, error)
+	GetJQLAutocompleteDataFunc        func(ctx context.Context) ([]jira.AutocompleteField, error)
+	GetJQLAutocompleteSuggestionsFunc func(ctx context.Context, fieldName, fieldValue string) ([]jira.AutocompleteSuggestion, error)
+	SetOnRequestFunc                  func(fn func(jira.RequestLog))
+	SetCustomFieldsFunc               func(ids []string)
+
+	// Call recorders (populated before the *Func is invoked).
+	GetIssueCalls                      []GetIssueCall
+	SearchIssuesCalls                  []SearchIssuesCall
+	GetMyIssuesCalls                   []context.Context
+	GetTransitionsCalls                []GetTransitionsCall
+	DoTransitionCalls                  []DoTransitionCall
+	AddCommentCalls                    []AddCommentCall
+	UpdateCommentCalls                 []UpdateCommentCall
+	AssignIssueCalls                   []AssignIssueCall
+	GetProjectsCalls                   []context.Context
+	GetBoardsCalls                     []context.Context
+	GetBoardIssuesCalls                []GetBoardIssuesCall
+	UpdateIssueCalls                   []UpdateIssueCall
+	GetPrioritiesCalls                 []context.Context
+	CreateIssueCalls                   []CreateIssueCall
+	GetCreateMetaCalls                 []GetCreateMetaCall
+	GetCommentsCalls                   []GetCommentsCall
+	GetMyselfCalls                     []context.Context
+	GetUsersCalls                      []GetUsersCall
+	GetSprintsCalls                    []GetSprintsCall
+	MoveToSprintCalls                  []MoveToSprintCall
+	GetChangelogCalls                  []GetChangelogCall
+	GetLabelsCalls                     []context.Context
+	GetComponentsCalls                 []GetComponentsCall
+	GetIssueTypesCalls                 []GetIssueTypesCall
+	GetJQLAutocompleteDataCalls        []context.Context
+	GetJQLAutocompleteSuggestionsCalls []GetJQLAutocompleteSuggestionsCall
+	SetOnRequestCalls                  int
+	SetCustomFieldsCalls               [][]string
+}
+
+func (f *FakeClient) fatal(name string) {
+	f.T.Helper()
+	f.T.Fatalf("jiratest.FakeClient: unexpected call to %s (no *Func configured)", name)
+}
+
+// --- jira.ClientInterface implementation ---
+
+func (f *FakeClient) GetIssue(ctx context.Context, key string) (*jira.Issue, error) {
+	f.GetIssueCalls = append(f.GetIssueCalls, GetIssueCall{Ctx: ctx, Key: key})
+	if f.GetIssueFunc == nil {
+		f.fatal("GetIssue")
+		return nil, nil
+	}
+	return f.GetIssueFunc(ctx, key)
+}
+
+func (f *FakeClient) SearchIssues(ctx context.Context, jql string, startAt, maxResults int) (*jira.SearchResult, error) {
+	f.SearchIssuesCalls = append(f.SearchIssuesCalls, SearchIssuesCall{Ctx: ctx, JQL: jql, StartAt: startAt, MaxResults: maxResults})
+	if f.SearchIssuesFunc == nil {
+		f.fatal("SearchIssues")
+		return nil, nil
+	}
+	return f.SearchIssuesFunc(ctx, jql, startAt, maxResults)
+}
+
+func (f *FakeClient) GetMyIssues(ctx context.Context) ([]jira.Issue, error) {
+	f.GetMyIssuesCalls = append(f.GetMyIssuesCalls, ctx)
+	if f.GetMyIssuesFunc == nil {
+		f.fatal("GetMyIssues")
+		return nil, nil
+	}
+	return f.GetMyIssuesFunc(ctx)
+}
+
+func (f *FakeClient) GetTransitions(ctx context.Context, key string) ([]jira.Transition, error) {
+	f.GetTransitionsCalls = append(f.GetTransitionsCalls, GetTransitionsCall{Ctx: ctx, Key: key})
+	if f.GetTransitionsFunc == nil {
+		f.fatal("GetTransitions")
+		return nil, nil
+	}
+	return f.GetTransitionsFunc(ctx, key)
+}
+
+func (f *FakeClient) DoTransition(ctx context.Context, key, transitionID string) error {
+	f.DoTransitionCalls = append(f.DoTransitionCalls, DoTransitionCall{Ctx: ctx, Key: key, TransitionID: transitionID})
+	if f.DoTransitionFunc == nil {
+		f.fatal("DoTransition")
+		return nil
+	}
+	return f.DoTransitionFunc(ctx, key, transitionID)
+}
+
+func (f *FakeClient) AddComment(ctx context.Context, key string, body any) (*jira.Comment, error) {
+	f.AddCommentCalls = append(f.AddCommentCalls, AddCommentCall{Ctx: ctx, Key: key, Body: body})
+	if f.AddCommentFunc == nil {
+		f.fatal("AddComment")
+		return nil, nil
+	}
+	return f.AddCommentFunc(ctx, key, body)
+}
+
+func (f *FakeClient) UpdateComment(ctx context.Context, key, commentID string, body any) error {
+	f.UpdateCommentCalls = append(f.UpdateCommentCalls, UpdateCommentCall{Ctx: ctx, Key: key, CommentID: commentID, Body: body})
+	if f.UpdateCommentFunc == nil {
+		f.fatal("UpdateComment")
+		return nil
+	}
+	return f.UpdateCommentFunc(ctx, key, commentID, body)
+}
+
+func (f *FakeClient) AssignIssue(ctx context.Context, key, accountID string) error {
+	f.AssignIssueCalls = append(f.AssignIssueCalls, AssignIssueCall{Ctx: ctx, Key: key, AccountID: accountID})
+	if f.AssignIssueFunc == nil {
+		f.fatal("AssignIssue")
+		return nil
+	}
+	return f.AssignIssueFunc(ctx, key, accountID)
+}
+
+func (f *FakeClient) GetProjects(ctx context.Context) ([]jira.Project, error) {
+	f.GetProjectsCalls = append(f.GetProjectsCalls, ctx)
+	if f.GetProjectsFunc == nil {
+		f.fatal("GetProjects")
+		return nil, nil
+	}
+	return f.GetProjectsFunc(ctx)
+}
+
+func (f *FakeClient) GetBoards(ctx context.Context) ([]jira.Board, error) {
+	f.GetBoardsCalls = append(f.GetBoardsCalls, ctx)
+	if f.GetBoardsFunc == nil {
+		f.fatal("GetBoards")
+		return nil, nil
+	}
+	return f.GetBoardsFunc(ctx)
+}
+
+func (f *FakeClient) GetBoardIssues(ctx context.Context, boardID int, jql string) ([]jira.Issue, error) {
+	f.GetBoardIssuesCalls = append(f.GetBoardIssuesCalls, GetBoardIssuesCall{Ctx: ctx, BoardID: boardID, JQL: jql})
+	if f.GetBoardIssuesFunc == nil {
+		f.fatal("GetBoardIssues")
+		return nil, nil
+	}
+	return f.GetBoardIssuesFunc(ctx, boardID, jql)
+}
+
+func (f *FakeClient) UpdateIssue(ctx context.Context, key string, fields map[string]any) error {
+	f.UpdateIssueCalls = append(f.UpdateIssueCalls, UpdateIssueCall{Ctx: ctx, Key: key, Fields: fields})
+	if f.UpdateIssueFunc == nil {
+		f.fatal("UpdateIssue")
+		return nil
+	}
+	return f.UpdateIssueFunc(ctx, key, fields)
+}
+
+func (f *FakeClient) GetPriorities(ctx context.Context) ([]jira.Priority, error) {
+	f.GetPrioritiesCalls = append(f.GetPrioritiesCalls, ctx)
+	if f.GetPrioritiesFunc == nil {
+		f.fatal("GetPriorities")
+		return nil, nil
+	}
+	return f.GetPrioritiesFunc(ctx)
+}
+
+func (f *FakeClient) CreateIssue(ctx context.Context, fields map[string]any) (*jira.Issue, error) {
+	f.CreateIssueCalls = append(f.CreateIssueCalls, CreateIssueCall{Ctx: ctx, Fields: fields})
+	if f.CreateIssueFunc == nil {
+		f.fatal("CreateIssue")
+		return nil, nil
+	}
+	return f.CreateIssueFunc(ctx, fields)
+}
+
+func (f *FakeClient) GetCreateMeta(ctx context.Context, projectKey, issueTypeID string) ([]jira.CreateMetaField, error) {
+	f.GetCreateMetaCalls = append(f.GetCreateMetaCalls, GetCreateMetaCall{Ctx: ctx, ProjectKey: projectKey, IssueTypeID: issueTypeID})
+	if f.GetCreateMetaFunc == nil {
+		f.fatal("GetCreateMeta")
+		return nil, nil
+	}
+	return f.GetCreateMetaFunc(ctx, projectKey, issueTypeID)
+}
+
+func (f *FakeClient) GetComments(ctx context.Context, key string) ([]jira.Comment, error) {
+	f.GetCommentsCalls = append(f.GetCommentsCalls, GetCommentsCall{Ctx: ctx, Key: key})
+	if f.GetCommentsFunc == nil {
+		f.fatal("GetComments")
+		return nil, nil
+	}
+	return f.GetCommentsFunc(ctx, key)
+}
+
+func (f *FakeClient) GetMyself(ctx context.Context) (*jira.User, error) {
+	f.GetMyselfCalls = append(f.GetMyselfCalls, ctx)
+	if f.GetMyselfFunc == nil {
+		f.fatal("GetMyself")
+		return nil, nil
+	}
+	return f.GetMyselfFunc(ctx)
+}
+
+func (f *FakeClient) GetUsers(ctx context.Context, projectKey string) ([]jira.User, error) {
+	f.GetUsersCalls = append(f.GetUsersCalls, GetUsersCall{Ctx: ctx, ProjectKey: projectKey})
+	if f.GetUsersFunc == nil {
+		f.fatal("GetUsers")
+		return nil, nil
+	}
+	return f.GetUsersFunc(ctx, projectKey)
+}
+
+func (f *FakeClient) GetSprints(ctx context.Context, boardID int) ([]jira.Sprint, error) {
+	f.GetSprintsCalls = append(f.GetSprintsCalls, GetSprintsCall{Ctx: ctx, BoardID: boardID})
+	if f.GetSprintsFunc == nil {
+		f.fatal("GetSprints")
+		return nil, nil
+	}
+	return f.GetSprintsFunc(ctx, boardID)
+}
+
+func (f *FakeClient) MoveToSprint(ctx context.Context, sprintID int, key string) error {
+	f.MoveToSprintCalls = append(f.MoveToSprintCalls, MoveToSprintCall{Ctx: ctx, SprintID: sprintID, Key: key})
+	if f.MoveToSprintFunc == nil {
+		f.fatal("MoveToSprint")
+		return nil
+	}
+	return f.MoveToSprintFunc(ctx, sprintID, key)
+}
+
+func (f *FakeClient) GetChangelog(ctx context.Context, key string) ([]jira.ChangelogEntry, error) {
+	f.GetChangelogCalls = append(f.GetChangelogCalls, GetChangelogCall{Ctx: ctx, Key: key})
+	if f.GetChangelogFunc == nil {
+		f.fatal("GetChangelog")
+		return nil, nil
+	}
+	return f.GetChangelogFunc(ctx, key)
+}
+
+func (f *FakeClient) GetLabels(ctx context.Context) ([]string, error) {
+	f.GetLabelsCalls = append(f.GetLabelsCalls, ctx)
+	if f.GetLabelsFunc == nil {
+		f.fatal("GetLabels")
+		return nil, nil
+	}
+	return f.GetLabelsFunc(ctx)
+}
+
+func (f *FakeClient) GetComponents(ctx context.Context, projectKey string) ([]jira.Component, error) {
+	f.GetComponentsCalls = append(f.GetComponentsCalls, GetComponentsCall{Ctx: ctx, ProjectKey: projectKey})
+	if f.GetComponentsFunc == nil {
+		f.fatal("GetComponents")
+		return nil, nil
+	}
+	return f.GetComponentsFunc(ctx, projectKey)
+}
+
+func (f *FakeClient) GetIssueTypes(ctx context.Context, projectID string) ([]jira.IssueType, error) {
+	f.GetIssueTypesCalls = append(f.GetIssueTypesCalls, GetIssueTypesCall{Ctx: ctx, ProjectID: projectID})
+	if f.GetIssueTypesFunc == nil {
+		f.fatal("GetIssueTypes")
+		return nil, nil
+	}
+	return f.GetIssueTypesFunc(ctx, projectID)
+}
+
+func (f *FakeClient) GetJQLAutocompleteData(ctx context.Context) ([]jira.AutocompleteField, error) {
+	f.GetJQLAutocompleteDataCalls = append(f.GetJQLAutocompleteDataCalls, ctx)
+	if f.GetJQLAutocompleteDataFunc == nil {
+		f.fatal("GetJQLAutocompleteData")
+		return nil, nil
+	}
+	return f.GetJQLAutocompleteDataFunc(ctx)
+}
+
+func (f *FakeClient) GetJQLAutocompleteSuggestions(ctx context.Context, fieldName, fieldValue string) ([]jira.AutocompleteSuggestion, error) {
+	f.GetJQLAutocompleteSuggestionsCalls = append(f.GetJQLAutocompleteSuggestionsCalls, GetJQLAutocompleteSuggestionsCall{Ctx: ctx, FieldName: fieldName, FieldValue: fieldValue})
+	if f.GetJQLAutocompleteSuggestionsFunc == nil {
+		f.fatal("GetJQLAutocompleteSuggestions")
+		return nil, nil
+	}
+	return f.GetJQLAutocompleteSuggestionsFunc(ctx, fieldName, fieldValue)
+}
+
+func (f *FakeClient) SetOnRequest(fn func(jira.RequestLog)) {
+	f.SetOnRequestCalls++
+	if f.SetOnRequestFunc == nil {
+		f.fatal("SetOnRequest")
+		return
+	}
+	f.SetOnRequestFunc(fn)
+}
+
+func (f *FakeClient) SetCustomFields(ids []string) {
+	f.SetCustomFieldsCalls = append(f.SetCustomFieldsCalls, ids)
+	if f.SetCustomFieldsFunc == nil {
+		f.fatal("SetCustomFields")
+		return
+	}
+	f.SetCustomFieldsFunc(ids)
+}
+
+var _ jira.ClientInterface = (*FakeClient)(nil)

--- a/pkg/tui/app.go
+++ b/pkg/tui/app.go
@@ -153,6 +153,11 @@ type App struct {
 	usersCache      map[string][]jira.User
 	issueCache      map[string]*jira.Issue
 	createMetaCache map[string][]jira.CreateMetaField
+	// previewKey is the Jira key of the issue currently shown as a preview
+	// (e.g. a sub-issue selected in the info panel). When set, it takes
+	// precedence over the main list selection for actions that operate on
+	// the visible issue, such as refresh. Empty means no preview active.
+	previewKey string
 	createCtx   createCtx
 
 	gitRepoPath    string

--- a/pkg/tui/app.go
+++ b/pkg/tui/app.go
@@ -544,17 +544,18 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return a, nil
 
 	case views.IssueSelectedMsg:
-		if msg.Issue != nil {
-			a.previewKey = msg.Issue.Key
-			if cached, ok := a.issueCache[msg.Issue.Key]; ok {
-				a.detailView.SetIssue(cached)
-				a.infoPanel.SetIssue(cached)
-			} else {
-				a.detailView.SetIssue(msg.Issue)
-				a.infoPanel.SetIssue(msg.Issue)
-			}
+		if msg.Issue == nil {
+			return a, nil
 		}
-		return a, nil
+		a.previewKey = msg.Issue.Key
+		if cached, ok := a.issueCache[msg.Issue.Key]; ok {
+			a.detailView.SetIssue(cached)
+			a.infoPanel.SetIssue(cached)
+		} else {
+			a.detailView.SetIssue(msg.Issue)
+			a.infoPanel.SetIssue(msg.Issue)
+		}
+		return a, a.prefetchRelated(msg.Issue)
 
 	case views.PreviewRequestMsg:
 		a.previewKey = msg.Key

--- a/pkg/tui/app.go
+++ b/pkg/tui/app.go
@@ -534,6 +534,10 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 		}
 		return a, nil
+
+	case views.PreviewRequestMsg:
+		a.previewKey = msg.Key
+		return a, fetchIssueDetail(a.client, msg.Key)
 	case views.ProjectHoveredMsg:
 		if msg.Project != nil {
 			a.detailView.SetProject(msg.Project)

--- a/pkg/tui/app.go
+++ b/pkg/tui/app.go
@@ -88,6 +88,21 @@ type issuesLoadedMsg struct {
 	tab    int
 }
 type issueDetailLoadedMsg struct{ issue *jira.Issue }
+
+// previewDetailLoadedMsg carries the response of a preview-triggered fetch.
+// See App.previewEpoch.
+type previewDetailLoadedMsg struct {
+	issue *jira.Issue
+	epoch int
+}
+
+// previewDebounceMsg is delivered when a PreviewRequestMsg's debounce tick
+// expires. See App.previewEpoch.
+type previewDebounceMsg struct {
+	key   string
+	epoch int
+}
+
 type transitionDoneMsg struct{}
 type errorMsg struct{ err error }
 type projectsLoadedMsg struct{ projects []jira.Project }
@@ -156,7 +171,13 @@ type App struct {
 	// previewKey identifies the issue displayed in the right-side views.
 	// Empty means nothing is displayed.
 	previewKey string
-	createCtx   createCtx
+	// previewEpoch is bumped on every PreviewRequestMsg. Debounce ticks
+	// and fetch responses carry the epoch of the intent that spawned
+	// them; handlers drop anything whose epoch no longer matches. This
+	// is how we simulate "cancel the previous intent", which bubbletea
+	// does not provide natively for tea.Cmd.
+	previewEpoch int
+	createCtx        createCtx
 
 	gitRepoPath    string
 	gitBranch      string
@@ -537,7 +558,38 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case views.PreviewRequestMsg:
 		a.previewKey = msg.Key
-		return a, fetchIssueDetail(a.client, msg.Key)
+		a.previewEpoch++
+		if cached, ok := a.issueCache[msg.Key]; ok && cached != nil {
+			a.detailView.UpdateIssueData(cached)
+			return a, nil
+		}
+		epoch := a.previewEpoch
+		key := msg.Key
+		return a, tea.Tick(150*time.Millisecond, func(_ time.Time) tea.Msg {
+			return previewDebounceMsg{key: key, epoch: epoch}
+		})
+
+	case previewDebounceMsg:
+		if msg.epoch != a.previewEpoch {
+			return a, nil
+		}
+		return a, fetchPreviewDetail(a.client, msg.key, a.previewEpoch)
+
+	case previewDetailLoadedMsg:
+		if msg.epoch != a.previewEpoch {
+			return a, nil
+		}
+		if msg.issue == nil {
+			return a, nil
+		}
+		a.statusPanel.SetError("")
+		*a.logFlag = false
+		a.statusPanel.SetOnline(true)
+		a.issueCache[msg.issue.Key] = msg.issue
+		a.detailView.UpdateIssueData(msg.issue)
+		a.infoPanel.SetIssue(msg.issue)
+		a.issuesList.PatchIssue(msg.issue)
+		return a, a.prefetchRelated(msg.issue)
 	case views.ProjectHoveredMsg:
 		if msg.Project != nil {
 			a.detailView.SetProject(msg.Project)

--- a/pkg/tui/app.go
+++ b/pkg/tui/app.go
@@ -153,10 +153,8 @@ type App struct {
 	usersCache      map[string][]jira.User
 	issueCache      map[string]*jira.Issue
 	createMetaCache map[string][]jira.CreateMetaField
-	// previewKey is the Jira key of the issue currently shown as a preview
-	// (e.g. a sub-issue selected in the info panel). When set, it takes
-	// precedence over the main list selection for actions that operate on
-	// the visible issue, such as refresh. Empty means no preview active.
+	// previewKey identifies the issue displayed in the right-side views.
+	// Empty means nothing is displayed.
 	previewKey string
 	createCtx   createCtx
 
@@ -526,6 +524,7 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case views.IssueSelectedMsg:
 		if msg.Issue != nil {
+			a.previewKey = msg.Issue.Key
 			if cached, ok := a.issueCache[msg.Issue.Key]; ok {
 				a.detailView.SetIssue(cached)
 				a.infoPanel.SetIssue(cached)

--- a/pkg/tui/app.go
+++ b/pkg/tui/app.go
@@ -586,10 +586,10 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		*a.logFlag = false
 		a.statusPanel.SetOnline(true)
 		a.issueCache[msg.issue.Key] = msg.issue
+		// DetailView only: InfoPanel belongs to the main list issue.
 		a.detailView.UpdateIssueData(msg.issue)
-		a.infoPanel.SetIssue(msg.issue)
 		a.issuesList.PatchIssue(msg.issue)
-		return a, a.prefetchRelated(msg.issue)
+		return a, nil
 	case views.ProjectHoveredMsg:
 		if msg.Project != nil {
 			a.detailView.SetProject(msg.Project)

--- a/pkg/tui/commands.go
+++ b/pkg/tui/commands.go
@@ -109,6 +109,18 @@ func fetchIssueDetail(client jira.ClientInterface, key string) tea.Cmd {
 	})
 }
 
+// fetchPreviewDetail is like fetchIssueDetail but returns a previewDetailLoadedMsg
+// carrying the caller's epoch, so that responses from a superseded preview
+// intent can be dropped. See App.previewEpoch.
+func fetchPreviewDetail(client jira.ClientInterface, key string, epoch int) tea.Cmd {
+	return fetchFullIssue(client, key, func(issue *jira.Issue) tea.Msg {
+		if issue == nil {
+			return errorMsg{err: fmt.Errorf("failed to fetch issue %s", key)}
+		}
+		return previewDetailLoadedMsg{issue: issue, epoch: epoch}
+	})
+}
+
 func fetchProjects(client jira.ClientInterface) tea.Cmd {
 	return func() tea.Msg {
 		projects, err := client.GetProjects(context.Background())

--- a/pkg/tui/current_issue_test.go
+++ b/pkg/tui/current_issue_test.go
@@ -1,0 +1,275 @@
+package tui
+
+import (
+	"context"
+	"testing"
+	"text/template"
+
+	"github.com/textfuel/lazyjira/pkg/config"
+	"github.com/textfuel/lazyjira/pkg/jira"
+	"github.com/textfuel/lazyjira/pkg/jira/jiratest"
+	"github.com/textfuel/lazyjira/pkg/tui/views"
+)
+
+// setupPreviewedSub creates an app with MAIN selected in the list and SUB-1
+// cached as the preview. Action handlers should target SUB-1.
+func setupPreviewedSub(t *testing.T, fake *jiratest.FakeClient, sub *jira.Issue) *App {
+	t.Helper()
+	a := newAppWithFake(t, fake)
+	a.issuesList.SetIssues([]jira.Issue{{Key: mainKey, Summary: "main summary"}})
+	a.previewKey = subKey1
+	a.issueCache[subKey1] = sub
+	return a
+}
+
+// TestEditAction_TargetsPreviewedIssue verifies that pressing the edit action
+// while previewing a sub-issue edits the sub's summary, not the main issue.
+func TestEditAction_TargetsPreviewedIssue(t *testing.T) {
+	fake := &jiratest.FakeClient{T: t}
+	a := newAppWithFake(t, fake)
+	a.issuesList.SetIssues([]jira.Issue{{Key: mainKey, Summary: "main summary"}})
+	a.previewKey = subKey1
+	a.issueCache[subKey1] = &jira.Issue{Key: subKey1, Summary: "sub summary"}
+	a.side = sideLeft
+	a.leftFocus = focusIssues
+
+	_, _ = a.handleActionEdit()
+
+	if got := a.editContext.issueKey; got != subKey1 {
+		t.Errorf("editContext.issueKey = %q, want %q", got, subKey1)
+	}
+}
+
+// TestCustomCommand_TargetsPreviewedIssue verifies that a custom command's
+// template is rendered with the previewed issue's key, not the list cursor.
+func TestCustomCommand_TargetsPreviewedIssue(t *testing.T) {
+	fake := &jiratest.FakeClient{T: t}
+	a := newAppWithFake(t, fake)
+	a.issuesList.SetIssues([]jira.Issue{{Key: mainKey, Summary: "main"}})
+	a.previewKey = subKey1
+	a.issueCache[subKey1] = &jira.Issue{Key: subKey1, Summary: "sub"}
+
+	tmpl, err := template.New("t").Option("missingkey=error").Parse("{{.Key}}")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	rc := config.ResolvedCustomCommand{
+		Key:      "x",
+		Scopes:   config.ScopeIssue,
+		Contexts: []config.Context{config.CtxIssues},
+		Template: tmpl,
+	}
+
+	data, ok := a.buildCommandData(rc)
+	if !ok {
+		t.Fatal("buildCommandData returned ok=false")
+	}
+	scope, ok := data.(issueScopeData)
+	if !ok {
+		t.Fatalf("buildCommandData returned %T, want issueScopeData", data)
+	}
+	if scope.Key != subKey1 {
+		t.Errorf("scope.Key = %q, want %q", scope.Key, subKey1)
+	}
+}
+
+// TestCurrentIssue_StubWhenPreviewKeyUncached covers the race between a
+// preview request firing and the fetch populating the cache. During that
+// window the user might press an issue-scoped key; the action must target
+// the preview key (shown on screen) rather than the list cursor.
+func TestCurrentIssue_StubWhenPreviewKeyUncached(t *testing.T) {
+	fake := &jiratest.FakeClient{T: t}
+	a := newAppWithFake(t, fake)
+	a.issuesList.SetIssues([]jira.Issue{{Key: mainKey}})
+	a.previewKey = subKey1 // no cache entry yet
+
+	cur := a.currentIssue()
+	if cur == nil {
+		t.Fatal("currentIssue() returned nil with previewKey set")
+	}
+	if cur.Key != subKey1 {
+		t.Errorf("currentIssue().Key = %q, want %q (stub for previewKey)", cur.Key, subKey1)
+	}
+}
+
+// TestCurrentIssue_FallsBackToListWhenNoPreview covers the steady-state:
+// before any preview is active, issue-scoped actions operate on the list
+// selection.
+func TestCurrentIssue_FallsBackToListWhenNoPreview(t *testing.T) {
+	fake := &jiratest.FakeClient{T: t}
+	a := newAppWithFake(t, fake)
+	a.issuesList.SetIssues([]jira.Issue{{Key: mainKey}})
+	// previewKey intentionally empty
+
+	cur := a.currentIssue()
+	if cur == nil {
+		t.Fatal("currentIssue() returned nil with list selection present")
+	}
+	if cur.Key != mainKey {
+		t.Errorf("currentIssue().Key = %q, want %q", cur.Key, mainKey)
+	}
+}
+
+// TestEditAction_OnInfoSubTab_EditsPreviewedIssueSummary: pressing edit while
+// the info panel has focus on the Sub or Lnk tab edits the summary of the
+// issue currently previewed, not the main list issue.
+func TestEditAction_OnInfoSubTab_EditsPreviewedIssueSummary(t *testing.T) {
+	fake := &jiratest.FakeClient{T: t}
+	a := setupPreviewedSub(t, fake, &jira.Issue{Key: subKey1, Summary: "sub summary"})
+	a.side = sideLeft
+	a.leftFocus = focusInfo
+	// Main issue has a subtask so the Sub tab has an item.
+	main := &jira.Issue{Key: mainKey, Subtasks: []jira.Issue{{Key: subKey1}}}
+	a.infoPanel.SetIssue(main)
+	a.infoPanel.NextTab() // Fields -> Links
+	a.infoPanel.NextTab() // Links  -> Subtasks
+
+	_, _ = a.handleActionEdit()
+
+	if got := a.editContext.issueKey; got != subKey1 {
+		t.Errorf("editContext.issueKey = %q, want %q", got, subKey1)
+	}
+	if a.editContext.kind != editSummary {
+		t.Errorf("editContext.kind = %v, want editSummary", a.editContext.kind)
+	}
+}
+
+// TestEditAction_Description_TargetsPreviewedIssue: pressing edit from the
+// detail view (side=right, Details tab) edits the previewed issue's
+// description.
+func TestEditAction_Description_TargetsPreviewedIssue(t *testing.T) {
+	fake := &jiratest.FakeClient{T: t}
+	a := setupPreviewedSub(t, fake, &jira.Issue{Key: subKey1, Description: "sub desc"})
+	a.side = sideRight
+	a.detailView.SetActiveTab(views.TabDetails)
+
+	_, _ = a.handleActionEdit()
+
+	if got := a.editContext.issueKey; got != subKey1 {
+		t.Errorf("editContext.issueKey = %q, want %q", got, subKey1)
+	}
+	if a.editContext.kind != editDesc {
+		t.Errorf("editContext.kind = %v, want editDesc", a.editContext.kind)
+	}
+}
+
+// TestTransitionAction_TargetsPreviewedIssue: ActTransition fetches
+// transitions for the previewed issue.
+func TestTransitionAction_TargetsPreviewedIssue(t *testing.T) {
+	var calledKey string
+	fake := &jiratest.FakeClient{T: t}
+	fake.GetTransitionsFunc = func(_ context.Context, key string) ([]jira.Transition, error) {
+		calledKey = key
+		return nil, nil
+	}
+	a := setupPreviewedSub(t, fake, &jira.Issue{Key: subKey1})
+
+	_, cmd, handled := a.handleIssueAction(ActTransition)
+	if !handled {
+		t.Fatal("ActTransition not handled")
+	}
+	if cmd == nil {
+		t.Fatal("expected cmd, got nil")
+	}
+	cmd()
+
+	if calledKey != subKey1 {
+		t.Errorf("GetTransitions called with %q, want %q", calledKey, subKey1)
+	}
+}
+
+// TestAssigneeAction_TargetsPreviewedIssue: ActAssignee fetches users
+// scoped to the previewed issue.
+func TestAssigneeAction_TargetsPreviewedIssue(t *testing.T) {
+	var calledProject string
+	fake := &jiratest.FakeClient{T: t}
+	fake.GetUsersFunc = func(_ context.Context, projectKey string) ([]jira.User, error) {
+		calledProject = projectKey
+		return nil, nil
+	}
+	a := setupPreviewedSub(t, fake, &jira.Issue{Key: subKey1})
+	a.projectKey = "SUB"
+
+	_, cmd, handled := a.handleIssueAction(ActAssignee)
+	if !handled {
+		t.Fatal("ActAssignee not handled")
+	}
+	if cmd == nil {
+		t.Fatal("expected cmd, got nil")
+	}
+	cmd()
+
+	if a.onSelect == nil {
+		t.Error("onSelect was not installed (handler needs a previewed issue)")
+	}
+	if calledProject != "SUB" {
+		t.Errorf("GetUsers called for project %q, want SUB", calledProject)
+	}
+}
+
+// TestCommentsAction_TargetsPreviewedIssue: ActComments opens the detail
+// view's Comments tab and shows the previewed issue.
+func TestCommentsAction_TargetsPreviewedIssue(t *testing.T) {
+	fake := &jiratest.FakeClient{T: t}
+	a := setupPreviewedSub(t, fake, &jira.Issue{Key: subKey1, Summary: "cached"})
+	a.detailView.SetIssue(a.issueCache[subKey1])
+
+	_, cmd, handled := a.handleIssueAction(ActComments)
+	if !handled {
+		t.Fatal("ActComments not handled")
+	}
+	if cmd != nil {
+		// No-op since the previewed issue is cached.
+		cmd()
+	}
+	if a.detailView.ActiveTab() != views.TabComments {
+		t.Errorf("detailView tab = %v, want Comments", a.detailView.ActiveTab())
+	}
+	if a.detailView.IssueKey() != subKey1 {
+		t.Errorf("detailView.IssueKey() = %q, want %q", a.detailView.IssueKey(), subKey1)
+	}
+}
+
+// TestNewCommentAction_TargetsPreviewedIssue: ActNew in the Comments tab
+// opens the editor bound to the previewed issue.
+func TestNewCommentAction_TargetsPreviewedIssue(t *testing.T) {
+	fake := &jiratest.FakeClient{T: t}
+	a := setupPreviewedSub(t, fake, &jira.Issue{Key: subKey1})
+	a.side = sideRight
+	a.detailView.SetActiveTab(views.TabComments)
+
+	_, _, handled := a.handleIssueAction(ActNew)
+	if !handled {
+		t.Fatal("ActNew not handled")
+	}
+	if got := a.editContext.issueKey; got != subKey1 {
+		t.Errorf("editContext.issueKey = %q, want %q", got, subKey1)
+	}
+	if a.editContext.kind != editCommentNew {
+		t.Errorf("editContext.kind = %v, want editCommentNew", a.editContext.kind)
+	}
+}
+
+// TestDuplicateIssueAction_TargetsPreviewedIssue: starting a duplicate uses
+// the previewed issue as the source.
+func TestDuplicateIssueAction_TargetsPreviewedIssue(t *testing.T) {
+	fake := &jiratest.FakeClient{T: t}
+	fake.GetIssueTypesFunc = func(_ context.Context, _ string) ([]jira.IssueType, error) {
+		return nil, nil
+	}
+	a := setupPreviewedSub(t, fake, &jira.Issue{Key: subKey1, Summary: "sub summary"})
+	a.side = sideLeft
+	a.leftFocus = focusIssues
+	a.projectKey = "SUB"
+
+	_, _, handled := a.handleIssueAction(ActDuplicateIssue)
+	if !handled {
+		t.Fatal("ActDuplicateIssue not handled")
+	}
+	if a.createCtx.duplicateFrom == nil {
+		t.Fatal("duplicateFrom not set")
+	}
+	if got := a.createCtx.duplicateFrom.Key; got != subKey1 {
+		t.Errorf("duplicateFrom.Key = %q, want %q", got, subKey1)
+	}
+}

--- a/pkg/tui/custom_commands.go
+++ b/pkg/tui/custom_commands.go
@@ -151,7 +151,7 @@ func scopeNoun(s config.ScopeMask) string {
 func (a *App) buildCommandData(rc config.ResolvedCustomCommand) (any, bool) {
 	switch rc.Scopes {
 	case config.ScopeIssue:
-		if a.issuesList.SelectedIssue() == nil {
+		if a.currentIssue() == nil {
 			return nil, false
 		}
 		return a.buildIssueScopeData(), true
@@ -168,7 +168,7 @@ func (a *App) buildCommandData(rc config.ResolvedCustomCommand) (any, bool) {
 		}
 		return a.buildCommentScopeData(cmt), true
 	case config.ScopeIssue | config.ScopeComment:
-		if a.issuesList.SelectedIssue() == nil {
+		if a.currentIssue() == nil {
 			return nil, false
 		}
 		cmt := a.detailView.SelectedComment()
@@ -184,7 +184,7 @@ func (a *App) buildCommandData(rc config.ResolvedCustomCommand) (any, bool) {
 }
 
 func (a *App) buildIssueScopeData() issueScopeData {
-	sel := a.issuesList.SelectedIssue()
+	sel := a.currentIssue()
 	data := issueScopeData{
 		GitBranch:   a.gitBranch,
 		GitRepoPath: a.gitRepoPath,
@@ -300,10 +300,11 @@ func (a *App) handleCustomCommandFinished(msg customCommandFinishedMsg) (tea.Mod
 	if tail := lastNonEmptyLine(msg.output); tail != "" {
 		a.helpBar.SetStatusMsg(tail)
 	}
-	// Refresh the selected issue only when the command declares refresh: true.
+	// Refresh the previewed issue only when the command declares refresh: true.
 	if msg.refresh {
-		if sel := a.issuesList.SelectedIssue(); sel != nil {
-			cmds = append(cmds, fetchIssueDetail(a.client, sel.Key))
+		if cur := a.currentIssue(); cur != nil {
+			delete(a.issueCache, cur.Key)
+			cmds = append(cmds, fetchIssueDetail(a.client, cur.Key))
 		}
 	}
 	return a, tea.Batch(cmds...)

--- a/pkg/tui/handlers_data.go
+++ b/pkg/tui/handlers_data.go
@@ -29,7 +29,9 @@ func (a *App) handleIssuesLoaded(msg issuesLoadedMsg) (tea.Model, tea.Cmd) {
 		}
 	}
 	if msg.tab == a.issuesList.GetTabIndex() && a.side == sideLeft && a.leftFocus == focusIssues {
-		a.previewSelectedIssue()
+		if cmd := a.previewSelectedIssue(); cmd != nil {
+			cmds = append(cmds, cmd)
+		}
 	}
 	if a.gitDetectedKey != "" {
 		detectedKey := a.gitDetectedKey
@@ -395,6 +397,9 @@ func (a *App) prefetchRelated(issue *jira.Issue) tea.Cmd {
 		if link.InwardIssue != nil {
 			collect(link.InwardIssue.Key)
 		}
+	}
+	if issue.Parent != nil {
+		collect(issue.Parent.Key)
 	}
 	if len(keys) == 0 {
 		return nil

--- a/pkg/tui/handlers_data.go
+++ b/pkg/tui/handlers_data.go
@@ -61,7 +61,9 @@ func (a *App) handleIssuesLoaded(msg issuesLoadedMsg) (tea.Model, tea.Cmd) {
 	return a, tea.Batch(cmds...)
 }
 
-// handleIssueDetailLoaded updates the detail view with full issue data
+// handleIssueDetailLoaded applies a freshly fetched issue. DetailView follows
+// previewKey; InfoPanel follows the list selection so its tab and cursor are
+// preserved when a preview of another issue arrives.
 func (a *App) handleIssueDetailLoaded(msg issueDetailLoadedMsg) (tea.Model, tea.Cmd) {
 	a.statusPanel.SetError("")
 	*a.logFlag = false
@@ -69,6 +71,8 @@ func (a *App) handleIssueDetailLoaded(msg issueDetailLoadedMsg) (tea.Model, tea.
 	a.issueCache[msg.issue.Key] = msg.issue
 	if a.previewKey == "" || a.previewKey == msg.issue.Key {
 		a.detailView.UpdateIssueData(msg.issue)
+	}
+	if sel := a.issuesList.SelectedIssue(); sel != nil && sel.Key == msg.issue.Key {
 		a.infoPanel.SetIssue(msg.issue)
 	}
 	a.issuesList.PatchIssue(msg.issue)

--- a/pkg/tui/handlers_data.go
+++ b/pkg/tui/handlers_data.go
@@ -67,13 +67,9 @@ func (a *App) handleIssueDetailLoaded(msg issueDetailLoadedMsg) (tea.Model, tea.
 	*a.logFlag = false
 	a.statusPanel.SetOnline(true)
 	a.issueCache[msg.issue.Key] = msg.issue
-	if a.detailView.IssueKey() == "" || a.detailView.IssueKey() == msg.issue.Key {
+	if a.previewKey == "" || a.previewKey == msg.issue.Key {
 		a.detailView.UpdateIssueData(msg.issue)
-	}
-	if sel := a.issuesList.SelectedIssue(); sel != nil && sel.Key == msg.issue.Key {
-		if a.infoPanel.IssueKey() == "" || a.infoPanel.IssueKey() == msg.issue.Key {
-			a.infoPanel.SetIssue(msg.issue)
-		}
+		a.infoPanel.SetIssue(msg.issue)
 	}
 	a.issuesList.PatchIssue(msg.issue)
 

--- a/pkg/tui/handlers_keys.go
+++ b/pkg/tui/handlers_keys.go
@@ -431,6 +431,7 @@ func (a *App) handleIssueAction(action Action) (tea.Model, tea.Cmd, bool) {
 
 	case ActRefresh:
 		if a.previewKey != "" {
+			delete(a.issueCache, a.previewKey)
 			*a.logFlag = true
 			return a, fetchIssueDetail(a.client, a.previewKey), true
 		}

--- a/pkg/tui/handlers_keys.go
+++ b/pkg/tui/handlers_keys.go
@@ -242,6 +242,10 @@ func (a *App) handleFocusAction(action Action) (tea.Model, tea.Cmd, bool) {
 			case focusIssues:
 				a.leftFocus = focusStatus
 			case focusInfo:
+				tab := a.infoPanel.ActiveTab()
+				if tab == views.InfoTabSubtasks || tab == views.InfoTabLinks {
+					a.previewSelectedIssue()
+				}
 				a.leftFocus = focusIssues
 			case focusProjects:
 				a.leftFocus = focusInfo

--- a/pkg/tui/handlers_keys.go
+++ b/pkg/tui/handlers_keys.go
@@ -428,9 +428,15 @@ func (a *App) handleIssueAction(action Action) (tea.Model, tea.Cmd, bool) {
 		return a, nil, true
 
 	case ActRefresh:
-		if sel := a.issuesList.SelectedIssue(); sel != nil {
+		key := a.previewKey
+		if key == "" {
+			if sel := a.issuesList.SelectedIssue(); sel != nil {
+				key = sel.Key
+			}
+		}
+		if key != "" {
 			*a.logFlag = true
-			return a, fetchIssueDetail(a.client, sel.Key), true
+			return a, fetchIssueDetail(a.client, key), true
 		}
 		return a, nil, true
 

--- a/pkg/tui/handlers_keys.go
+++ b/pkg/tui/handlers_keys.go
@@ -243,10 +243,13 @@ func (a *App) handleFocusAction(action Action) (tea.Model, tea.Cmd, bool) {
 				a.leftFocus = focusStatus
 			case focusInfo:
 				tab := a.infoPanel.ActiveTab()
+				var cmd tea.Cmd
 				if tab == views.InfoTabSubtasks || tab == views.InfoTabLinks {
-					a.previewSelectedIssue()
+					cmd = a.previewSelectedIssue()
 				}
 				a.leftFocus = focusIssues
+				a.updateFocusState()
+				return a, cmd, true
 			case focusProjects:
 				a.leftFocus = focusInfo
 			}
@@ -307,7 +310,7 @@ func (a *App) handleTabAction(action Action) (tea.Model, tea.Cmd, bool) {
 			if !a.issuesList.HasCachedTab() {
 				return a, a.fetchActiveTab(), true
 			}
-			a.previewSelectedIssue()
+			return a, a.previewSelectedIssue(), true
 		case a.side == sideLeft && a.leftFocus == focusInfo:
 			a.infoPanel.PrevTab()
 			return a, a.previewForInfoTab(), true
@@ -323,7 +326,7 @@ func (a *App) handleTabAction(action Action) (tea.Model, tea.Cmd, bool) {
 			if !a.issuesList.HasCachedTab() {
 				return a, a.fetchActiveTab(), true
 			}
-			a.previewSelectedIssue()
+			return a, a.previewSelectedIssue(), true
 		case a.side == sideLeft && a.leftFocus == focusInfo:
 			a.infoPanel.NextTab()
 			return a, a.previewForInfoTab(), true

--- a/pkg/tui/handlers_keys.go
+++ b/pkg/tui/handlers_keys.go
@@ -428,15 +428,9 @@ func (a *App) handleIssueAction(action Action) (tea.Model, tea.Cmd, bool) {
 		return a, nil, true
 
 	case ActRefresh:
-		key := a.previewKey
-		if key == "" {
-			if sel := a.issuesList.SelectedIssue(); sel != nil {
-				key = sel.Key
-			}
-		}
-		if key != "" {
+		if a.previewKey != "" {
 			*a.logFlag = true
-			return a, fetchIssueDetail(a.client, key), true
+			return a, fetchIssueDetail(a.client, a.previewKey), true
 		}
 		return a, nil, true
 

--- a/pkg/tui/handlers_keys.go
+++ b/pkg/tui/handlers_keys.go
@@ -361,36 +361,36 @@ func (a *App) handleTabAction(action Action) (tea.Model, tea.Cmd, bool) {
 func (a *App) handleIssueAction(action Action) (tea.Model, tea.Cmd, bool) {
 	switch action { //nolint:exhaustive
 	case ActCopyURL:
-		if sel := a.issuesList.SelectedIssue(); sel != nil {
-			copyToClipboard(a.cfg.Jira.Host + "/browse/" + sel.Key)
+		if cur := a.currentIssue(); cur != nil {
+			copyToClipboard(a.cfg.Jira.Host + "/browse/" + cur.Key)
 		}
 		return a, nil, true
 
 	case ActBrowser:
-		if sel := a.issuesList.SelectedIssue(); sel != nil && (a.leftFocus == focusIssues || a.side == sideRight) {
-			openBrowser(a.cfg.Jira.Host + "/browse/" + sel.Key)
+		if cur := a.currentIssue(); cur != nil {
+			openBrowser(a.cfg.Jira.Host + "/browse/" + cur.Key)
 		}
 		return a, nil, true
 
 	case ActTransition:
 		if a.side == sideLeft && (a.leftFocus == focusIssues || a.leftFocus == focusInfo) {
-			if sel := a.issuesList.SelectedIssue(); sel != nil {
+			if cur := a.currentIssue(); cur != nil {
 				*a.logFlag = true
-				return a, fetchTransitions(a.client, sel.Key), true
+				return a, fetchTransitions(a.client, cur.Key), true
 			}
 		}
 		return a, nil, true
 
 	case ActComments:
-		sel := a.issuesList.SelectedIssue()
-		if sel == nil {
+		cur := a.currentIssue()
+		if cur == nil {
 			return a, nil, true
 		}
 		a.side = sideRight
 		a.detailView.SetActiveTab(views.TabComments)
 		a.updateFocusState()
-		if _, ok := a.issueCache[sel.Key]; !ok {
-			return a, fetchIssueDetail(a.client, sel.Key), true
+		if _, ok := a.issueCache[cur.Key]; !ok {
+			return a, fetchIssueDetail(a.client, cur.Key), true
 		}
 		return a, nil, true
 
@@ -410,29 +410,29 @@ func (a *App) handleIssueAction(action Action) (tea.Model, tea.Cmd, bool) {
 			m, cmd := a.startCreateIssue()
 			return m, cmd, true
 		}
-		sel := a.issuesList.SelectedIssue()
-		if sel == nil || a.side != sideRight || a.detailView.ActiveTab() != views.TabComments {
+		cur := a.currentIssue()
+		if cur == nil || a.side != sideRight || a.detailView.ActiveTab() != views.TabComments {
 			return a, nil, true
 		}
-		a.editContext = editCtx{kind: editCommentNew, issueKey: sel.Key}
+		a.editContext = editCtx{kind: editCommentNew, issueKey: cur.Key}
 		return a, launchEditor("", ".md"), true
 
 	case ActPriority:
-		if sel := a.issuesList.SelectedIssue(); sel != nil {
+		if cur := a.currentIssue(); cur != nil {
 			*a.logFlag = true
 			return a, fetchPriorities(a.client), true
 		}
 		return a, nil, true
 
 	case ActAssignee:
-		if sel := a.issuesList.SelectedIssue(); sel != nil {
+		if cur := a.currentIssue(); cur != nil {
 			*a.logFlag = true
-			a.onSelect = a.makePersonSelectCallback(sel.Key, "assignee")
+			a.onSelect = a.makePersonSelectCallback(cur.Key, "assignee")
 			if cached, ok := a.usersCache[a.projectKey]; ok {
-				m, cmd := a.handleUsersLoaded(usersLoadedMsg{users: cached, issueKey: sel.Key})
+				m, cmd := a.handleUsersLoaded(usersLoadedMsg{users: cached, issueKey: cur.Key})
 				return m, cmd, true
 			}
-			return a, fetchUsers(a.client, a.projectKey, sel.Key), true
+			return a, fetchUsers(a.client, a.projectKey, cur.Key), true
 		}
 		return a, nil, true
 
@@ -451,13 +451,9 @@ func (a *App) handleIssueAction(action Action) (tea.Model, tea.Cmd, bool) {
 }
 
 func (a *App) startDuplicateIssue() (tea.Model, tea.Cmd) {
-	sel := a.issuesList.SelectedIssue()
-	if sel == nil || a.projectKey == "" {
+	source := a.currentIssue()
+	if source == nil || a.projectKey == "" {
 		return a, nil
-	}
-	source := sel
-	if cached, ok := a.issueCache[sel.Key]; ok {
-		source = cached
 	}
 	a.createCtx = createCtx{
 		intent:        true,
@@ -578,12 +574,8 @@ func (a *App) infoPanelSelectedKey() string {
 
 // handleActionURLPicker shows the URL picker modal
 func (a *App) handleActionURLPicker() (tea.Model, tea.Cmd) {
-	if sel := a.issuesList.SelectedIssue(); sel != nil {
-		cached := sel
-		if c, ok := a.issueCache[sel.Key]; ok {
-			cached = c
-		}
-		groups := views.ExtractURLs(cached, a.cfg.Jira.Host)
+	if cur := a.currentIssue(); cur != nil {
+		groups := views.ExtractURLs(cur, a.cfg.Jira.Host)
 		if len(groups) > 0 {
 			var items []components.ModalItem
 			for i, g := range groups {
@@ -618,17 +610,27 @@ func (a *App) handleActionURLPicker() (tea.Model, tea.Cmd) {
 
 // handleActionEdit dispatches context-aware editing
 func (a *App) handleActionEdit() (tea.Model, tea.Cmd) {
-	sel := a.issuesList.SelectedIssue()
-	if sel == nil {
+	cur := a.currentIssue()
+	if cur == nil {
 		return a, nil
 	}
 	if a.side == sideLeft && a.leftFocus == focusIssues {
-		a.inputModal.Show("Edit Summary", sel.Summary)
-		a.editContext = editCtx{kind: editSummary, issueKey: sel.Key}
+		a.inputModal.Show("Edit Summary", cur.Summary)
+		a.editContext = editCtx{kind: editSummary, issueKey: cur.Key}
 		return a, nil
 	}
 	if a.side == sideLeft && a.leftFocus == focusInfo {
-		return a.editInfoField(sel)
+		if a.infoPanel.ActiveTab() == views.InfoTabFields {
+			// Fields tab shows the main list issue's fields; edit those.
+			if sel := a.issuesList.SelectedIssue(); sel != nil {
+				return a.editInfoField(sel)
+			}
+			return a, nil
+		}
+		// Sub or Lnk tab: edit the previewed issue's summary.
+		a.inputModal.Show("Edit Summary", cur.Summary)
+		a.editContext = editCtx{kind: editSummary, issueKey: cur.Key}
+		return a, nil
 	}
 	if a.side == sideRight && a.detailView.ActiveTab() == views.TabComments {
 		cmt := a.detailView.SelectedComment()
@@ -641,20 +643,16 @@ func (a *App) handleActionEdit() (tea.Model, tea.Cmd) {
 		} else if cmt.Body != "" {
 			md = cmt.Body
 		}
-		a.editContext = editCtx{kind: editCommentMod, issueKey: sel.Key, commentID: cmt.ID}
+		a.editContext = editCtx{kind: editCommentMod, issueKey: cur.Key, commentID: cmt.ID}
 		return a, launchEditor(md, ".md")
 	}
-	cached := sel
-	if c, ok := a.issueCache[sel.Key]; ok {
-		cached = c
-	}
 	md := ""
-	if cached.DescriptionADF != nil {
-		md = views.ADFToMarkdown(cached.DescriptionADF)
-	} else if cached.Description != "" {
-		md = cached.Description
+	if cur.DescriptionADF != nil {
+		md = views.ADFToMarkdown(cur.DescriptionADF)
+	} else if cur.Description != "" {
+		md = cur.Description
 	}
-	a.editContext = editCtx{kind: editDesc, issueKey: sel.Key}
+	a.editContext = editCtx{kind: editDesc, issueKey: cur.Key}
 	return a, launchEditor(md, ".md")
 }
 
@@ -667,7 +665,7 @@ func (a *App) handleActionCreateBranch() (tea.Model, tea.Cmd) {
 		a.statusPanel.SetError("not a git repository")
 		return a, nil
 	}
-	sel := a.issuesList.SelectedIssue()
+	sel := a.currentIssue()
 	if sel == nil {
 		return a, nil
 	}

--- a/pkg/tui/handlers_keys.go
+++ b/pkg/tui/handlers_keys.go
@@ -306,6 +306,7 @@ func (a *App) handleTabAction(action Action) (tea.Model, tea.Cmd, bool) {
 			a.previewSelectedIssue()
 		case a.side == sideLeft && a.leftFocus == focusInfo:
 			a.infoPanel.PrevTab()
+			return a, a.previewForInfoTab(), true
 		}
 		return a, nil, true
 
@@ -321,6 +322,7 @@ func (a *App) handleTabAction(action Action) (tea.Model, tea.Cmd, bool) {
 			a.previewSelectedIssue()
 		case a.side == sideLeft && a.leftFocus == focusInfo:
 			a.infoPanel.NextTab()
+			return a, a.previewForInfoTab(), true
 		}
 		return a, nil, true
 

--- a/pkg/tui/navigation.go
+++ b/pkg/tui/navigation.go
@@ -27,10 +27,10 @@ func (a *App) showCachedIssue(key string) {
 	}
 }
 
-func (a *App) previewSelectedIssue() {
+func (a *App) previewSelectedIssue() tea.Cmd {
 	sel := a.issuesList.SelectedIssue()
 	if sel == nil {
-		return
+		return nil
 	}
 	a.previewKey = sel.Key
 	if cached, ok := a.issueCache[sel.Key]; ok {
@@ -40,6 +40,7 @@ func (a *App) previewSelectedIssue() {
 		a.detailView.SetIssue(sel)
 		a.infoPanel.SetIssue(sel)
 	}
+	return a.prefetchRelated(sel)
 }
 
 // previewForInfoTab refreshes the preview for the current InfoPanel tab, so
@@ -48,8 +49,7 @@ func (a *App) previewSelectedIssue() {
 func (a *App) previewForInfoTab() tea.Cmd {
 	switch a.infoPanel.ActiveTab() {
 	case views.InfoTabFields:
-		a.previewSelectedIssue()
-		return nil
+		return a.previewSelectedIssue()
 	case views.InfoTabSubtasks:
 		if key := a.infoPanel.SelectedSubtaskKey(); key != "" {
 			return func() tea.Msg { return views.PreviewRequestMsg{Key: key} }

--- a/pkg/tui/navigation.go
+++ b/pkg/tui/navigation.go
@@ -12,10 +12,17 @@ import (
 	"github.com/textfuel/lazyjira/pkg/tui/views"
 )
 
-// showCachedIssue updates the detail view with the cached version of the given issue key.
+// showCachedIssue updates the detail view with the cached version of the
+// given issue key. The InfoPanel is only updated when the key matches the
+// main list selection; otherwise the panel stays with the main issue so its
+// tab and cursor are preserved.
 func (a *App) showCachedIssue(key string) {
-	if cached, ok := a.issueCache[key]; ok {
-		a.detailView.SetIssue(cached)
+	cached, ok := a.issueCache[key]
+	if !ok {
+		return
+	}
+	a.detailView.SetIssue(cached)
+	if sel := a.issuesList.SelectedIssue(); sel != nil && sel.Key == key {
 		a.infoPanel.SetIssue(cached)
 	}
 }

--- a/pkg/tui/navigation.go
+++ b/pkg/tui/navigation.go
@@ -6,6 +6,10 @@ import (
 	"runtime"
 	"strings"
 	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/textfuel/lazyjira/pkg/tui/views"
 )
 
 // showCachedIssue updates the detail view with the cached version of the given issue key.
@@ -29,6 +33,26 @@ func (a *App) previewSelectedIssue() {
 		a.detailView.SetIssue(sel)
 		a.infoPanel.SetIssue(sel)
 	}
+}
+
+// previewForInfoTab refreshes the preview for the current InfoPanel tab, so
+// entering Sub or Lnk immediately previews its first entry. Fields reverts
+// to the main issue; empty lists dispatch nothing.
+func (a *App) previewForInfoTab() tea.Cmd {
+	switch a.infoPanel.ActiveTab() {
+	case views.InfoTabFields:
+		a.previewSelectedIssue()
+		return nil
+	case views.InfoTabSubtasks:
+		if key := a.infoPanel.SelectedSubtaskKey(); key != "" {
+			return func() tea.Msg { return views.PreviewRequestMsg{Key: key} }
+		}
+	case views.InfoTabLinks:
+		if key := a.infoPanel.SelectedLinkKey(); key != "" {
+			return func() tea.Msg { return views.PreviewRequestMsg{Key: key} }
+		}
+	}
+	return nil
 }
 
 // extractIssueKey checks if a URL points to our Jira and extracts the issue key.

--- a/pkg/tui/navigation.go
+++ b/pkg/tui/navigation.go
@@ -9,8 +9,28 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 
+	"github.com/textfuel/lazyjira/pkg/jira"
 	"github.com/textfuel/lazyjira/pkg/tui/views"
 )
+
+// currentIssue returns the issue the user is currently looking at: the
+// previewed issue if cached, otherwise a stub carrying just the preview key.
+// Falls back to the list selection only when no preview is active. User-
+// initiated actions (edit, copy URL, transition, custom commands, ...)
+// operate on the result so they target what is on screen even when a sub or
+// link is being previewed. The stub covers the brief window between a
+// preview request firing and the fetch response populating the cache; actions
+// that need more than the key (edit summary/description) must accept a key-
+// only stub gracefully.
+func (a *App) currentIssue() *jira.Issue {
+	if a.previewKey != "" {
+		if cached, ok := a.issueCache[a.previewKey]; ok && cached != nil {
+			return cached
+		}
+		return &jira.Issue{Key: a.previewKey}
+	}
+	return a.issuesList.SelectedIssue()
+}
 
 // showCachedIssue updates the detail view with the cached version of the
 // given issue key. The InfoPanel is only updated when the key matches the

--- a/pkg/tui/navigation.go
+++ b/pkg/tui/navigation.go
@@ -21,6 +21,7 @@ func (a *App) previewSelectedIssue() {
 	if sel == nil {
 		return
 	}
+	a.previewKey = sel.Key
 	if cached, ok := a.issueCache[sel.Key]; ok {
 		a.detailView.SetIssue(cached)
 		a.infoPanel.SetIssue(cached)

--- a/pkg/tui/prefetch_test.go
+++ b/pkg/tui/prefetch_test.go
@@ -1,0 +1,99 @@
+package tui
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/textfuel/lazyjira/pkg/jira"
+	"github.com/textfuel/lazyjira/pkg/jira/jiratest"
+	"github.com/textfuel/lazyjira/pkg/tui/views"
+)
+
+// TestPrefetchRelated_IncludesParent ensures the parent key is fetched along
+// with subtasks and links so that navigating up the hierarchy feels the same
+// as navigating into sub-tasks.
+func TestPrefetchRelated_IncludesParent(t *testing.T) {
+	const parentKey = "PARENT-1"
+
+	var got string
+	fake := &jiratest.FakeClient{T: t}
+	fake.SearchIssuesFunc = func(_ context.Context, jql string, _, _ int) (*jira.SearchResult, error) {
+		got = jql
+		return &jira.SearchResult{}, nil
+	}
+	a := newAppWithFake(t, fake)
+
+	issue := &jira.Issue{
+		Key:      mainKey,
+		Parent:   &jira.Issue{Key: parentKey},
+		Subtasks: []jira.Issue{{Key: subKey1}},
+	}
+
+	cmd := a.prefetchRelated(issue)
+	if cmd == nil {
+		t.Fatal("expected non-nil prefetch cmd")
+	}
+	cmd()
+
+	if !strings.Contains(got, parentKey) {
+		t.Errorf("SearchIssues JQL %q does not contain parent %q", got, parentKey)
+	}
+	if !strings.Contains(got, subKey1) {
+		t.Errorf("SearchIssues JQL %q does not contain subtask %q", got, subKey1)
+	}
+}
+
+// TestIssueSelectedMsg_PrefetchesRelated ensures selecting a task in the list
+// warms the cache with its subtasks, links and parent so navigating into them
+// feels instant.
+func TestIssueSelectedMsg_PrefetchesRelated(t *testing.T) {
+	var got string
+	fake := &jiratest.FakeClient{T: t}
+	fake.SearchIssuesFunc = func(_ context.Context, jql string, _, _ int) (*jira.SearchResult, error) {
+		got = jql
+		return &jira.SearchResult{}, nil
+	}
+	a := newAppWithFake(t, fake)
+
+	issue := &jira.Issue{
+		Key:      mainKey,
+		Subtasks: []jira.Issue{{Key: subKey1}},
+	}
+
+	_, cmd := a.Update(views.IssueSelectedMsg{Issue: issue})
+	if cmd == nil {
+		t.Fatal("expected a prefetch cmd from IssueSelectedMsg, got nil")
+	}
+	cmd()
+
+	if !strings.Contains(got, subKey1) {
+		t.Errorf("SearchIssues JQL %q does not contain %q", got, subKey1)
+	}
+}
+
+// TestPreviewSelectedIssue_ReturnsPrefetchCmd ensures the helper used on tab
+// switches and focus returns also warms the cache for the now-selected task.
+func TestPreviewSelectedIssue_ReturnsPrefetchCmd(t *testing.T) {
+	var got string
+	fake := &jiratest.FakeClient{T: t}
+	fake.SearchIssuesFunc = func(_ context.Context, jql string, _, _ int) (*jira.SearchResult, error) {
+		got = jql
+		return &jira.SearchResult{}, nil
+	}
+	a := newAppWithFake(t, fake)
+	a.issuesList.SetIssues([]jira.Issue{{
+		Key:      mainKey,
+		Subtasks: []jira.Issue{{Key: subKey1}},
+	}})
+
+	cmd := a.previewSelectedIssue()
+	if cmd == nil {
+		t.Fatal("expected a prefetch cmd from previewSelectedIssue, got nil")
+	}
+	cmd()
+
+	if !strings.Contains(got, subKey1) {
+		t.Errorf("SearchIssues JQL %q does not contain %q", got, subKey1)
+	}
+}

--- a/pkg/tui/preview_debounce_test.go
+++ b/pkg/tui/preview_debounce_test.go
@@ -17,7 +17,8 @@ import (
 // synthetic previewDebounceMsg for epoch=1 (stale) followed by one for
 // epoch=2 (fresh). Only the fresh one must trigger a GetIssue call.
 func TestPreviewDebounce_RapidMovement(t *testing.T) {
-	const key1, key2 = "SUB-1", "SUB-2"
+	const key2 = "SUB-2"
+	key1 := subKey1
 
 	fake := &jiratest.FakeClient{T: t}
 	// Configure for key2 only; any unexpected GetIssue for key1 would t.Fatalf.
@@ -76,7 +77,8 @@ func TestPreviewDebounce_RapidMovement(t *testing.T) {
 // first before the second PreviewRequestMsg arrives), both result in a
 // GetIssue call.
 func TestPreviewDebounce_Lapse(t *testing.T) {
-	const key1, key2 = "SUB-1", "SUB-2"
+	const key2 = "SUB-2"
+	key1 := subKey1
 
 	var issueCalls []string
 	fake := &jiratest.FakeClient{T: t}
@@ -127,7 +129,8 @@ func TestPreviewDebounce_Lapse(t *testing.T) {
 // TestPreviewStaleResponse_DroppedWhenEpochAdvanced verifies that a detail
 // response carrying an old epoch does not update infoPanel or issueCache.
 func TestPreviewStaleResponse_DroppedWhenEpochAdvanced(t *testing.T) {
-	const key1, key2 = "SUB-1", "SUB-2"
+	const key2 = "SUB-2"
+	key1 := subKey1
 
 	fake := &jiratest.FakeClient{T: t}
 	stubFullIssueFetch(fake, &jira.Issue{Key: key2, Summary: "current"})

--- a/pkg/tui/preview_debounce_test.go
+++ b/pkg/tui/preview_debounce_test.go
@@ -1,0 +1,210 @@
+package tui
+
+import (
+	"context"
+	"testing"
+
+	"github.com/textfuel/lazyjira/pkg/jira"
+	"github.com/textfuel/lazyjira/pkg/jira/jiratest"
+	"github.com/textfuel/lazyjira/pkg/tui/views"
+)
+
+// TestPreviewDebounce_RapidMovement verifies that when two PreviewRequestMsgs
+// arrive in rapid succession only the second one causes a GetIssue call.
+//
+// We simulate debounce deterministically without real timers: dispatch both
+// PreviewRequestMsgs first so the epoch advances to 2, then dispatch a
+// synthetic previewDebounceMsg for epoch=1 (stale) followed by one for
+// epoch=2 (fresh). Only the fresh one must trigger a GetIssue call.
+func TestPreviewDebounce_RapidMovement(t *testing.T) {
+	const key1, key2 = "SUB-1", "SUB-2"
+
+	fake := &jiratest.FakeClient{T: t}
+	// Configure for key2 only; any unexpected GetIssue for key1 would t.Fatalf.
+	fake.GetIssueFunc = func(_ context.Context, key string) (*jira.Issue, error) {
+		if key != key2 {
+			t.Errorf("unexpected GetIssue call for key %q (expected %q only)", key, key2)
+		}
+		return &jira.Issue{Key: key}, nil
+	}
+	fake.GetCommentsFunc = func(_ context.Context, _ string) ([]jira.Comment, error) {
+		return nil, nil
+	}
+	fake.GetChangelogFunc = func(_ context.Context, _ string) ([]jira.ChangelogEntry, error) {
+		return nil, nil
+	}
+
+	a := newAppWithFake(t, fake)
+
+	// Two rapid PreviewRequestMsgs advance the epoch to 2.
+	_, _ = a.Update(views.PreviewRequestMsg{Key: key1})
+	_, _ = a.Update(views.PreviewRequestMsg{Key: key2})
+
+	if a.previewEpoch != 2 {
+		t.Fatalf("previewEpoch = %d after two msgs, want 2", a.previewEpoch)
+	}
+
+	// Stale debounce tick for epoch=1: must be a no-op.
+	_, fetchCmd := a.Update(previewDebounceMsg{key: key1, epoch: 1})
+	if fetchCmd != nil {
+		fetchCmd() // execute to surface any unexpected GetIssue call
+		if len(fake.GetIssueCalls) > 0 {
+			t.Errorf("stale debounce tick caused %d GetIssue call(s), want 0", len(fake.GetIssueCalls))
+		}
+	}
+
+	before := len(fake.GetIssueCalls)
+
+	// Fresh debounce tick for epoch=2: must trigger one GetIssue call.
+	_, fetchCmd2 := a.Update(previewDebounceMsg{key: key2, epoch: 2})
+	if fetchCmd2 == nil {
+		t.Fatal("expected fetch cmd from fresh debounce tick, got nil")
+	}
+	fetchCmd2()
+
+	after := len(fake.GetIssueCalls)
+	if got := after - before; got != 1 {
+		t.Errorf("fresh debounce tick caused %d GetIssue call(s), want 1", got)
+	}
+	if after > 0 && fake.GetIssueCalls[after-1].Key != key2 {
+		t.Errorf("GetIssue called with key %q, want %q", fake.GetIssueCalls[after-1].Key, key2)
+	}
+}
+
+// TestPreviewDebounce_Lapse verifies that when two PreviewRequestMsgs are
+// separated by enough time (simulated by dispatching the debounce for the
+// first before the second PreviewRequestMsg arrives), both result in a
+// GetIssue call.
+func TestPreviewDebounce_Lapse(t *testing.T) {
+	const key1, key2 = "SUB-1", "SUB-2"
+
+	var issueCalls []string
+	fake := &jiratest.FakeClient{T: t}
+	fake.GetIssueFunc = func(_ context.Context, key string) (*jira.Issue, error) {
+		issueCalls = append(issueCalls, key)
+		return &jira.Issue{Key: key}, nil
+	}
+	fake.GetCommentsFunc = func(_ context.Context, _ string) ([]jira.Comment, error) {
+		return nil, nil
+	}
+	fake.GetChangelogFunc = func(_ context.Context, _ string) ([]jira.ChangelogEntry, error) {
+		return nil, nil
+	}
+
+	a := newAppWithFake(t, fake)
+
+	// First PreviewRequestMsg - epoch becomes 1.
+	_, _ = a.Update(views.PreviewRequestMsg{Key: key1})
+
+	// Debounce fires before the second msg (lapse): epoch=1 still matches.
+	_, fetchCmd1 := a.Update(previewDebounceMsg{key: key1, epoch: 1})
+	if fetchCmd1 == nil {
+		t.Fatal("expected fetch cmd from first debounce tick, got nil")
+	}
+	fetchCmd1()
+
+	// Second PreviewRequestMsg - epoch becomes 2.
+	_, _ = a.Update(views.PreviewRequestMsg{Key: key2})
+
+	// Debounce fires for epoch=2, still matches.
+	_, fetchCmd2 := a.Update(previewDebounceMsg{key: key2, epoch: 2})
+	if fetchCmd2 == nil {
+		t.Fatal("expected fetch cmd from second debounce tick, got nil")
+	}
+	fetchCmd2()
+
+	if len(issueCalls) != 2 {
+		t.Fatalf("expected 2 GetIssue calls, got %d: %v", len(issueCalls), issueCalls)
+	}
+	if issueCalls[0] != key1 {
+		t.Errorf("first GetIssue call key = %q, want %q", issueCalls[0], key1)
+	}
+	if issueCalls[1] != key2 {
+		t.Errorf("second GetIssue call key = %q, want %q", issueCalls[1], key2)
+	}
+}
+
+// TestPreviewStaleResponse_DroppedWhenEpochAdvanced verifies that a detail
+// response carrying an old epoch does not update infoPanel or issueCache.
+func TestPreviewStaleResponse_DroppedWhenEpochAdvanced(t *testing.T) {
+	const key1, key2 = "SUB-1", "SUB-2"
+
+	fake := &jiratest.FakeClient{T: t}
+	stubFullIssueFetch(fake, &jira.Issue{Key: key2, Summary: "current"})
+
+	a := newAppWithFake(t, fake)
+	// Pre-load InfoPanel with a main issue so a stale response that wrongly
+	// resets it would flip IssueKey away from mainKey.
+	main := &jira.Issue{Key: mainKey, Summary: "main"}
+	a.issuesList.SetIssues([]jira.Issue{*main})
+	a.infoPanel.SetIssue(main)
+
+	// Simulate previewEpoch at 2 with previewKey = key2 (user is on key2).
+	a.previewKey = key2
+	a.previewEpoch = 2
+
+	// Stale response for epoch=1 arrives.
+	_, _ = a.Update(previewDetailLoadedMsg{
+		issue: &jira.Issue{Key: key1, Summary: "stale"},
+		epoch: 1,
+	})
+
+	// The stale response must not touch the cache or the panels.
+	if got := a.infoPanel.IssueKey(); got != mainKey {
+		t.Errorf("infoPanel.IssueKey() = %q, want %q (must stay with main)", got, mainKey)
+	}
+	if got := a.detailView.IssueKey(); got == key1 {
+		t.Errorf("detailView updated with stale key %q, want no update", key1)
+	}
+	if _, ok := a.issueCache[key1]; ok {
+		t.Errorf("issueCache populated with stale key %q, want absent", key1)
+	}
+
+	// Fresh response for epoch=2 arrives.
+	_, _ = a.Update(previewDetailLoadedMsg{
+		issue:     &jira.Issue{Key: key2, Summary: "current"},
+		epoch: 2,
+	})
+
+	if got := a.infoPanel.IssueKey(); got != key2 {
+		t.Errorf("infoPanel.IssueKey() = %q after fresh response, want %q", got, key2)
+	}
+	if _, ok := a.issueCache[key2]; !ok {
+		t.Errorf("issueCache missing key %q after fresh response", key2)
+	}
+}
+
+// TestNonPreviewFetch_NotAffectedByDebounce verifies that ActRefresh works
+// normally regardless of previewEpoch value.
+func TestNonPreviewFetch_NotAffectedByDebounce(t *testing.T) {
+	fake := &jiratest.FakeClient{T: t}
+	stubFullIssueFetch(fake, &jira.Issue{Key: mainKey, Summary: "main"})
+
+	a := newAppWithFake(t, fake)
+	a.issuesList.SetIssues([]jira.Issue{{Key: mainKey}})
+	a.previewKey = mainKey
+	a.previewEpoch = 99
+
+	_, cmd, handled := a.handleIssueAction(ActRefresh)
+	if !handled {
+		t.Fatal("ActRefresh was not handled")
+	}
+	if cmd == nil {
+		t.Fatal("expected cmd from ActRefresh, got nil")
+	}
+	msg := cmd()
+
+	loaded, ok := msg.(issueDetailLoadedMsg)
+	if !ok {
+		t.Fatalf("ActRefresh produced %T, want issueDetailLoadedMsg", msg)
+	}
+	if loaded.issue == nil || loaded.issue.Key != mainKey {
+		t.Errorf("issueDetailLoadedMsg.issue.Key = %q, want %q", loaded.issue.Key, mainKey)
+	}
+
+	// issueDetailLoadedMsg (non-preview) must update views without epoch check.
+	_, _ = a.handleIssueDetailLoaded(loaded)
+	if got := a.infoPanel.IssueKey(); got != mainKey {
+		t.Errorf("infoPanel.IssueKey() = %q after ActRefresh, want %q", got, mainKey)
+	}
+}

--- a/pkg/tui/preview_debounce_test.go
+++ b/pkg/tui/preview_debounce_test.go
@@ -165,12 +165,14 @@ func TestPreviewStaleResponse_DroppedWhenEpochAdvanced(t *testing.T) {
 
 	// Fresh response for epoch=2 arrives.
 	_, _ = a.Update(previewDetailLoadedMsg{
-		issue:     &jira.Issue{Key: key2, Summary: "current"},
+		issue: &jira.Issue{Key: key2, Summary: "current"},
 		epoch: 2,
 	})
 
-	if got := a.infoPanel.IssueKey(); got != key2 {
-		t.Errorf("infoPanel.IssueKey() = %q after fresh response, want %q", got, key2)
+	// A preview response only updates the DetailView + cache, not the
+	// InfoPanel (which belongs to the main list issue).
+	if got := a.detailView.IssueKey(); got != key2 {
+		t.Errorf("detailView.IssueKey() = %q after fresh response, want %q", got, key2)
 	}
 	if _, ok := a.issueCache[key2]; !ok {
 		t.Errorf("issueCache missing key %q after fresh response", key2)

--- a/pkg/tui/preview_infopanel_stability_test.go
+++ b/pkg/tui/preview_infopanel_stability_test.go
@@ -1,0 +1,185 @@
+package tui
+
+import (
+	"testing"
+
+	"github.com/textfuel/lazyjira/pkg/jira"
+	"github.com/textfuel/lazyjira/pkg/jira/jiratest"
+	"github.com/textfuel/lazyjira/pkg/tui/views"
+)
+
+// TestPreviewDetailLoaded_DoesNotMutateInfoPanel pins the invariant that a
+// preview response must not overwrite the InfoPanel. The InfoPanel belongs to
+// the main issue selected in the list, its active tab and cursor reflect the
+// user's navigation context. Only the DetailView on the right may follow the
+// previewed issue.
+func TestPreviewDetailLoaded_DoesNotMutateInfoPanel(t *testing.T) {
+	fake := &jiratest.FakeClient{T: t}
+	a := newAppWithFake(t, fake)
+
+	// Main issue selected in the list; InfoPanel belongs to it.
+	main := &jira.Issue{Key: mainKey, Summary: "main"}
+	a.issuesList.SetIssues([]jira.Issue{*main})
+	a.infoPanel.SetIssue(main)
+
+	// User has navigated into the Sub tab on the main issue.
+	a.previewKey = subKey1
+	a.previewEpoch = 1
+
+	// The sub-issue's fetch response arrives.
+	_, _ = a.Update(previewDetailLoadedMsg{
+		issue: &jira.Issue{Key: subKey1, Summary: "sub"},
+		epoch: 1,
+	})
+
+	if got := a.infoPanel.IssueKey(); got != mainKey {
+		t.Errorf("infoPanel.IssueKey() = %q after preview response, want %q (InfoPanel must stay on main issue)", got, mainKey)
+	}
+}
+
+// TestIssueDetailLoaded_DoesNotMutateInfoPanelForSubPreview covers the
+// ActRefresh path: when the user is previewing a sub-issue and presses refresh,
+// the detail response comes through the non-preview channel. It still must not
+// overwrite the InfoPanel.
+func TestIssueDetailLoaded_DoesNotMutateInfoPanelForSubPreview(t *testing.T) {
+	fake := &jiratest.FakeClient{T: t}
+	a := newAppWithFake(t, fake)
+
+	main := &jira.Issue{Key: mainKey, Summary: "main"}
+	a.issuesList.SetIssues([]jira.Issue{*main})
+	a.infoPanel.SetIssue(main)
+
+	// Previewing a sub-issue.
+	a.previewKey = subKey1
+
+	_, _ = a.handleIssueDetailLoaded(issueDetailLoadedMsg{
+		issue: &jira.Issue{Key: subKey1, Summary: "sub-fresh"},
+	})
+
+	if got := a.infoPanel.IssueKey(); got != mainKey {
+		t.Errorf("infoPanel.IssueKey() = %q after sub-issue refresh, want %q", got, mainKey)
+	}
+}
+
+// TestShowCachedIssue_DoesNotMutateInfoPanelForForeignKey ensures navigating
+// to a linked issue (not the main list selection) does not reset the InfoPanel.
+// showCachedIssue is called from navigateToLinkedIssue and friends with a key
+// that does not match the current list cursor; before the fix it overwrote
+// the InfoPanel and reset its tab/cursor.
+func TestShowCachedIssue_DoesNotMutateInfoPanelForForeignKey(t *testing.T) {
+	fake := &jiratest.FakeClient{T: t}
+	a := newAppWithFake(t, fake)
+	main := &jira.Issue{Key: mainKey, Summary: "main"}
+	a.issuesList.SetIssues([]jira.Issue{*main})
+	a.infoPanel.SetIssue(main)
+	a.issueCache[subKey1] = &jira.Issue{Key: subKey1, Summary: "sub"}
+
+	a.showCachedIssue(subKey1)
+
+	if got := a.infoPanel.IssueKey(); got != mainKey {
+		t.Errorf("infoPanel.IssueKey() = %q after showCachedIssue(%q), want %q",
+			got, subKey1, mainKey)
+	}
+}
+
+// TestTabSwitchToSubtasks_DispatchesPreviewRequest verifies that entering the
+// Subtasks tab immediately previews the first subtask without requiring an
+// extra cursor move.
+func TestTabSwitchToSubtasks_DispatchesPreviewRequest(t *testing.T) {
+	fake := &jiratest.FakeClient{T: t}
+	a := newAppWithFake(t, fake)
+	main := &jira.Issue{
+		Key:      mainKey,
+		Subtasks: []jira.Issue{{Key: subKey1}},
+	}
+	a.issuesList.SetIssues([]jira.Issue{*main})
+	a.infoPanel.SetIssue(main)
+	a.side = sideLeft
+	a.leftFocus = focusInfo
+
+	// Cycle: Fields -> Links (no links here) -> Subtasks.
+	_, _, _ = a.handleTabAction(ActNextTab)
+	_, cmd, handled := a.handleTabAction(ActNextTab)
+	if !handled {
+		t.Fatal("ActNextTab not handled")
+	}
+	if cmd == nil {
+		t.Fatal("expected non-nil cmd on sub-tab entry, got nil")
+	}
+	msg := cmd()
+	pr, ok := msg.(views.PreviewRequestMsg)
+	if !ok {
+		t.Fatalf("expected PreviewRequestMsg, got %T", msg)
+	}
+	if pr.Key != subKey1 {
+		t.Errorf("PreviewRequestMsg.Key = %q, want %q", pr.Key, subKey1)
+	}
+}
+
+// TestTabSwitchToLinks_DispatchesPreviewRequest covers the same behaviour for
+// the Links tab.
+func TestTabSwitchToLinks_DispatchesPreviewRequest(t *testing.T) {
+	const linkKey = "LNK-1"
+
+	fake := &jiratest.FakeClient{T: t}
+	a := newAppWithFake(t, fake)
+	main := &jira.Issue{
+		Key: mainKey,
+		IssueLinks: []jira.IssueLink{{
+			Type:         &jira.IssueLinkType{Name: "relates to"},
+			OutwardIssue: &jira.Issue{Key: linkKey},
+		}},
+	}
+	a.issuesList.SetIssues([]jira.Issue{*main})
+	a.infoPanel.SetIssue(main)
+	a.side = sideLeft
+	a.leftFocus = focusInfo
+
+	// One NextTab advances from Fields to Links.
+	_, cmd, handled := a.handleTabAction(ActNextTab)
+	if !handled {
+		t.Fatal("ActNextTab not handled")
+	}
+	if cmd == nil {
+		t.Fatal("expected non-nil cmd on link-tab entry, got nil")
+	}
+	msg := cmd()
+	pr, ok := msg.(views.PreviewRequestMsg)
+	if !ok {
+		t.Fatalf("expected PreviewRequestMsg, got %T", msg)
+	}
+	if pr.Key != linkKey {
+		t.Errorf("PreviewRequestMsg.Key = %q, want %q", pr.Key, linkKey)
+	}
+}
+
+// TestTabSwitchToSubtasks_EmptyListNoDispatch guards the empty-list edge case:
+// when the main issue has no subtasks, entering the Subtasks tab must not fire
+// a PreviewRequestMsg.
+func TestTabSwitchToSubtasks_EmptyListNoDispatch(t *testing.T) {
+	fake := &jiratest.FakeClient{T: t}
+	a := newAppWithFake(t, fake)
+	main := &jira.Issue{Key: mainKey} // no subtasks, no links
+	a.issuesList.SetIssues([]jira.Issue{*main})
+	a.infoPanel.SetIssue(main)
+	a.side = sideLeft
+	a.leftFocus = focusInfo
+
+	// Cycle to Links (empty) then Subtasks (empty).
+	_, cmd1, _ := a.handleTabAction(ActNextTab)
+	if cmd1 != nil {
+		if msg := cmd1(); msg != nil {
+			if _, ok := msg.(views.PreviewRequestMsg); ok {
+				t.Errorf("empty Links tab dispatched PreviewRequestMsg, want no dispatch")
+			}
+		}
+	}
+	_, cmd2, _ := a.handleTabAction(ActNextTab)
+	if cmd2 != nil {
+		if msg := cmd2(); msg != nil {
+			if _, ok := msg.(views.PreviewRequestMsg); ok {
+				t.Errorf("empty Subtasks tab dispatched PreviewRequestMsg, want no dispatch")
+			}
+		}
+	}
+}

--- a/pkg/tui/preview_infopanel_stability_test.go
+++ b/pkg/tui/preview_infopanel_stability_test.go
@@ -82,6 +82,28 @@ func TestShowCachedIssue_DoesNotMutateInfoPanelForForeignKey(t *testing.T) {
 	}
 }
 
+// TestPreviewRequestMsg_CacheHit_UpdatesDetailViewImmediately pins the
+// invariant that a preview request for an already-cached issue is served
+// synchronously from cache. No fetch, no debounce delay, matching the
+// feel of scrolling through the main issue list.
+func TestPreviewRequestMsg_CacheHit_UpdatesDetailViewImmediately(t *testing.T) {
+	fake := &jiratest.FakeClient{T: t}
+	// No *Func set: any HTTP path would t.Fatalf.
+	a := newAppWithFake(t, fake)
+
+	cached := &jira.Issue{Key: subKey1, Summary: "cached sub"}
+	a.issueCache[subKey1] = cached
+
+	_, _ = a.Update(views.PreviewRequestMsg{Key: subKey1})
+
+	if got := a.detailView.IssueKey(); got != subKey1 {
+		t.Errorf("detailView.IssueKey() = %q, want %q (cache hit should update synchronously)", got, subKey1)
+	}
+	if a.previewKey != subKey1 {
+		t.Errorf("previewKey = %q, want %q", a.previewKey, subKey1)
+	}
+}
+
 // TestTabSwitchToSubtasks_DispatchesPreviewRequest verifies that entering the
 // Subtasks tab immediately previews the first subtask without requiring an
 // extra cursor move.

--- a/pkg/tui/preview_request_test.go
+++ b/pkg/tui/preview_request_test.go
@@ -12,7 +12,7 @@ import (
 // PreviewRequestMsg sets a.previewKey and returns a non-nil Cmd that calls
 // GetIssue with the given key.
 func TestPreviewRequestMsg_SetsPreviewKeyAndFetches(t *testing.T) {
-	const subKey = "SUB-1"
+	subKey := subKey1
 
 	fake := &jiratest.FakeClient{T: t}
 	stubFullIssueFetch(fake, &jira.Issue{Key: subKey, Summary: "sub issue"})
@@ -30,7 +30,7 @@ func TestPreviewRequestMsg_SetsPreviewKeyAndFetches(t *testing.T) {
 // debounce tick fires (simulated via previewDebounceMsg), a GetIssue call is
 // made for the correct key.
 func TestPreviewRequestMsg_CmdEventuallyCallsGetIssue(t *testing.T) {
-	const subKey = "SUB-1"
+	subKey := subKey1
 
 	fake := &jiratest.FakeClient{T: t}
 	stubFullIssueFetch(fake, &jira.Issue{Key: subKey, Summary: "sub issue"})

--- a/pkg/tui/preview_request_test.go
+++ b/pkg/tui/preview_request_test.go
@@ -1,0 +1,52 @@
+package tui
+
+import (
+	"testing"
+
+	"github.com/textfuel/lazyjira/pkg/jira"
+	"github.com/textfuel/lazyjira/pkg/jira/jiratest"
+	"github.com/textfuel/lazyjira/pkg/tui/views"
+)
+
+// TestPreviewRequestMsg_SetsPreviewKeyAndFetches verifies that receiving
+// PreviewRequestMsg sets a.previewKey and returns a non-nil Cmd that calls
+// GetIssue with the given key.
+func TestPreviewRequestMsg_SetsPreviewKeyAndFetches(t *testing.T) {
+	const subKey = "SUB-1"
+
+	fake := &jiratest.FakeClient{T: t}
+	stubFullIssueFetch(fake, &jira.Issue{Key: subKey, Summary: "sub issue"})
+
+	a := newAppWithFake(t, fake)
+
+	_, _ = a.Update(views.PreviewRequestMsg{Key: subKey})
+
+	if got := a.previewKey; got != subKey {
+		t.Errorf("previewKey = %q, want %q", got, subKey)
+	}
+}
+
+// TestPreviewRequestMsg_CmdCallsGetIssue verifies the returned Cmd
+// triggers a GetIssue call with the correct key.
+func TestPreviewRequestMsg_CmdCallsGetIssue(t *testing.T) {
+	const subKey = "SUB-1"
+
+	fake := &jiratest.FakeClient{T: t}
+	stubFullIssueFetch(fake, &jira.Issue{Key: subKey, Summary: "sub issue"})
+
+	a := newAppWithFake(t, fake)
+
+	_, cmd := a.Update(views.PreviewRequestMsg{Key: subKey})
+	if cmd == nil {
+		t.Fatal("expected non-nil tea.Cmd from PreviewRequestMsg handler, got nil")
+	}
+
+	cmd() // execute the command to trigger the fake calls
+
+	if len(fake.GetIssueCalls) != 1 {
+		t.Fatalf("expected 1 GetIssue call, got %d: %+v", len(fake.GetIssueCalls), fake.GetIssueCalls)
+	}
+	if got := fake.GetIssueCalls[0].Key; got != subKey {
+		t.Errorf("GetIssue called with key %q, want %q", got, subKey)
+	}
+}

--- a/pkg/tui/preview_request_test.go
+++ b/pkg/tui/preview_request_test.go
@@ -26,9 +26,10 @@ func TestPreviewRequestMsg_SetsPreviewKeyAndFetches(t *testing.T) {
 	}
 }
 
-// TestPreviewRequestMsg_CmdCallsGetIssue verifies the returned Cmd
-// triggers a GetIssue call with the correct key.
-func TestPreviewRequestMsg_CmdCallsGetIssue(t *testing.T) {
+// TestPreviewRequestMsg_CmdEventuallyCallsGetIssue verifies that after the
+// debounce tick fires (simulated via previewDebounceMsg), a GetIssue call is
+// made for the correct key.
+func TestPreviewRequestMsg_CmdEventuallyCallsGetIssue(t *testing.T) {
 	const subKey = "SUB-1"
 
 	fake := &jiratest.FakeClient{T: t}
@@ -36,12 +37,20 @@ func TestPreviewRequestMsg_CmdCallsGetIssue(t *testing.T) {
 
 	a := newAppWithFake(t, fake)
 
-	_, cmd := a.Update(views.PreviewRequestMsg{Key: subKey})
-	if cmd == nil {
+	_, tickCmd := a.Update(views.PreviewRequestMsg{Key: subKey})
+	if tickCmd == nil {
 		t.Fatal("expected non-nil tea.Cmd from PreviewRequestMsg handler, got nil")
 	}
 
-	cmd() // execute the command to trigger the fake calls
+	// The tick cmd returns a previewDebounceMsg when fired. We simulate it
+	// deterministically by dispatching the debounce message directly, which
+	// avoids waiting for the real 150 ms timer.
+	_, fetchCmd := a.Update(previewDebounceMsg{key: subKey, epoch: a.previewEpoch})
+	if fetchCmd == nil {
+		t.Fatal("expected fetch cmd from debounce tick, got nil")
+	}
+
+	fetchCmd() // triggers GetIssue on the fake
 
 	if len(fake.GetIssueCalls) != 1 {
 		t.Fatalf("expected 1 GetIssue call, got %d: %+v", len(fake.GetIssueCalls), fake.GetIssueCalls)

--- a/pkg/tui/preview_reset_test.go
+++ b/pkg/tui/preview_reset_test.go
@@ -1,0 +1,144 @@
+package tui
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/textfuel/lazyjira/pkg/jira"
+	"github.com/textfuel/lazyjira/pkg/jira/jiratest"
+	"github.com/textfuel/lazyjira/pkg/tui/views"
+)
+
+// setupInfoFocusedOnSubtabs sets up an App with:
+//   - mainKey as the list selection
+//   - previewKey set to subKey (simulating a prior sub-issue preview)
+//   - InfoPanel focused, active tab = tab
+//   - InfoPanel loaded with a non-empty issue so it has content
+func setupInfoFocused(t *testing.T, tab views.InfoPanelTab) *App {
+	t.Helper()
+	fake := &jiratest.FakeClient{T: t}
+	a := newAppWithFake(t, fake)
+
+	mainIssue := jira.Issue{
+		Key:     mainKey,
+		Summary: "main issue",
+		Subtasks: []jira.Issue{
+			{Key: subKey1, Summary: "sub one"},
+		},
+		IssueLinks: []jira.IssueLink{
+			{
+				Type:         &jira.IssueLinkType{Name: "Blocks", Outward: "blocks", Inward: "is blocked by"},
+				OutwardIssue: &jira.Issue{Key: "LNK-1", Summary: "linked"},
+			},
+		},
+	}
+	a.issuesList.SetIssues([]jira.Issue{mainIssue})
+	a.infoPanel.SetIssue(&mainIssue)
+
+	// Advance infopanel to the requested tab
+	for a.infoPanel.ActiveTab() != tab {
+		a.infoPanel.NextTab()
+	}
+
+	// Simulate that user moved cursor in Sub/Lnk tab and preview was set to a sub-key
+	a.previewKey = subKey1
+
+	a.side = sideLeft
+	a.leftFocus = focusInfo
+	a.infoPanel.Focused = true
+	a.keymap = DefaultKeymap()
+	a.infoPanel.ResolveNav = DefaultKeymap().MatchNav
+	return a
+}
+
+// TestEscFromSubTab_ResetsPreviewToMainIssue verifies that the Esc/FocusLeft
+// action while the InfoPanel has focus and the Sub tab is active resets
+// previewKey to the list selection's key.
+func TestEscFromSubTab_ResetsPreviewToMainIssue(t *testing.T) {
+	a := setupInfoFocused(t, views.InfoTabSubtasks)
+	if a.previewKey != subKey1 {
+		t.Fatalf("precondition: previewKey = %q, want SUB-1", a.previewKey)
+	}
+
+	a.handleFocusAction(ActFocusLeft)
+
+	if got := a.previewKey; got != mainKey {
+		t.Errorf("previewKey = %q after FocusLeft from Sub tab, want %q", got, mainKey)
+	}
+}
+
+// TestEscFromLnkTab_ResetsPreviewToMainIssue verifies the same reset when the
+// Lnk tab is active.
+func TestEscFromLnkTab_ResetsPreviewToMainIssue(t *testing.T) {
+	a := setupInfoFocused(t, views.InfoTabLinks)
+	a.previewKey = "LNK-1"
+
+	a.handleFocusAction(ActFocusLeft)
+
+	if got := a.previewKey; got != mainKey {
+		t.Errorf("previewKey = %q after FocusLeft from Lnk tab, want %q", got, mainKey)
+	}
+}
+
+// TestInfoPanelTabSwitchToFields_ResetsPreviewKey verifies that switching the
+// InfoPanel tab to Fields resets previewKey to the current list selection.
+func TestInfoPanelTabSwitchToFields_ResetsPreviewKey(t *testing.T) {
+	// Start on Sub tab with previewKey pointing at a sub-issue
+	a := setupInfoFocused(t, views.InfoTabSubtasks)
+	a.previewKey = subKey1
+
+	// Switch from Sub -> Lnk -> Fields (NextTab cycles Fields->Lnk->Sub;
+	// we need to tab until we reach Fields)
+	// visibleTabs order: Fields, Links, Subtasks (indices 0,1,2)
+	// PrevTab from Subtasks -> Links -> Fields
+	a.handleTabAction(ActPrevTab) // Sub -> Lnk
+	a.handleTabAction(ActPrevTab) // Lnk -> Fields
+
+	if got := a.previewKey; got != mainKey {
+		t.Errorf("previewKey = %q after switching to Fields tab, want %q", got, mainKey)
+	}
+}
+
+// TestEmptySubList_NoPreviewDispatch verifies that switching to the Sub tab on
+// an issue with no subtasks does not produce a PreviewRequestMsg.
+func TestEmptySubList_NoPreviewDispatch(t *testing.T) {
+	fake := &jiratest.FakeClient{T: t}
+	// No GetIssueFunc set — any call would t.Fatalf via FakeClient.
+	a := newAppWithFake(t, fake)
+
+	issueNoSubs := &jira.Issue{Key: mainKey, Summary: "no subs"}
+	a.issuesList.SetIssues([]jira.Issue{*issueNoSubs})
+	a.infoPanel.SetIssue(issueNoSubs)
+	a.previewKey = mainKey
+	a.side = sideLeft
+	a.leftFocus = focusInfo
+	a.infoPanel.Focused = true
+	a.keymap = DefaultKeymap()
+
+	// Ensure we start on Fields tab
+	if a.infoPanel.ActiveTab() != views.InfoTabFields {
+		t.Fatal("precondition: expected InfoTabFields as default tab")
+	}
+
+	// Switch to Sub tab via NextTab actions (Fields->Links->Subtasks)
+	a.handleTabAction(ActNextTab) // Fields -> Links
+	a.handleTabAction(ActNextTab) // Links -> Sub
+
+	if a.infoPanel.ActiveTab() != views.InfoTabSubtasks {
+		t.Fatal("expected InfoTabSubtasks after two NextTab actions")
+	}
+
+	// Now simulate cursor movement in Sub tab — should produce no PreviewRequestMsg
+	// because there are no subtasks. The InfoPanel.Update handles cursor movement.
+	navKey := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("j")}
+	a.infoPanel.ResolveNav = DefaultKeymap().MatchNav
+	_, cmd := a.infoPanel.Update(navKey)
+	if cmd == nil {
+		return // nil is acceptable: no preview dispatch
+	}
+	msg := cmd()
+	if _, ok := msg.(views.PreviewRequestMsg); ok {
+		t.Error("empty Sub list must not dispatch PreviewRequestMsg on cursor move")
+	}
+}

--- a/pkg/tui/refresh_test.go
+++ b/pkg/tui/refresh_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 const mainKey = "ABC-1"
+const subKey1 = "SUB-1"
 
 // newAppWithFake augments newTestApp() with a FakeClient, a non-nil logFlag,
 // an InfoPanel, a StatusPanel, and an empty issueCache — enough to flow a
@@ -22,6 +23,7 @@ func newAppWithFake(t *testing.T, fake *jiratest.FakeClient) *App {
 	a.logFlag = &logFlag
 	a.infoPanel = views.NewInfoPanel()
 	a.statusPanel = views.NewStatusPanel("", "", "")
+	a.logPanel = views.NewLogPanel()
 	a.issueCache = map[string]*jira.Issue{}
 	return a
 }
@@ -111,17 +113,17 @@ func TestHandleIssueDetailLoaded_RoutesByPreviewKey(t *testing.T) {
 	fake := &jiratest.FakeClient{T: t}
 	a := newAppWithFake(t, fake)
 	a.issuesList.SetIssues([]jira.Issue{{Key: "MAIN-1"}})
-	a.previewKey = "SUB-1"
+	a.previewKey = subKey1
 
 	_, _ = a.handleIssueDetailLoaded(issueDetailLoadedMsg{
-		issue: &jira.Issue{Key: "SUB-1", Summary: "fresh"},
+		issue: &jira.Issue{Key: subKey1, Summary: "fresh"},
 	})
 
-	if got := a.infoPanel.IssueKey(); got != "SUB-1" {
-		t.Errorf("infoPanel.IssueKey() = %q, want %q", got, "SUB-1")
+	if got := a.infoPanel.IssueKey(); got != subKey1 {
+		t.Errorf("infoPanel.IssueKey() = %q, want %q", got, subKey1)
 	}
-	if got := a.detailView.IssueKey(); got != "SUB-1" {
-		t.Errorf("detailView.IssueKey() = %q, want %q", got, "SUB-1")
+	if got := a.detailView.IssueKey(); got != subKey1 {
+		t.Errorf("detailView.IssueKey() = %q, want %q", got, subKey1)
 	}
 }
 

--- a/pkg/tui/refresh_test.go
+++ b/pkg/tui/refresh_test.go
@@ -1,0 +1,98 @@
+package tui
+
+import (
+	"context"
+	"testing"
+
+	"github.com/textfuel/lazyjira/pkg/jira"
+	"github.com/textfuel/lazyjira/pkg/jira/jiratest"
+)
+
+// newAppWithFake augments newTestApp() with a FakeClient and a non-nil logFlag,
+// the minimum needed for action handlers that fetch via the Jira client.
+func newAppWithFake(t *testing.T, fake *jiratest.FakeClient) *App {
+	t.Helper()
+	a := newTestApp()
+	a.client = fake
+	logFlag := false
+	a.logFlag = &logFlag
+	return a
+}
+
+// stubFullIssueFetch wires the three methods that fetchFullIssue calls.
+// Only GetIssue returns a real issue; Comments + Changelog are empty.
+func stubFullIssueFetch(fake *jiratest.FakeClient, issue *jira.Issue) {
+	fake.GetIssueFunc = func(_ context.Context, _ string) (*jira.Issue, error) {
+		return issue, nil
+	}
+	fake.GetCommentsFunc = func(_ context.Context, _ string) ([]jira.Comment, error) {
+		return nil, nil
+	}
+	fake.GetChangelogFunc = func(_ context.Context, _ string) ([]jira.ChangelogEntry, error) {
+		return nil, nil
+	}
+}
+
+// TestActRefresh_FetchesSelectedIssueKey documents the current behavior:
+// pressing the refresh action re-fetches the currently selected issue via
+// GetIssue. This is a characterization test guarding the happy path.
+func TestActRefresh_FetchesSelectedIssueKey(t *testing.T) {
+	fake := &jiratest.FakeClient{T: t}
+	stubFullIssueFetch(fake, &jira.Issue{Key: "ABC-1", Summary: "updated"})
+
+	a := newAppWithFake(t, fake)
+	a.issuesList.SetIssues([]jira.Issue{{Key: "ABC-1"}})
+
+	_, cmd, handled := a.handleIssueAction(ActRefresh)
+	if !handled {
+		t.Fatal("ActRefresh was not handled")
+	}
+	if cmd == nil {
+		t.Fatal("expected tea.Cmd, got nil")
+	}
+	msg := cmd()
+
+	if len(fake.GetIssueCalls) != 1 {
+		t.Fatalf("expected 1 GetIssue call, got %d: %+v", len(fake.GetIssueCalls), fake.GetIssueCalls)
+	}
+	if got := fake.GetIssueCalls[0].Key; got != "ABC-1" {
+		t.Errorf("GetIssue called with key %q, want %q", got, "ABC-1")
+	}
+
+	loaded, ok := msg.(issueDetailLoadedMsg)
+	if !ok {
+		t.Fatalf("expected issueDetailLoadedMsg, got %T", msg)
+	}
+	if loaded.issue == nil || loaded.issue.Key != "ABC-1" {
+		t.Errorf("loaded.issue = %+v, want Key=ABC-1", loaded.issue)
+	}
+}
+
+// TestActRefresh_UsesPreviewKey_WhenSet documents the desired behavior:
+// when a preview (e.g. a sub-issue selected in the info panel) is active,
+// the refresh action must re-fetch that preview's issue, not the main list
+// selection.
+func TestActRefresh_UsesPreviewKey_WhenSet(t *testing.T) {
+	fake := &jiratest.FakeClient{T: t}
+	stubFullIssueFetch(fake, &jira.Issue{Key: "ABC-2", Summary: "sub-item"})
+
+	a := newAppWithFake(t, fake)
+	a.issuesList.SetIssues([]jira.Issue{{Key: "ABC-1"}})
+	a.previewKey = "ABC-2"
+
+	_, cmd, handled := a.handleIssueAction(ActRefresh)
+	if !handled {
+		t.Fatal("ActRefresh was not handled")
+	}
+	if cmd == nil {
+		t.Fatal("expected tea.Cmd, got nil")
+	}
+	cmd()
+
+	if len(fake.GetIssueCalls) != 1 {
+		t.Fatalf("expected 1 GetIssue call, got %d: %+v", len(fake.GetIssueCalls), fake.GetIssueCalls)
+	}
+	if got := fake.GetIssueCalls[0].Key; got != "ABC-2" {
+		t.Errorf("GetIssue called with key %q, want %q (preview key)", got, "ABC-2")
+	}
+}

--- a/pkg/tui/refresh_test.go
+++ b/pkg/tui/refresh_test.go
@@ -176,3 +176,29 @@ func TestActRefresh_UsesPreviewKey_WhenSet(t *testing.T) {
 		t.Errorf("GetIssue called with key %q, want %q (preview key)", got, "ABC-2")
 	}
 }
+
+// TestActRefresh_InvalidatesCacheBeforeFetch ensures that ActRefresh removes the
+// existing cache entry for the previewed issue synchronously, before the fetch
+// cmd is dispatched. Any cache read between the keypress and the response must
+// see a miss, never stale data.
+func TestActRefresh_InvalidatesCacheBeforeFetch(t *testing.T) {
+	fake := &jiratest.FakeClient{T: t}
+	stubFullIssueFetch(fake, &jira.Issue{Key: mainKey, Summary: "fresh"})
+
+	a := newAppWithFake(t, fake)
+	a.issuesList.SetIssues([]jira.Issue{{Key: mainKey}})
+	a.previewKey = mainKey
+	// Pre-populate the cache with a stale entry.
+	stale := &jira.Issue{Key: mainKey, Summary: "stale"}
+	a.issueCache[mainKey] = stale
+
+	_, _, handled := a.handleIssueAction(ActRefresh)
+	if !handled {
+		t.Fatal("ActRefresh was not handled")
+	}
+
+	// The cache entry must be gone synchronously — before cmd is executed.
+	if _, ok := a.issueCache[mainKey]; ok {
+		t.Errorf("issueCache[%q] still present after ActRefresh; expected cache invalidation", mainKey)
+	}
+}

--- a/pkg/tui/refresh_test.go
+++ b/pkg/tui/refresh_test.go
@@ -6,16 +6,23 @@ import (
 
 	"github.com/textfuel/lazyjira/pkg/jira"
 	"github.com/textfuel/lazyjira/pkg/jira/jiratest"
+	"github.com/textfuel/lazyjira/pkg/tui/views"
 )
 
-// newAppWithFake augments newTestApp() with a FakeClient and a non-nil logFlag,
-// the minimum needed for action handlers that fetch via the Jira client.
+const mainKey = "ABC-1"
+
+// newAppWithFake augments newTestApp() with a FakeClient, a non-nil logFlag,
+// an InfoPanel, a StatusPanel, and an empty issueCache — enough to flow a
+// message through App.Update without NPEs.
 func newAppWithFake(t *testing.T, fake *jiratest.FakeClient) *App {
 	t.Helper()
 	a := newTestApp()
 	a.client = fake
 	logFlag := false
 	a.logFlag = &logFlag
+	a.infoPanel = views.NewInfoPanel()
+	a.statusPanel = views.NewStatusPanel("", "", "")
+	a.issueCache = map[string]*jira.Issue{}
 	return a
 }
 
@@ -33,15 +40,16 @@ func stubFullIssueFetch(fake *jiratest.FakeClient, issue *jira.Issue) {
 	}
 }
 
-// TestActRefresh_FetchesSelectedIssueKey documents the current behavior:
-// pressing the refresh action re-fetches the currently selected issue via
-// GetIssue. This is a characterization test guarding the happy path.
-func TestActRefresh_FetchesSelectedIssueKey(t *testing.T) {
+// TestActRefresh_FetchesPreviewedIssue documents the happy path: after the
+// usual navigation sets previewKey to the displayed issue, pressing refresh
+// re-fetches that issue.
+func TestActRefresh_FetchesPreviewedIssue(t *testing.T) {
 	fake := &jiratest.FakeClient{T: t}
-	stubFullIssueFetch(fake, &jira.Issue{Key: "ABC-1", Summary: "updated"})
+	stubFullIssueFetch(fake, &jira.Issue{Key: mainKey, Summary: "updated"})
 
 	a := newAppWithFake(t, fake)
-	a.issuesList.SetIssues([]jira.Issue{{Key: "ABC-1"}})
+	a.issuesList.SetIssues([]jira.Issue{{Key: mainKey}})
+	a.previewKey = mainKey
 
 	_, cmd, handled := a.handleIssueAction(ActRefresh)
 	if !handled {
@@ -55,16 +63,88 @@ func TestActRefresh_FetchesSelectedIssueKey(t *testing.T) {
 	if len(fake.GetIssueCalls) != 1 {
 		t.Fatalf("expected 1 GetIssue call, got %d: %+v", len(fake.GetIssueCalls), fake.GetIssueCalls)
 	}
-	if got := fake.GetIssueCalls[0].Key; got != "ABC-1" {
-		t.Errorf("GetIssue called with key %q, want %q", got, "ABC-1")
+	if got := fake.GetIssueCalls[0].Key; got != mainKey {
+		t.Errorf("GetIssue called with key %q, want %q", got, mainKey)
 	}
 
 	loaded, ok := msg.(issueDetailLoadedMsg)
 	if !ok {
 		t.Fatalf("expected issueDetailLoadedMsg, got %T", msg)
 	}
-	if loaded.issue == nil || loaded.issue.Key != "ABC-1" {
+	if loaded.issue == nil || loaded.issue.Key != mainKey {
 		t.Errorf("loaded.issue = %+v, want Key=ABC-1", loaded.issue)
+	}
+}
+
+// TestIssueSelectedMsg_UpdatesPreviewKey pins down the invariant that the
+// previewKey follows whatever issue the user has selected in the list.
+func TestIssueSelectedMsg_UpdatesPreviewKey(t *testing.T) {
+	fake := &jiratest.FakeClient{T: t}
+	a := newAppWithFake(t, fake)
+
+	_, _ = a.Update(views.IssueSelectedMsg{Issue: &jira.Issue{Key: mainKey}})
+
+	if got := a.previewKey; got != mainKey {
+		t.Errorf("previewKey = %q, want %q", got, mainKey)
+	}
+}
+
+// TestPreviewSelectedIssue_UpdatesPreviewKey covers the helper that syncs the
+// preview to the current list selection (called on tab switches and after
+// issues load). It must keep previewKey aligned.
+func TestPreviewSelectedIssue_UpdatesPreviewKey(t *testing.T) {
+	fake := &jiratest.FakeClient{T: t}
+	a := newAppWithFake(t, fake)
+	a.issuesList.SetIssues([]jira.Issue{{Key: "XYZ-9"}})
+
+	a.previewSelectedIssue()
+
+	if got := a.previewKey; got != "XYZ-9" {
+		t.Errorf("previewKey = %q, want %q", got, "XYZ-9")
+	}
+}
+
+// TestHandleIssueDetailLoaded_RoutesByPreviewKey ensures a detail response for
+// the previewed issue updates detailView + infoPanel, even if the list cursor
+// has moved on (or never matched, e.g. when previewing a sub-issue).
+func TestHandleIssueDetailLoaded_RoutesByPreviewKey(t *testing.T) {
+	fake := &jiratest.FakeClient{T: t}
+	a := newAppWithFake(t, fake)
+	a.issuesList.SetIssues([]jira.Issue{{Key: "MAIN-1"}})
+	a.previewKey = "SUB-1"
+
+	_, _ = a.handleIssueDetailLoaded(issueDetailLoadedMsg{
+		issue: &jira.Issue{Key: "SUB-1", Summary: "fresh"},
+	})
+
+	if got := a.infoPanel.IssueKey(); got != "SUB-1" {
+		t.Errorf("infoPanel.IssueKey() = %q, want %q", got, "SUB-1")
+	}
+	if got := a.detailView.IssueKey(); got != "SUB-1" {
+		t.Errorf("detailView.IssueKey() = %q, want %q", got, "SUB-1")
+	}
+}
+
+// TestActRefresh_NoFetchWhenPreviewKeyEmpty pins the invariant that previewKey
+// is the single source of truth: with no preview active, refresh is a no-op
+// even if the list has a selection. This removes the implicit fallback to
+// the list cursor.
+func TestActRefresh_NoFetchWhenPreviewKeyEmpty(t *testing.T) {
+	fake := &jiratest.FakeClient{T: t}
+	// No *Func set — any call would t.Fatalf.
+	a := newAppWithFake(t, fake)
+	a.issuesList.SetIssues([]jira.Issue{{Key: mainKey}})
+	// previewKey intentionally left empty.
+
+	_, cmd, handled := a.handleIssueAction(ActRefresh)
+	if !handled {
+		t.Fatal("ActRefresh was not handled")
+	}
+	if cmd != nil {
+		t.Errorf("expected nil cmd (no fetch), got non-nil")
+	}
+	if len(fake.GetIssueCalls) != 0 {
+		t.Errorf("expected 0 GetIssue calls, got %d: %+v", len(fake.GetIssueCalls), fake.GetIssueCalls)
 	}
 }
 
@@ -77,7 +157,7 @@ func TestActRefresh_UsesPreviewKey_WhenSet(t *testing.T) {
 	stubFullIssueFetch(fake, &jira.Issue{Key: "ABC-2", Summary: "sub-item"})
 
 	a := newAppWithFake(t, fake)
-	a.issuesList.SetIssues([]jira.Issue{{Key: "ABC-1"}})
+	a.issuesList.SetIssues([]jira.Issue{{Key: mainKey}})
 	a.previewKey = "ABC-2"
 
 	_, cmd, handled := a.handleIssueAction(ActRefresh)

--- a/pkg/tui/refresh_test.go
+++ b/pkg/tui/refresh_test.go
@@ -107,23 +107,26 @@ func TestPreviewSelectedIssue_UpdatesPreviewKey(t *testing.T) {
 }
 
 // TestHandleIssueDetailLoaded_RoutesByPreviewKey ensures a detail response for
-// the previewed issue updates detailView + infoPanel, even if the list cursor
-// has moved on (or never matched, e.g. when previewing a sub-issue).
+// the previewed sub-issue updates the DetailView (which follows previewKey)
+// but leaves the InfoPanel untouched (the InfoPanel belongs to the main list
+// issue and must keep its tab/cursor).
 func TestHandleIssueDetailLoaded_RoutesByPreviewKey(t *testing.T) {
 	fake := &jiratest.FakeClient{T: t}
 	a := newAppWithFake(t, fake)
-	a.issuesList.SetIssues([]jira.Issue{{Key: "MAIN-1"}})
+	main := &jira.Issue{Key: mainKey, Summary: "main"}
+	a.issuesList.SetIssues([]jira.Issue{*main})
+	a.infoPanel.SetIssue(main)
 	a.previewKey = subKey1
 
 	_, _ = a.handleIssueDetailLoaded(issueDetailLoadedMsg{
 		issue: &jira.Issue{Key: subKey1, Summary: "fresh"},
 	})
 
-	if got := a.infoPanel.IssueKey(); got != subKey1 {
-		t.Errorf("infoPanel.IssueKey() = %q, want %q", got, subKey1)
-	}
 	if got := a.detailView.IssueKey(); got != subKey1 {
-		t.Errorf("detailView.IssueKey() = %q, want %q", got, subKey1)
+		t.Errorf("detailView.IssueKey() = %q, want %q (DetailView follows previewKey)", got, subKey1)
+	}
+	if got := a.infoPanel.IssueKey(); got != mainKey {
+		t.Errorf("infoPanel.IssueKey() = %q, want %q (InfoPanel stays on main issue)", got, mainKey)
 	}
 }
 

--- a/pkg/tui/views/infopanel.go
+++ b/pkg/tui/views/infopanel.go
@@ -13,6 +13,10 @@ import (
 	"github.com/textfuel/lazyjira/pkg/tui/theme"
 )
 
+// PreviewRequestMsg is dispatched by InfoPanel when the cursor moves to a
+// different issue in the Sub or Lnk tab, requesting a detail preview fetch.
+type PreviewRequestMsg struct{ Key string }
+
 // InfoPanelTab identifies a tab within the Info panel
 type InfoPanelTab int
 
@@ -226,7 +230,21 @@ func (p *InfoPanel) Update(msg tea.Msg) (*InfoPanel, tea.Cmd) {
 		return p, nil
 	}
 	if msg, ok := msg.(tea.KeyMsg); ok {
-		p.KeyNav(msg.String())
+		moved := p.KeyNav(msg.String())
+		if moved {
+			switch p.activeTab {
+			case InfoTabSubtasks:
+				if key := p.SelectedSubtaskKey(); key != "" {
+					return p, func() tea.Msg { return PreviewRequestMsg{Key: key} }
+				}
+			case InfoTabLinks:
+				if key := p.SelectedLinkKey(); key != "" {
+					return p, func() tea.Msg { return PreviewRequestMsg{Key: key} }
+				}
+			case InfoTabFields:
+				// no preview dispatch on cursor move in fields tab
+			}
+		}
 	}
 	return p, nil
 }

--- a/pkg/tui/views/infopanel_test.go
+++ b/pkg/tui/views/infopanel_test.go
@@ -1,0 +1,168 @@
+package views
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/textfuel/lazyjira/pkg/jira"
+	"github.com/textfuel/lazyjira/pkg/tui/components"
+)
+
+// navDownResolver is a minimal NavResolver that maps "j" to NavDown.
+func navDownResolver(key string) components.NavAction {
+	if key == "j" {
+		return components.NavDown
+	}
+	return components.NavNone
+}
+
+func makeInfoPanelFocused() *InfoPanel {
+	p := NewInfoPanel()
+	p.ResolveNav = navDownResolver
+	p.Focused = true
+	return p
+}
+
+func pressJ() tea.KeyMsg {
+	return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("j")}
+}
+
+// TestInfoPanel_SubTab_CursorMove_DispatchesPreviewRequestMsg verifies that
+// pressing a nav key while in the Sub tab emits PreviewRequestMsg with
+// the sub-issue key now under the cursor.
+func TestInfoPanel_SubTab_CursorMove_DispatchesPreviewRequestMsg(t *testing.T) {
+	p := makeInfoPanelFocused()
+
+	issue := &jira.Issue{
+		Key: "MAIN-1",
+		Subtasks: []jira.Issue{
+			{Key: "SUB-1", Summary: "first subtask"},
+			{Key: "SUB-2", Summary: "second subtask"},
+		},
+	}
+	p.SetIssue(issue)
+
+	for p.activeTab != InfoTabSubtasks {
+		p.NextTab()
+	}
+
+	// Cursor starts at 0 (SUB-1). Press "j" to move to SUB-2.
+	_, cmd := p.Update(pressJ())
+	if cmd == nil {
+		t.Fatal("expected non-nil tea.Cmd after cursor move in Sub tab, got nil")
+	}
+
+	msg := cmd()
+	prm, ok := msg.(PreviewRequestMsg)
+	if !ok {
+		t.Fatalf("expected PreviewRequestMsg, got %T", msg)
+	}
+	if prm.Key != "SUB-2" {
+		t.Errorf("PreviewRequestMsg.Key = %q, want %q", prm.Key, "SUB-2")
+	}
+}
+
+// TestInfoPanel_LnkTab_CursorMove_OutwardLink verifies that a cursor move in
+// the Lnk tab emits PreviewRequestMsg with the outward link key.
+func TestInfoPanel_LnkTab_CursorMove_OutwardLink(t *testing.T) {
+	p := makeInfoPanelFocused()
+
+	issue := &jira.Issue{
+		Key: "MAIN-1",
+		IssueLinks: []jira.IssueLink{
+			{
+				Type:         &jira.IssueLinkType{Name: "Blocks", Outward: "blocks", Inward: "is blocked by"},
+				OutwardIssue: &jira.Issue{Key: "OUT-1", Summary: "outward issue"},
+			},
+			{
+				Type:         &jira.IssueLinkType{Name: "Blocks", Outward: "blocks", Inward: "is blocked by"},
+				OutwardIssue: &jira.Issue{Key: "OUT-2", Summary: "second outward"},
+			},
+		},
+	}
+	p.SetIssue(issue)
+
+	for p.activeTab != InfoTabLinks {
+		p.NextTab()
+	}
+
+	// Cursor starts at 0 (OUT-1). Press "j" to move to OUT-2.
+	_, cmd := p.Update(pressJ())
+	if cmd == nil {
+		t.Fatal("expected non-nil tea.Cmd after cursor move in Lnk tab, got nil")
+	}
+
+	msg := cmd()
+	prm, ok := msg.(PreviewRequestMsg)
+	if !ok {
+		t.Fatalf("expected PreviewRequestMsg, got %T", msg)
+	}
+	if prm.Key != "OUT-2" {
+		t.Errorf("PreviewRequestMsg.Key = %q, want %q", prm.Key, "OUT-2")
+	}
+}
+
+// TestInfoPanel_LnkTab_CursorMove_InwardLink verifies that a cursor move to an
+// inward link emits the inward issue's key.
+func TestInfoPanel_LnkTab_CursorMove_InwardLink(t *testing.T) {
+	p := makeInfoPanelFocused()
+
+	issue := &jira.Issue{
+		Key: "MAIN-1",
+		IssueLinks: []jira.IssueLink{
+			{
+				Type:         &jira.IssueLinkType{Name: "Blocks", Outward: "blocks", Inward: "is blocked by"},
+				OutwardIssue: &jira.Issue{Key: "OUT-1", Summary: "outward"},
+				InwardIssue:  &jira.Issue{Key: "IN-1", Summary: "inward"},
+			},
+		},
+	}
+	p.SetIssue(issue)
+
+	for p.activeTab != InfoTabLinks {
+		p.NextTab()
+	}
+
+	// Two items: OUT-1 (index 0), IN-1 (index 1). Cursor at 0, press "j".
+	_, cmd := p.Update(pressJ())
+	if cmd == nil {
+		t.Fatal("expected non-nil tea.Cmd after cursor move in Lnk tab (inward), got nil")
+	}
+
+	msg := cmd()
+	prm, ok := msg.(PreviewRequestMsg)
+	if !ok {
+		t.Fatalf("expected PreviewRequestMsg, got %T", msg)
+	}
+	if prm.Key != "IN-1" {
+		t.Errorf("PreviewRequestMsg.Key = %q, want %q", prm.Key, "IN-1")
+	}
+}
+
+// TestInfoPanel_FieldsTab_CursorMove_NoPreviewRequestMsg verifies that cursor
+// movement in the Fields tab does NOT dispatch PreviewRequestMsg.
+func TestInfoPanel_FieldsTab_CursorMove_NoPreviewRequestMsg(t *testing.T) {
+	p := makeInfoPanelFocused()
+
+	issue := &jira.Issue{
+		Key:     "MAIN-1",
+		Summary: "something",
+	}
+	p.SetIssue(issue)
+
+	if p.activeTab != InfoTabFields {
+		t.Fatal("expected InfoTabFields as default tab")
+	}
+
+	_, cmd := p.Update(pressJ())
+
+	if cmd == nil {
+		return // nil is acceptable: no preview dispatch
+	}
+
+	msg := cmd()
+	if _, ok := msg.(PreviewRequestMsg); ok {
+		t.Error("Fields tab must not dispatch PreviewRequestMsg on cursor move")
+	}
+}


### PR DESCRIPTION
Closes #54

Moving the cursor to an issue in the Subtasks or Links tab now
previews that issue in the main pane, and contextual actions
(refresh, edit, transition, open in browser, comments, custom
commands) act on it. Entering a Sub/Lnk tab previews its first
entry immediately; leaving the tab resets the preview back to
the main issue.

The effect: the Sub/Lnk tab behaves like any other selection
pane in a lazy*-style layout. You can browse related issues
without losing your place, and key actions always target the
issue the cursor currently points to.

**Implementation notes**

- A new `jiratest.FakeClient` provides handler-level test
  coverage. Writing tests at this level surfaced a pre-existing
  bug where refresh read stale data from the cache before
  dispatching the fetch; it is also fixed in this branch.

- `App.previewKey` holds the key of the issue currently shown in
  the right-hand views. Selection, cursor moves in the info
  panel and tab-leave paths all write it; the detail view and
  action handlers read it.

- Preview fetches debounce for 150 ms and carry a monotonic
  counter. Responses whose counter is stale by the time they
  arrive are dropped, so a slow response for an earlier
  selection cannot overwrite a later one. Bubbletea has no
  native `tea.Cmd` cancellation, which is why the counter is
  needed. Cache hits bypass the debounce and update the detail
  view synchronously.

- On task selection, a single JQL batch warms the cache for the
  task's parent, subtasks and linked issues, so entering a Sub
  or Lnk tab usually lands on a cache hit.

**To test:**

1. Open an issue with sub-tasks or links. Move the cursor in the
   `Sub` or `Lnk` tab: the main pane previews the highlighted
   item. The info panel stays put.
2. Refresh: the preview re-fetches, not the list item.
3. Edit, transition, or trigger a custom command: they all
   target the previewed issue.
4. Leave the Sub/Lnk tab: the preview returns to the main issue.