### PR TITLE
feat: add catppuccin theme support

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ make build-demo
 - **4-panel layout** - issues, projects, detail, status - with vim-style navigation
 - **Inline editing** - transitions, priority, assignee, labels, comments, description (`$EDITOR`)
 - **Configurable** - custom keybindings (including navigation keys), JQL tabs, issue columns, custom fields
-- **Adaptive** - side-by-side or stacked layout, mouse support, ANSI 16 colors
+- **Themes** - default ANSI palette plus all four Catppuccin flavors (Latte, Frappé, Macchiato, Mocha)
+- **Adaptive** - side-by-side or stacked layout, mouse support
 
 ## Installation
 
@@ -141,6 +142,27 @@ For environments that require client certificates (mTLS), see [Configuration](do
 
 Credentials saved to `~/.config/lazyjira/auth.json`.
 
+## Themes
+
+lazyjira ships with the default ANSI 16 palette plus all four [Catppuccin](https://github.com/catppuccin/catppuccin) flavors. Set `gui.theme` in `~/.config/lazyjira/config.yml`:
+
+```yaml
+gui:
+  theme: catppuccin-mocha
+```
+
+Supported values:
+
+| Theme                  | Description                          |
+|------------------------|--------------------------------------|
+| `default` *(or unset)* | Standard ANSI 16 palette (original)  |
+| `catppuccin-latte`     | Light flavor                         |
+| `catppuccin-frappe`    | Dark flavor (low contrast)           |
+| `catppuccin-macchiato` | Dark flavor (medium contrast)        |
+| `catppuccin-mocha`     | Dark flavor (high contrast)          |
+
+The theme takes effect on next launch.
+
 ## Usage
 
 ```
@@ -175,7 +197,7 @@ Press `?` inside the app for all keybindings.
 - [ ] CLI mode (non-interactive commands for scripting and automation)
 - [ ] Robust issue type changer (handle subtask/parent unlinking, field validation)
 - [ ] Clickable hyperlinks in terminal (OSC 8) for URLs in descriptions and comments
-- [ ] Theming, borders, date format, language and other GUI options
+- [x] Theming (Catppuccin), borders, date format, language and other GUI options
 - [ ] Mouse support toggle
 - [ ] Show icons toggle
 - [ ] Cache with configurable TTL

--- a/README.md
+++ b/README.md
@@ -197,7 +197,8 @@ Press `?` inside the app for all keybindings.
 - [ ] CLI mode (non-interactive commands for scripting and automation)
 - [ ] Robust issue type changer (handle subtask/parent unlinking, field validation)
 - [ ] Clickable hyperlinks in terminal (OSC 8) for URLs in descriptions and comments
-- [x] Theming (Catppuccin), borders, date format, language and other GUI options
+- [x] Catppuccin Theming
+- [ ] Custom colors theming, date format, languages
 - [ ] Mouse support toggle
 - [ ] Show icons toggle
 - [ ] Cache with configurable TTL

--- a/cmd/lazyjira/main.go
+++ b/cmd/lazyjira/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/textfuel/lazyjira/v2/pkg/config"
 	"github.com/textfuel/lazyjira/v2/pkg/jira"
 	"github.com/textfuel/lazyjira/v2/pkg/tui"
+	"github.com/textfuel/lazyjira/v2/pkg/tui/theme"
 )
 
 // version is set at build time via ldflags
@@ -60,6 +61,10 @@ func run() error {
 		if err != nil {
 			return fmt.Errorf("loading config: %w", err)
 		}
+	}
+
+	if err := theme.SetTheme(cfg.GUI.Theme); err != nil {
+		return err
 	}
 
 	var client jira.ClientInterface

--- a/docs/Config.md
+++ b/docs/Config.md
@@ -170,6 +170,13 @@ gui:
 
 `collapsedPanelHeight` sets the height of non-focused left panels in lines (default 5, minimum 3).
 
+`theme` selects the color palette. Supported values: `default` (ANSI 16, original look), `catppuccin-latte`, `catppuccin-frappe`, `catppuccin-macchiato`, `catppuccin-mocha`. Omit or set to `default` to keep the original colors. Catppuccin themes use hex colors and require a terminal with truecolor support.
+
+```yaml
+gui:
+  theme: catppuccin-mocha
+```
+
 `selectCreatedIssue` controls whether the app auto-selects a newly created issue in the list. If the issue does not match the current tab, the app switches to the All tab. Enabled by default.
 
 ```yaml

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 
 require (
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
+	github.com/catppuccin/go v0.3.0 // indirect
 	github.com/charmbracelet/colorprofile v0.4.1 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.15 // indirect
 	github.com/charmbracelet/x/term v0.2.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/alecthomas/repr v0.5.2 h1:SU73FTI9D1P5UNtvseffFSGmdNci/O6RsqzeXJtP0Qs
 github.com/alecthomas/repr v0.5.2/go.mod h1:Fr0507jx4eOXV7AlPV6AVZLYrLIuIeSOWtW57eE/O/4=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
+github.com/catppuccin/go v0.3.0 h1:d+0/YicIq+hSTo5oPuRi5kOpqkVA5tAsU6dNhvRu+aY=
+github.com/catppuccin/go v0.3.0/go.mod h1:8IHJuMGaUUjQM82qBrGNBv7LFq6JI3NnQCF6MOlZjpc=
 github.com/charmbracelet/bubbletea v1.3.10 h1:otUDHWMMzQSB0Pkc87rm691KZ3SWa4KUlvF9nRvCICw=
 github.com/charmbracelet/bubbletea v1.3.10/go.mod h1:ORQfo0fk8U+po9VaNvnV95UPWA1BitP1E0N6xJPlHr4=
 github.com/charmbracelet/colorprofile v0.4.1 h1:a1lO03qTrSIRaK8c3JRxJDZOvhvIeSco3ej+ngLk1kk=

--- a/gomod2nix.toml
+++ b/gomod2nix.toml
@@ -1,102 +1,81 @@
 schema = 3
 
 [mod]
-  [mod.'github.com/alecthomas/chroma/v2']
-    version = 'v2.23.1'
-    hash = 'sha256-pDznsfPRcIw9BWmD+pwn7B5iJ7JHGnTRmia9skytQ3A='
-
-  [mod.'github.com/aymanbagabas/go-osc52/v2']
-    version = 'v2.0.1'
-    hash = 'sha256-6Bp0jBZ6npvsYcKZGHHIUSVSTAMEyieweAX2YAKDjjg='
-
-  [mod.'github.com/charmbracelet/bubbletea']
-    version = 'v1.3.10'
-    hash = 'sha256-7wr85TLszu1CHNEMv+o4w+r24Z0xdzCgecPv+ZtRX/A='
-
-  [mod.'github.com/charmbracelet/colorprofile']
-    version = 'v0.4.1'
-    hash = 'sha256-d/NjM/ybG+bGRRRMMcjbPCFGFS5noZRMaL05Ix5r/II='
-
-  [mod.'github.com/charmbracelet/lipgloss']
-    version = 'v1.1.0'
-    hash = 'sha256-RHsRT2EZ1nDOElxAK+6/DC9XAaGVjDTgPvRh3pyCfY4='
-
-  [mod.'github.com/charmbracelet/x/ansi']
-    version = 'v0.11.6'
-    hash = 'sha256-UToZIkqXl9MEppcRgbeBqaaMeAzRkGa0w3lVUs6sxWI='
-
-  [mod.'github.com/charmbracelet/x/cellbuf']
-    version = 'v0.0.15'
-    hash = 'sha256-0S60XaWhKZG+TB3Kqe1oMn2Okwdq53nym8XayVSHHiM='
-
-  [mod.'github.com/charmbracelet/x/term']
-    version = 'v0.2.2'
-    hash = 'sha256-KF7IU1Luxl/sZP6XjomWB2e3lxSUS4/5AahhapGir/4='
-
-  [mod.'github.com/clipperhouse/displaywidth']
-    version = 'v0.9.0'
-    hash = 'sha256-9CNyTZPSncKQ7Y0my9DR4WYXDjtDHYNL512D691WDAM='
-
-  [mod.'github.com/clipperhouse/stringish']
-    version = 'v0.1.1'
-    hash = 'sha256-Mp8M1CRbwr6dcJ4BD9tXD5I78ZgCFEm0GDxJv0GYReg='
-
-  [mod.'github.com/clipperhouse/uax29/v2']
-    version = 'v2.5.0'
-    hash = 'sha256-Men4JLhiuEtAx8ZSzId5ciRWhud68o3k/B48ppwyxkM='
-
-  [mod.'github.com/dlclark/regexp2']
-    version = 'v1.11.5'
-    hash = 'sha256-jN5+2ED+YbIoPIuyJ4Ou5pqJb2w1uNKzp5yTjKY6rEQ='
-
-  [mod.'github.com/erikgeiser/coninput']
-    version = 'v0.0.0-20211004153227-1c3628e74d0f'
-    hash = 'sha256-OWSqN1+IoL73rWXWdbbcahZu8n2al90Y3eT5Z0vgHvU='
-
-  [mod.'github.com/lucasb-eyer/go-colorful']
-    version = 'v1.3.0'
-    hash = 'sha256-6BKrJsfmxie+YFAWzTYVPQfrwjQEXRo+J8LY+50C1BU='
-
-  [mod.'github.com/mattn/go-isatty']
-    version = 'v0.0.20'
-    hash = 'sha256-qhw9hWtU5wnyFyuMbKx+7RB8ckQaFQ8D+8GKPkN3HHQ='
-
-  [mod.'github.com/mattn/go-localereader']
-    version = 'v0.0.1'
-    hash = 'sha256-JlWckeGaWG+bXK8l8WEdZqmSiTwCA8b1qbmBKa/Fj3E='
-
-  [mod.'github.com/mattn/go-runewidth']
-    version = 'v0.0.19'
-    hash = 'sha256-GpnbKplhX410Q/eIdknvWbYZgdav1keN+7wNUeOSMHE='
-
-  [mod.'github.com/muesli/ansi']
-    version = 'v0.0.0-20230316100256-276c6243b2f6'
-    hash = 'sha256-qRKn0Bh2yvP0QxeEMeZe11Vz0BPFIkVcleKsPeybKMs='
-
-  [mod.'github.com/muesli/cancelreader']
-    version = 'v0.2.2'
-    hash = 'sha256-uEPpzwRJBJsQWBw6M71FDfgJuR7n55d/7IV8MO+rpwQ='
-
-  [mod.'github.com/muesli/termenv']
-    version = 'v0.16.0'
-    hash = 'sha256-hGo275DJlyLtcifSLpWnk8jardOksdeX9lH4lBeE3gI='
-
-  [mod.'github.com/rivo/uniseg']
-    version = 'v0.4.7'
-    hash = 'sha256-rDcdNYH6ZD8KouyyiZCUEy8JrjOQoAkxHBhugrfHjFo='
-
-  [mod.'github.com/xo/terminfo']
-    version = 'v0.0.0-20220910002029-abceb7e1c41e'
-    hash = 'sha256-GyCDxxMQhXA3Pi/TsWXpA8cX5akEoZV7CFx4RO3rARU='
-
-  [mod.'golang.org/x/sys']
-    version = 'v0.38.0'
-    hash = 'sha256-1+i5EaG3JwH3KMtefzJLG5R6jbOeJM4GK3/LHBVnSy0='
-
-  [mod.'golang.org/x/text']
-    version = 'v0.3.8'
-    hash = 'sha256-KKHU0OMfT4oxTIzIVqan8MY8wNvgBW00s24hF+kWbMA='
-
-  [mod.'gopkg.in/yaml.v3']
-    version = 'v3.0.1'
-    hash = 'sha256-FqL9TKYJ0XkNwJFnq9j0VvJ5ZUU1RvH/52h/f5bkYAU='
+  [mod."github.com/alecthomas/chroma/v2"]
+    version = "v2.23.1"
+    hash = "sha256-pDznsfPRcIw9BWmD+pwn7B5iJ7JHGnTRmia9skytQ3A="
+  [mod."github.com/aymanbagabas/go-osc52/v2"]
+    version = "v2.0.1"
+    hash = "sha256-6Bp0jBZ6npvsYcKZGHHIUSVSTAMEyieweAX2YAKDjjg="
+  [mod."github.com/catppuccin/go"]
+    version = "v0.3.0"
+    hash = "sha256-otcMhI62ezoKGqzG7Owi/NROep7O0voJxp6bwXYg9+Q="
+  [mod."github.com/charmbracelet/bubbletea"]
+    version = "v1.3.10"
+    hash = "sha256-7wr85TLszu1CHNEMv+o4w+r24Z0xdzCgecPv+ZtRX/A="
+  [mod."github.com/charmbracelet/colorprofile"]
+    version = "v0.4.1"
+    hash = "sha256-d/NjM/ybG+bGRRRMMcjbPCFGFS5noZRMaL05Ix5r/II="
+  [mod."github.com/charmbracelet/lipgloss"]
+    version = "v1.1.0"
+    hash = "sha256-RHsRT2EZ1nDOElxAK+6/DC9XAaGVjDTgPvRh3pyCfY4="
+  [mod."github.com/charmbracelet/x/ansi"]
+    version = "v0.11.6"
+    hash = "sha256-UToZIkqXl9MEppcRgbeBqaaMeAzRkGa0w3lVUs6sxWI="
+  [mod."github.com/charmbracelet/x/cellbuf"]
+    version = "v0.0.15"
+    hash = "sha256-0S60XaWhKZG+TB3Kqe1oMn2Okwdq53nym8XayVSHHiM="
+  [mod."github.com/charmbracelet/x/term"]
+    version = "v0.2.2"
+    hash = "sha256-KF7IU1Luxl/sZP6XjomWB2e3lxSUS4/5AahhapGir/4="
+  [mod."github.com/clipperhouse/displaywidth"]
+    version = "v0.9.0"
+    hash = "sha256-9CNyTZPSncKQ7Y0my9DR4WYXDjtDHYNL512D691WDAM="
+  [mod."github.com/clipperhouse/stringish"]
+    version = "v0.1.1"
+    hash = "sha256-Mp8M1CRbwr6dcJ4BD9tXD5I78ZgCFEm0GDxJv0GYReg="
+  [mod."github.com/clipperhouse/uax29/v2"]
+    version = "v2.5.0"
+    hash = "sha256-Men4JLhiuEtAx8ZSzId5ciRWhud68o3k/B48ppwyxkM="
+  [mod."github.com/dlclark/regexp2"]
+    version = "v1.11.5"
+    hash = "sha256-jN5+2ED+YbIoPIuyJ4Ou5pqJb2w1uNKzp5yTjKY6rEQ="
+  [mod."github.com/erikgeiser/coninput"]
+    version = "v0.0.0-20211004153227-1c3628e74d0f"
+    hash = "sha256-OWSqN1+IoL73rWXWdbbcahZu8n2al90Y3eT5Z0vgHvU="
+  [mod."github.com/lucasb-eyer/go-colorful"]
+    version = "v1.3.0"
+    hash = "sha256-6BKrJsfmxie+YFAWzTYVPQfrwjQEXRo+J8LY+50C1BU="
+  [mod."github.com/mattn/go-isatty"]
+    version = "v0.0.20"
+    hash = "sha256-qhw9hWtU5wnyFyuMbKx+7RB8ckQaFQ8D+8GKPkN3HHQ="
+  [mod."github.com/mattn/go-localereader"]
+    version = "v0.0.1"
+    hash = "sha256-JlWckeGaWG+bXK8l8WEdZqmSiTwCA8b1qbmBKa/Fj3E="
+  [mod."github.com/mattn/go-runewidth"]
+    version = "v0.0.19"
+    hash = "sha256-GpnbKplhX410Q/eIdknvWbYZgdav1keN+7wNUeOSMHE="
+  [mod."github.com/muesli/ansi"]
+    version = "v0.0.0-20230316100256-276c6243b2f6"
+    hash = "sha256-qRKn0Bh2yvP0QxeEMeZe11Vz0BPFIkVcleKsPeybKMs="
+  [mod."github.com/muesli/cancelreader"]
+    version = "v0.2.2"
+    hash = "sha256-uEPpzwRJBJsQWBw6M71FDfgJuR7n55d/7IV8MO+rpwQ="
+  [mod."github.com/muesli/termenv"]
+    version = "v0.16.0"
+    hash = "sha256-hGo275DJlyLtcifSLpWnk8jardOksdeX9lH4lBeE3gI="
+  [mod."github.com/rivo/uniseg"]
+    version = "v0.4.7"
+    hash = "sha256-rDcdNYH6ZD8KouyyiZCUEy8JrjOQoAkxHBhugrfHjFo="
+  [mod."github.com/xo/terminfo"]
+    version = "v0.0.0-20220910002029-abceb7e1c41e"
+    hash = "sha256-GyCDxxMQhXA3Pi/TsWXpA8cX5akEoZV7CFx4RO3rARU="
+  [mod."golang.org/x/sys"]
+    version = "v0.38.0"
+    hash = "sha256-1+i5EaG3JwH3KMtefzJLG5R6jbOeJM4GK3/LHBVnSy0="
+  [mod."golang.org/x/text"]
+    version = "v0.3.8"
+    hash = "sha256-KKHU0OMfT4oxTIzIVqan8MY8wNvgBW00s24hF+kWbMA="
+  [mod."gopkg.in/yaml.v3"]
+    version = "v3.0.1"
+    hash = "sha256-FqL9TKYJ0XkNwJFnq9j0VvJ5ZUU1RvH/52h/f5bkYAU="

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -177,7 +177,7 @@ func (p *ProjectConfig) UnmarshalYAML(node *yaml.Node) error {
 }
 
 type GUIConfig struct {
-	Theme                string            `yaml:"theme"`    // TODO not yet wired up
+	Theme                string            `yaml:"theme"`
 	Language             string            `yaml:"language"` // TODO not yet wired up
 	SidePanelWidth       int               `yaml:"sidePanelWidth"`
 	CollapsedPanelHeight int               `yaml:"collapsedPanelHeight"`

--- a/pkg/tui/app.go
+++ b/pkg/tui/app.go
@@ -15,6 +15,7 @@ import (
 	"github.com/textfuel/lazyjira/v2/pkg/git"
 	"github.com/textfuel/lazyjira/v2/pkg/jira"
 	"github.com/textfuel/lazyjira/v2/pkg/tui/components"
+	"github.com/textfuel/lazyjira/v2/pkg/tui/theme"
 	"github.com/textfuel/lazyjira/v2/pkg/tui/views"
 )
 
@@ -967,9 +968,9 @@ func (a *App) renderHelpOverlay(base string) string {
 
 	popupW := min(maxKey+40, a.width-4)
 
-	keyNormal := lipgloss.NewStyle().Foreground(lipgloss.Color("2")).Bold(true)
-	keySel := lipgloss.NewStyle().Foreground(lipgloss.Color("2")).Bold(true).Background(lipgloss.Color("4"))
-	descSel := lipgloss.NewStyle().Background(lipgloss.Color("4"))
+	keyNormal := lipgloss.NewStyle().Foreground(theme.ColorGreen).Bold(true)
+	keySel := lipgloss.NewStyle().Foreground(theme.ColorGreen).Bold(true).Background(theme.ColorHighlight)
+	descSel := lipgloss.NewStyle().Background(theme.ColorHighlight)
 
 	lines := make([]string, 0, len(bindings)+2)
 	lines = append(lines, "")

--- a/pkg/tui/components/createform.go
+++ b/pkg/tui/components/createform.go
@@ -787,7 +787,7 @@ func (f *CreateForm) renderForm(bg string, w, h int) string {
 	combined := lipgloss.JoinVertical(lipgloss.Left, summaryPanel, descPanel, fieldsPanel)
 
 	if f.errorMsg != "" {
-		errStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("1"))
+		errStyle := lipgloss.NewStyle().Foreground(theme.ColorRed)
 		errLine := errStyle.Render(" " + f.errorMsg)
 		if lw := lipgloss.Width(errLine); lw < formW {
 			errLine += strings.Repeat(" ", formW-lw)
@@ -825,7 +825,7 @@ func (f *CreateForm) renderSummary(formW, panelH int) string {
 }
 
 func (f *CreateForm) renderSummaryWithCursor(innerW, innerH int) string {
-	cursorStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("6"))
+	cursorStyle := lipgloss.NewStyle().Foreground(theme.ColorCyan)
 	allRunes := append([]rune{' '}, f.summaryText...)
 	cursorPos := f.summaryCursor + 1 // +1 for leading space
 
@@ -1005,9 +1005,9 @@ func (f *CreateForm) renderFields(formW, panelH int) string {
 		f.fieldOffset = maxOffset
 	}
 
-	selStyle := lipgloss.NewStyle().Background(lipgloss.Color("4")).Foreground(lipgloss.Color("15"))
-	errStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("1"))
-	reqMark := lipgloss.NewStyle().Foreground(lipgloss.Color("1")).Bold(true).Render("*")
+	selStyle := lipgloss.NewStyle().Background(theme.ColorHighlight).Foreground(lipgloss.Color("15"))
+	errStyle := lipgloss.NewStyle().Foreground(theme.ColorRed)
+	reqMark := lipgloss.NewStyle().Foreground(theme.ColorRed).Bold(true).Render("*")
 
 	// label column = longest field name + 1 space gap (+ 1 for req mark / leading space)
 	labelW := 0

--- a/pkg/tui/components/createform.go
+++ b/pkg/tui/components/createform.go
@@ -1095,11 +1095,13 @@ func (f *CreateForm) renderFields(formW, panelH int) string {
 	return RenderPanelFull(title, footer, content, formW, innerH, focused, scroll)
 }
 
-var noneStyle = lipgloss.NewStyle().Foreground(theme.ColorGray)
+func noneStyle() lipgloss.Style {
+	return lipgloss.NewStyle().Foreground(theme.ColorGray)
+}
 
 func styleFieldValue(fld CreateFormField, val string) string {
 	if val == "None" {
-		return noneStyle.Render(val)
+		return noneStyle().Render(val)
 	}
 	switch fld.FieldID {
 	case "priority":

--- a/pkg/tui/components/diffview.go
+++ b/pkg/tui/components/diffview.go
@@ -6,6 +6,8 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+
+	"github.com/textfuel/lazyjira/pkg/tui/theme"
 )
 
 // DiffConfirmedMsg is sent when user confirms the diff (Enter)
@@ -159,9 +161,9 @@ func computeUnifiedDiff(oldText, newText string) []string {
 	oldLines := strings.Split(oldText, "\n")
 	newLines := strings.Split(newText, "\n")
 
-	addStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("2"))
-	delStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("1"))
-	ctxStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("8"))
+	addStyle := lipgloss.NewStyle().Foreground(theme.ColorGreen)
+	delStyle := lipgloss.NewStyle().Foreground(theme.ColorRed)
+	ctxStyle := lipgloss.NewStyle().Foreground(theme.ColorGray)
 
 	// Simple LCS-based diff.
 	lcs := computeLCS(oldLines, newLines)

--- a/pkg/tui/components/diffview.go
+++ b/pkg/tui/components/diffview.go
@@ -7,7 +7,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 
-	"github.com/textfuel/lazyjira/pkg/tui/theme"
+	"github.com/textfuel/lazyjira/v2/pkg/tui/theme"
 )
 
 // DiffConfirmedMsg is sent when user confirms the diff (Enter)

--- a/pkg/tui/components/help.go
+++ b/pkg/tui/components/help.go
@@ -6,7 +6,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 
-	"github.com/textfuel/lazyjira/pkg/tui/theme"
+	"github.com/textfuel/lazyjira/v2/pkg/tui/theme"
 )
 
 // HelpItem represents a single keybinding hint.

--- a/pkg/tui/components/help.go
+++ b/pkg/tui/components/help.go
@@ -5,6 +5,8 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+
+	"github.com/textfuel/lazyjira/pkg/tui/theme"
 )
 
 // HelpItem represents a single keybinding hint.
@@ -52,7 +54,7 @@ func (h HelpBar) Update(msg tea.Msg) (HelpBar, tea.Cmd) {
 }
 
 func (h HelpBar) View() string {
-	blueStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("4"))
+	blueStyle := lipgloss.NewStyle().Foreground(theme.ColorBlue)
 	sep := blueStyle.Render(" | ")
 
 	availW := h.width
@@ -60,7 +62,7 @@ func (h HelpBar) View() string {
 	// Status message (green) on the left.
 	prefix := ""
 	if h.statusMsg != "" {
-		greenStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("2")).Bold(true)
+		greenStyle := lipgloss.NewStyle().Foreground(theme.ColorGreen).Bold(true)
 		prefix = " " + greenStyle.Render(h.statusMsg) + " "
 		availW -= lipgloss.Width(prefix)
 	}

--- a/pkg/tui/components/inputmodal.go
+++ b/pkg/tui/components/inputmodal.go
@@ -6,6 +6,8 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+
+	"github.com/textfuel/lazyjira/pkg/tui/theme"
 )
 
 // InputConfirmedMsg is sent when the user presses Enter in the input modal
@@ -173,7 +175,7 @@ func (m *InputModal) View() string {
 	contentW := min(max(m.width*6/10, 30), m.width-4)
 	innerW := contentW - 2
 
-	cursorStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("6"))
+	cursorStyle := lipgloss.NewStyle().Foreground(theme.ColorCyan)
 	allRunes := append([]rune{' '}, m.text...)
 	cursorPos := m.cursor + 1
 
@@ -278,7 +280,7 @@ func (m *InputModal) HintView() string {
 	contentW := min(max(m.width*6/10, 30), m.width-4)
 	innerW := contentW - 2
 
-	selStyle := lipgloss.NewStyle().Background(lipgloss.Color("4")).Foreground(lipgloss.Color("15"))
+	selStyle := lipgloss.NewStyle().Background(theme.ColorHighlight).Foreground(lipgloss.Color("15"))
 	normalStyle := lipgloss.NewStyle()
 
 	maxHints := min(5, len(m.hints))

--- a/pkg/tui/components/inputmodal.go
+++ b/pkg/tui/components/inputmodal.go
@@ -7,7 +7,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 
-	"github.com/textfuel/lazyjira/pkg/tui/theme"
+	"github.com/textfuel/lazyjira/v2/pkg/tui/theme"
 )
 
 // InputConfirmedMsg is sent when the user presses Enter in the input modal

--- a/pkg/tui/components/jqlhighlight.go
+++ b/pkg/tui/components/jqlhighlight.go
@@ -5,16 +5,17 @@ import (
 	"unicode"
 
 	"github.com/charmbracelet/lipgloss"
+
+	"github.com/textfuel/lazyjira/pkg/tui/theme"
 )
 
 // JQL syntax highlighting colors (matching Jira Cloud JQL editor).
-var (
-	jqlFieldStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("4")) // blue
-	jqlKeywordStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("5")) // magenta/purple
-	jqlOperatorStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("2")) // green
-	jqlStringStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("3")) // yellow for quoted strings
-	jqlDefaultStyle  = lipgloss.NewStyle()
-)
+// These are functions so they pick up the active theme's colors.
+func jqlFieldStyle() lipgloss.Style    { return lipgloss.NewStyle().Foreground(theme.ColorBlue) }
+func jqlKeywordStyle() lipgloss.Style  { return lipgloss.NewStyle().Foreground(lipgloss.Color("5")) }
+func jqlOperatorStyle() lipgloss.Style { return lipgloss.NewStyle().Foreground(theme.ColorGreen) }
+func jqlStringStyle() lipgloss.Style   { return lipgloss.NewStyle().Foreground(theme.ColorYellow) }
+func jqlDefaultStyle() lipgloss.Style  { return lipgloss.NewStyle() }
 
 // JQL operators (word-based).
 var jqlWordOperators = map[string]bool{
@@ -69,7 +70,7 @@ func HighlightJQL(runes []rune) []StyledSegment {
 			}
 			segments = append(segments, StyledSegment{
 				Text:  string(runes[i:j]),
-				Style: jqlStringStyle,
+				Style: jqlStringStyle(),
 			})
 			i = j
 			continue
@@ -83,7 +84,7 @@ func HighlightJQL(runes []rune) []StyledSegment {
 			}
 			segments = append(segments, StyledSegment{
 				Text:  string(runes[i:j]),
-				Style: jqlDefaultStyle,
+				Style: jqlDefaultStyle(),
 			})
 			i = j
 			continue
@@ -93,7 +94,7 @@ func HighlightJQL(runes []rune) []StyledSegment {
 		if r == '(' || r == ')' || r == ',' {
 			segments = append(segments, StyledSegment{
 				Text:  string(r),
-				Style: jqlDefaultStyle,
+				Style: jqlDefaultStyle(),
 			})
 			i++
 			continue
@@ -103,7 +104,7 @@ func HighlightJQL(runes []rune) []StyledSegment {
 		if r == '=' || r == '>' || r == '<' || r == '~' {
 			segments = append(segments, StyledSegment{
 				Text:  string(r),
-				Style: jqlOperatorStyle,
+				Style: jqlOperatorStyle(),
 			})
 			i++
 			continue
@@ -111,7 +112,7 @@ func HighlightJQL(runes []rune) []StyledSegment {
 		if r == '!' && i+1 < n && (runes[i+1] == '=' || runes[i+1] == '~') {
 			segments = append(segments, StyledSegment{
 				Text:  string(runes[i : i+2]),
-				Style: jqlOperatorStyle,
+				Style: jqlOperatorStyle(),
 			})
 			i += 2
 			continue
@@ -128,7 +129,7 @@ func HighlightJQL(runes []rune) []StyledSegment {
 			// Single unrecognized char.
 			segments = append(segments, StyledSegment{
 				Text:  string(r),
-				Style: jqlDefaultStyle,
+				Style: jqlDefaultStyle(),
 			})
 			i++
 			continue
@@ -151,10 +152,10 @@ func HighlightJQL(runes []rune) []StyledSegment {
 // classifyJQLWord determines the style for a word token based on context.
 func classifyJQLWord(wordLower, fullText string, pos int) lipgloss.Style {
 	if jqlKeywords[wordLower] {
-		return jqlKeywordStyle
+		return jqlKeywordStyle()
 	}
 	if jqlWordOperators[wordLower] {
-		return jqlOperatorStyle
+		return jqlOperatorStyle()
 	}
 
 	// Check if this looks like a field name:
@@ -162,7 +163,7 @@ func classifyJQLWord(wordLower, fullText string, pos int) lipgloss.Style {
 	// 2. Starts with "customfield_"
 	// 3. Appears before an operator (heuristic: followed by space+operator or space+keyword)
 	if jqlKnownFields[wordLower] || strings.HasPrefix(wordLower, "customfield_") {
-		return jqlFieldStyle
+		return jqlFieldStyle()
 	}
 
 	// Heuristic: if preceded by an operator or at start, likely a value (default).
@@ -171,19 +172,19 @@ func classifyJQLWord(wordLower, fullText string, pos int) lipgloss.Style {
 	afterLower := strings.ToLower(after)
 	for op := range jqlSymbolOperators {
 		if strings.HasPrefix(after, op) {
-			return jqlFieldStyle
+			return jqlFieldStyle()
 		}
 	}
 	for op := range jqlWordOperators {
 		if strings.HasPrefix(afterLower, op+" ") || strings.HasPrefix(afterLower, op+"(") || afterLower == op {
-			return jqlFieldStyle
+			return jqlFieldStyle()
 		}
 	}
 
 	// Functions like currentUser(), now().
 	if strings.HasSuffix(wordLower, "()") {
-		return jqlDefaultStyle
+		return jqlDefaultStyle()
 	}
 
-	return jqlDefaultStyle
+	return jqlDefaultStyle()
 }

--- a/pkg/tui/components/jqlhighlight.go
+++ b/pkg/tui/components/jqlhighlight.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/charmbracelet/lipgloss"
 
-	"github.com/textfuel/lazyjira/pkg/tui/theme"
+	"github.com/textfuel/lazyjira/v2/pkg/tui/theme"
 )
 
 // JQL syntax highlighting colors (matching Jira Cloud JQL editor).

--- a/pkg/tui/components/jqlhighlight.go
+++ b/pkg/tui/components/jqlhighlight.go
@@ -12,7 +12,7 @@ import (
 // JQL syntax highlighting colors (matching Jira Cloud JQL editor).
 // These are functions so they pick up the active theme's colors.
 func jqlFieldStyle() lipgloss.Style    { return lipgloss.NewStyle().Foreground(theme.ColorBlue) }
-func jqlKeywordStyle() lipgloss.Style  { return lipgloss.NewStyle().Foreground(lipgloss.Color("5")) }
+func jqlKeywordStyle() lipgloss.Style  { return lipgloss.NewStyle().Foreground(theme.ColorMagenta) }
 func jqlOperatorStyle() lipgloss.Style { return lipgloss.NewStyle().Foreground(theme.ColorGreen) }
 func jqlStringStyle() lipgloss.Style   { return lipgloss.NewStyle().Foreground(theme.ColorYellow) }
 func jqlDefaultStyle() lipgloss.Style  { return lipgloss.NewStyle() }

--- a/pkg/tui/components/jqlmodal.go
+++ b/pkg/tui/components/jqlmodal.go
@@ -379,13 +379,13 @@ func (m *JQLModal) View() string {
 
 	inputContent := m.input.View()
 	if m.loading {
-		inputContent += lipgloss.NewStyle().Foreground(lipgloss.Color("3")).Render("  Searching...")
+		inputContent += lipgloss.NewStyle().Foreground(theme.ColorYellow).Render("  Searching...")
 	}
 	inputPanel := RenderPanelFull("JQL Query", "", inputContent, m.width-2, 1, m.focusInput, nil)
 
 	errorLine := ""
 	if m.errorMsg != "" {
-		errStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("1")).Bold(true)
+		errStyle := lipgloss.NewStyle().Foreground(theme.ColorRed).Bold(true)
 		errorLine = " " + errStyle.Render(m.errorMsg)
 	}
 
@@ -431,7 +431,7 @@ func (m *JQLModal) renderListContent(listH, contentW int) string {
 	switch {
 	case m.acLoading:
 		lines := make([]string, listH)
-		lines[0] = lipgloss.NewStyle().Foreground(lipgloss.Color("3")).Render("  Loading...")
+		lines[0] = lipgloss.NewStyle().Foreground(theme.ColorYellow).Render("  Loading...")
 		return strings.Join(lines, "\n")
 
 	case len(m.items) == 0:
@@ -440,7 +440,7 @@ func (m *JQLModal) renderListContent(listH, contentW int) string {
 			emptyMsg = "No suggestions"
 		}
 		lines := make([]string, listH)
-		lines[0] = lipgloss.NewStyle().Foreground(lipgloss.Color("8")).Render("  " + emptyMsg)
+		lines[0] = lipgloss.NewStyle().Foreground(theme.ColorGray).Render("  " + emptyMsg)
 		return strings.Join(lines, "\n")
 
 	default:
@@ -454,7 +454,7 @@ func (m *JQLModal) renderListContent(listH, contentW int) string {
 			}
 			if i == m.cursor && !m.focusInput {
 				row := lipgloss.NewStyle().
-					Background(lipgloss.Color("4")).
+					Background(theme.ColorHighlight).
 					Width(contentW).
 					Render(" " + item)
 				rows = append(rows, row)

--- a/pkg/tui/components/modal.go
+++ b/pkg/tui/components/modal.go
@@ -464,7 +464,7 @@ func (m *Modal) viewReadOnly() string {
 }
 
 func (m *Modal) viewSelectable() string {
-	titleStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("2")).Bold(true)
+	titleStyle := lipgloss.NewStyle().Foreground(theme.ColorGreen).Bold(true)
 
 	contentW := m.selectionContentW()
 	if m.checklist {
@@ -508,7 +508,7 @@ func (m *Modal) viewSelectable() string {
 	}
 	lines = visible
 
-	borderStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("2"))
+	borderStyle := lipgloss.NewStyle().Foreground(theme.ColorGreen)
 	bv := borderStyle.Render("│")
 
 	topLine := borderStyle.Render("╭" + strings.Repeat("─", contentW) + "╮")
@@ -550,9 +550,9 @@ func (m *Modal) renderItems(titleStyle lipgloss.Style, contentW int) []string {
 	lines = append(lines, " "+titleStyle.Render(m.title))
 	lines = append(lines, "")
 
-	checkGreen := lipgloss.NewStyle().Foreground(lipgloss.Color("2"))
+	checkGreen := lipgloss.NewStyle().Foreground(theme.ColorGreen)
 	activeMarker := checkGreen.Render("*")
-	sepStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("8"))
+	sepStyle := lipgloss.NewStyle().Foreground(theme.ColorGray)
 	for i, item := range m.items {
 		if item.Separator {
 			label := TruncateEnd(item.Label, contentW-4)
@@ -569,7 +569,7 @@ func (m *Modal) renderItems(titleStyle lipgloss.Style, contentW int) []string {
 			style := lipgloss.NewStyle().Width(contentW)
 			switch {
 			case isCursor:
-				style = style.Bold(true).Background(lipgloss.Color("4"))
+				style = style.Bold(true).Background(theme.ColorHighlight)
 				if sel {
 					lines = append(lines, style.Render("✓ "+text))
 				} else {
@@ -589,12 +589,12 @@ func (m *Modal) renderItems(titleStyle lipgloss.Style, contentW int) []string {
 			style := lipgloss.NewStyle().Width(contentW)
 			switch {
 			case isCursor:
-				style = style.Bold(true).Background(lipgloss.Color("4"))
+				style = style.Bold(true).Background(theme.ColorHighlight)
 				lines = append(lines, style.Render(marker+text))
 			case item.Active:
 				lines = append(lines, style.Render(activeMarker+text))
 			case item.Internal:
-				lines = append(lines, style.Render(lipgloss.NewStyle().Foreground(lipgloss.Color("2")).Render(" "+text)))
+				lines = append(lines, style.Render(lipgloss.NewStyle().Foreground(theme.ColorGreen).Render(" "+text)))
 			default:
 				lines = append(lines, style.Render(" "+text))
 			}
@@ -657,7 +657,7 @@ func (m *Modal) HintView() string {
 	hintContent := lipgloss.NewStyle().Width(contentW).Render(" " + hint)
 	return lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
-		BorderForeground(lipgloss.Color("7")).
+		BorderForeground(theme.ColorWhite).
 		Width(contentW).
 		Height(hintH).
 		Render(hintContent)

--- a/pkg/tui/components/searchbar.go
+++ b/pkg/tui/components/searchbar.go
@@ -3,6 +3,8 @@ package components
 import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+
+	"github.com/textfuel/lazyjira/v2/pkg/tui/theme"
 )
 
 // SearchBar is a bottom search input that filters the current panel
@@ -67,7 +69,7 @@ func (s *SearchBar) View() string {
 // RenderFilterBarInput renders filter bar using TextInput (with cursor positioning)
 func RenderFilterBarInput(input *TextInput) string {
 	prefixStyle := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("6")).
+		Foreground(theme.ColorCyan).
 		Bold(true)
 
 	return prefixStyle.Render(" /") + input.View()

--- a/pkg/tui/components/textinput.go
+++ b/pkg/tui/components/textinput.go
@@ -6,6 +6,8 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+
+	"github.com/textfuel/lazyjira/pkg/tui/theme"
 )
 
 // TextInput is a readline-style text input component
@@ -166,7 +168,7 @@ func (t *TextInput) Update(msg tea.Msg) (TextInput, bool) {
 // View renders the text with a visible cursor block at the cursor position
 func (t *TextInput) View() string {
 	cursorStyle := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("6"))
+		Foreground(theme.ColorCyan)
 
 	cursorBlock := cursorStyle.Render("█")
 

--- a/pkg/tui/components/textinput.go
+++ b/pkg/tui/components/textinput.go
@@ -7,7 +7,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 
-	"github.com/textfuel/lazyjira/pkg/tui/theme"
+	"github.com/textfuel/lazyjira/v2/pkg/tui/theme"
 )
 
 // TextInput is a readline-style text input component

--- a/pkg/tui/theme/authorcolor.go
+++ b/pkg/tui/theme/authorcolor.go
@@ -7,21 +7,9 @@ import (
 	"github.com/charmbracelet/lipgloss"
 )
 
-// Distinct colors from ANSI 256 palette readable on dark backgrounds
-var authorPalette = []lipgloss.Color{
-	lipgloss.Color("208"), // orange
-	lipgloss.Color("176"), // pink/magenta
-	lipgloss.Color("114"), // light green
-	lipgloss.Color("216"), // salmon
-	lipgloss.Color("81"),  // sky blue
-	lipgloss.Color("222"), // gold
-	lipgloss.Color("183"), // lavender
-	lipgloss.Color("150"), // sage
-	lipgloss.Color("209"), // coral
-	lipgloss.Color("117"), // light cyan
-	lipgloss.Color("180"), // tan
-	lipgloss.Color("147"), // periwinkle
-}
+// authorPalette is sourced from the active theme's AuthorPalette.
+// SetTheme refreshes it on theme change.
+var authorPalette = Default.AuthorPalette
 
 var authorCache = make(map[string]lipgloss.Style)
 

--- a/pkg/tui/theme/catppuccin.go
+++ b/pkg/tui/theme/catppuccin.go
@@ -1,0 +1,130 @@
+package theme
+
+import "github.com/charmbracelet/lipgloss"
+
+// Catppuccin color palettes.
+// Spec: https://github.com/catppuccin/catppuccin
+
+func catppuccinLatte() *Theme {
+	return buildTheme(
+		ColorPalette{
+			Green:     lipgloss.Color("#40a02b"),
+			Blue:      lipgloss.Color("#1e66f5"),
+			Red:       lipgloss.Color("#d20f39"),
+			Yellow:    lipgloss.Color("#df8e1d"),
+			Cyan:      lipgloss.Color("#179299"),
+			White:     lipgloss.Color("#4c4f69"), // Text
+			Gray:      lipgloss.Color("#9ca0b0"), // Overlay0
+			Orange:    lipgloss.Color("#fe640b"), // Peach
+			None:      lipgloss.Color("-1"),
+			Highlight: lipgloss.Color("#acb0be"), // Surface2
+		},
+		[]lipgloss.Color{
+			lipgloss.Color("#dc8a78"), // Rosewater
+			lipgloss.Color("#dd7878"), // Flamingo
+			lipgloss.Color("#ea76cb"), // Pink
+			lipgloss.Color("#8839ef"), // Mauve
+			lipgloss.Color("#d20f39"), // Red
+			lipgloss.Color("#e64553"), // Maroon
+			lipgloss.Color("#fe640b"), // Peach
+			lipgloss.Color("#df8e1d"), // Yellow
+			lipgloss.Color("#40a02b"), // Green
+			lipgloss.Color("#179299"), // Teal
+			lipgloss.Color("#209fb5"), // Sapphire
+			lipgloss.Color("#7287fd"), // Lavender
+		},
+	)
+}
+
+func catppuccinFrappe() *Theme {
+	return buildTheme(
+		ColorPalette{
+			Green:     lipgloss.Color("#a6d189"),
+			Blue:      lipgloss.Color("#8caaee"),
+			Red:       lipgloss.Color("#e78284"),
+			Yellow:    lipgloss.Color("#e5c890"),
+			Cyan:      lipgloss.Color("#81c8be"),
+			White:     lipgloss.Color("#c6d0f5"), // Text
+			Gray:      lipgloss.Color("#737994"), // Overlay0
+			Orange:    lipgloss.Color("#ef9f76"), // Peach
+			None:      lipgloss.Color("-1"),
+			Highlight: lipgloss.Color("#626880"), // Surface2
+		},
+		[]lipgloss.Color{
+			lipgloss.Color("#f2d5cf"), // Rosewater
+			lipgloss.Color("#eebebe"), // Flamingo
+			lipgloss.Color("#f4b8e4"), // Pink
+			lipgloss.Color("#ca9ee6"), // Mauve
+			lipgloss.Color("#e78284"), // Red
+			lipgloss.Color("#ea999c"), // Maroon
+			lipgloss.Color("#ef9f76"), // Peach
+			lipgloss.Color("#e5c890"), // Yellow
+			lipgloss.Color("#a6d189"), // Green
+			lipgloss.Color("#81c8be"), // Teal
+			lipgloss.Color("#85c1dc"), // Sapphire
+			lipgloss.Color("#babbf1"), // Lavender
+		},
+	)
+}
+
+func catppuccinMacchiato() *Theme {
+	return buildTheme(
+		ColorPalette{
+			Green:     lipgloss.Color("#a6da95"),
+			Blue:      lipgloss.Color("#8aadf4"),
+			Red:       lipgloss.Color("#ed8796"),
+			Yellow:    lipgloss.Color("#eed49f"),
+			Cyan:      lipgloss.Color("#8bd5ca"),
+			White:     lipgloss.Color("#cad3f5"), // Text
+			Gray:      lipgloss.Color("#6e738d"), // Overlay0
+			Orange:    lipgloss.Color("#f5a97f"), // Peach
+			None:      lipgloss.Color("-1"),
+			Highlight: lipgloss.Color("#5b6078"), // Surface2
+		},
+		[]lipgloss.Color{
+			lipgloss.Color("#f4dbd6"), // Rosewater
+			lipgloss.Color("#f0c6c6"), // Flamingo
+			lipgloss.Color("#f5bde6"), // Pink
+			lipgloss.Color("#c6a0f6"), // Mauve
+			lipgloss.Color("#ed8796"), // Red
+			lipgloss.Color("#ee99a0"), // Maroon
+			lipgloss.Color("#f5a97f"), // Peach
+			lipgloss.Color("#eed49f"), // Yellow
+			lipgloss.Color("#a6da95"), // Green
+			lipgloss.Color("#8bd5ca"), // Teal
+			lipgloss.Color("#7dc4e4"), // Sapphire
+			lipgloss.Color("#b7bdf8"), // Lavender
+		},
+	)
+}
+
+func catppuccinMocha() *Theme {
+	return buildTheme(
+		ColorPalette{
+			Green:     lipgloss.Color("#a6e3a1"),
+			Blue:      lipgloss.Color("#89b4fa"),
+			Red:       lipgloss.Color("#f38ba8"),
+			Yellow:    lipgloss.Color("#f9e2af"),
+			Cyan:      lipgloss.Color("#94e2d5"),
+			White:     lipgloss.Color("#cdd6f4"), // Text
+			Gray:      lipgloss.Color("#6c7086"), // Overlay0
+			Orange:    lipgloss.Color("#fab387"), // Peach
+			None:      lipgloss.Color("-1"),
+			Highlight: lipgloss.Color("#585b70"), // Surface2
+		},
+		[]lipgloss.Color{
+			lipgloss.Color("#f5e0dc"), // Rosewater
+			lipgloss.Color("#f2cdcd"), // Flamingo
+			lipgloss.Color("#f5c2e7"), // Pink
+			lipgloss.Color("#cba6f7"), // Mauve
+			lipgloss.Color("#f38ba8"), // Red
+			lipgloss.Color("#eba0ac"), // Maroon
+			lipgloss.Color("#fab387"), // Peach
+			lipgloss.Color("#f9e2af"), // Yellow
+			lipgloss.Color("#a6e3a1"), // Green
+			lipgloss.Color("#94e2d5"), // Teal
+			lipgloss.Color("#74c7ec"), // Sapphire
+			lipgloss.Color("#b4befe"), // Lavender
+		},
+	)
+}

--- a/pkg/tui/theme/catppuccin.go
+++ b/pkg/tui/theme/catppuccin.go
@@ -1,130 +1,48 @@
 package theme
 
-import "github.com/charmbracelet/lipgloss"
+import (
+	"github.com/charmbracelet/lipgloss"
 
-// Catppuccin color palettes.
-// Spec: https://github.com/catppuccin/catppuccin
+	catppuccin "github.com/catppuccin/go"
+)
 
-func catppuccinLatte() *Theme {
+// fromCatppuccin builds a Theme from any Catppuccin flavor.
+// Surface2 is used as the selection background — a muted color
+// that's readable across all four flavors (including Latte).
+func fromCatppuccin(f catppuccin.Flavor) *Theme {
+	hex := func(c catppuccin.Color) lipgloss.Color { return lipgloss.Color(c.Hex) }
 	return buildTheme(
 		ColorPalette{
-			Green:     lipgloss.Color("#40a02b"),
-			Blue:      lipgloss.Color("#1e66f5"),
-			Red:       lipgloss.Color("#d20f39"),
-			Yellow:    lipgloss.Color("#df8e1d"),
-			Cyan:      lipgloss.Color("#179299"),
-			White:     lipgloss.Color("#4c4f69"), // Text
-			Gray:      lipgloss.Color("#9ca0b0"), // Overlay0
-			Orange:    lipgloss.Color("#fe640b"), // Peach
+			Green:     hex(f.Green()),
+			Blue:      hex(f.Blue()),
+			Red:       hex(f.Red()),
+			Yellow:    hex(f.Yellow()),
+			Cyan:      hex(f.Teal()),
+			Magenta:   hex(f.Mauve()),
+			White:     hex(f.Text()),
+			Gray:      hex(f.Overlay0()),
+			Orange:    hex(f.Peach()),
 			None:      lipgloss.Color("-1"),
-			Highlight: lipgloss.Color("#acb0be"), // Surface2
+			Highlight: hex(f.Surface2()),
 		},
 		[]lipgloss.Color{
-			lipgloss.Color("#dc8a78"), // Rosewater
-			lipgloss.Color("#dd7878"), // Flamingo
-			lipgloss.Color("#ea76cb"), // Pink
-			lipgloss.Color("#8839ef"), // Mauve
-			lipgloss.Color("#d20f39"), // Red
-			lipgloss.Color("#e64553"), // Maroon
-			lipgloss.Color("#fe640b"), // Peach
-			lipgloss.Color("#df8e1d"), // Yellow
-			lipgloss.Color("#40a02b"), // Green
-			lipgloss.Color("#179299"), // Teal
-			lipgloss.Color("#209fb5"), // Sapphire
-			lipgloss.Color("#7287fd"), // Lavender
+			hex(f.Rosewater()),
+			hex(f.Flamingo()),
+			hex(f.Pink()),
+			hex(f.Mauve()),
+			hex(f.Red()),
+			hex(f.Maroon()),
+			hex(f.Peach()),
+			hex(f.Yellow()),
+			hex(f.Green()),
+			hex(f.Teal()),
+			hex(f.Sapphire()),
+			hex(f.Lavender()),
 		},
 	)
 }
 
-func catppuccinFrappe() *Theme {
-	return buildTheme(
-		ColorPalette{
-			Green:     lipgloss.Color("#a6d189"),
-			Blue:      lipgloss.Color("#8caaee"),
-			Red:       lipgloss.Color("#e78284"),
-			Yellow:    lipgloss.Color("#e5c890"),
-			Cyan:      lipgloss.Color("#81c8be"),
-			White:     lipgloss.Color("#c6d0f5"), // Text
-			Gray:      lipgloss.Color("#737994"), // Overlay0
-			Orange:    lipgloss.Color("#ef9f76"), // Peach
-			None:      lipgloss.Color("-1"),
-			Highlight: lipgloss.Color("#626880"), // Surface2
-		},
-		[]lipgloss.Color{
-			lipgloss.Color("#f2d5cf"), // Rosewater
-			lipgloss.Color("#eebebe"), // Flamingo
-			lipgloss.Color("#f4b8e4"), // Pink
-			lipgloss.Color("#ca9ee6"), // Mauve
-			lipgloss.Color("#e78284"), // Red
-			lipgloss.Color("#ea999c"), // Maroon
-			lipgloss.Color("#ef9f76"), // Peach
-			lipgloss.Color("#e5c890"), // Yellow
-			lipgloss.Color("#a6d189"), // Green
-			lipgloss.Color("#81c8be"), // Teal
-			lipgloss.Color("#85c1dc"), // Sapphire
-			lipgloss.Color("#babbf1"), // Lavender
-		},
-	)
-}
-
-func catppuccinMacchiato() *Theme {
-	return buildTheme(
-		ColorPalette{
-			Green:     lipgloss.Color("#a6da95"),
-			Blue:      lipgloss.Color("#8aadf4"),
-			Red:       lipgloss.Color("#ed8796"),
-			Yellow:    lipgloss.Color("#eed49f"),
-			Cyan:      lipgloss.Color("#8bd5ca"),
-			White:     lipgloss.Color("#cad3f5"), // Text
-			Gray:      lipgloss.Color("#6e738d"), // Overlay0
-			Orange:    lipgloss.Color("#f5a97f"), // Peach
-			None:      lipgloss.Color("-1"),
-			Highlight: lipgloss.Color("#5b6078"), // Surface2
-		},
-		[]lipgloss.Color{
-			lipgloss.Color("#f4dbd6"), // Rosewater
-			lipgloss.Color("#f0c6c6"), // Flamingo
-			lipgloss.Color("#f5bde6"), // Pink
-			lipgloss.Color("#c6a0f6"), // Mauve
-			lipgloss.Color("#ed8796"), // Red
-			lipgloss.Color("#ee99a0"), // Maroon
-			lipgloss.Color("#f5a97f"), // Peach
-			lipgloss.Color("#eed49f"), // Yellow
-			lipgloss.Color("#a6da95"), // Green
-			lipgloss.Color("#8bd5ca"), // Teal
-			lipgloss.Color("#7dc4e4"), // Sapphire
-			lipgloss.Color("#b7bdf8"), // Lavender
-		},
-	)
-}
-
-func catppuccinMocha() *Theme {
-	return buildTheme(
-		ColorPalette{
-			Green:     lipgloss.Color("#a6e3a1"),
-			Blue:      lipgloss.Color("#89b4fa"),
-			Red:       lipgloss.Color("#f38ba8"),
-			Yellow:    lipgloss.Color("#f9e2af"),
-			Cyan:      lipgloss.Color("#94e2d5"),
-			White:     lipgloss.Color("#cdd6f4"), // Text
-			Gray:      lipgloss.Color("#6c7086"), // Overlay0
-			Orange:    lipgloss.Color("#fab387"), // Peach
-			None:      lipgloss.Color("-1"),
-			Highlight: lipgloss.Color("#585b70"), // Surface2
-		},
-		[]lipgloss.Color{
-			lipgloss.Color("#f5e0dc"), // Rosewater
-			lipgloss.Color("#f2cdcd"), // Flamingo
-			lipgloss.Color("#f5c2e7"), // Pink
-			lipgloss.Color("#cba6f7"), // Mauve
-			lipgloss.Color("#f38ba8"), // Red
-			lipgloss.Color("#eba0ac"), // Maroon
-			lipgloss.Color("#fab387"), // Peach
-			lipgloss.Color("#f9e2af"), // Yellow
-			lipgloss.Color("#a6e3a1"), // Green
-			lipgloss.Color("#94e2d5"), // Teal
-			lipgloss.Color("#74c7ec"), // Sapphire
-			lipgloss.Color("#b4befe"), // Lavender
-		},
-	)
-}
+func catppuccinLatte() *Theme     { return fromCatppuccin(catppuccin.Latte) }
+func catppuccinFrappe() *Theme    { return fromCatppuccin(catppuccin.Frappe) }
+func catppuccinMacchiato() *Theme { return fromCatppuccin(catppuccin.Macchiato) }
+func catppuccinMocha() *Theme     { return fromCatppuccin(catppuccin.Mocha) }

--- a/pkg/tui/theme/theme.go
+++ b/pkg/tui/theme/theme.go
@@ -1,22 +1,41 @@
 package theme
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
 )
 
-// Lazygit-style standard ANSI 16 palette colors
-const (
-	ColorGreen  = lipgloss.Color("2")   // ANSI green — active borders, accents
-	ColorBlue   = lipgloss.Color("4")   // ANSI blue — help bar, selected bg
-	ColorRed    = lipgloss.Color("1")   // ANSI red — errors, unstaged
-	ColorYellow = lipgloss.Color("3")   // ANSI yellow — warnings, in-progress
-	ColorCyan   = lipgloss.Color("6")   // ANSI cyan — search mode
-	ColorWhite  = lipgloss.Color("7")   // ANSI white (light gray)
-	ColorGray   = lipgloss.Color("8")   // ANSI bright black (dark gray)
-	ColorOrange = lipgloss.Color("208") // ANSI 256 orange — secondary accent (names, metadata)
-	ColorNone   = lipgloss.Color("-1")  // default terminal color
+// ColorPalette holds the semantic color values for a theme.
+// The default theme uses ANSI 16 codes; Catppuccin themes use hex values.
+type ColorPalette struct {
+	Green     lipgloss.Color
+	Blue      lipgloss.Color
+	Red       lipgloss.Color
+	Yellow    lipgloss.Color
+	Cyan      lipgloss.Color
+	White     lipgloss.Color
+	Gray      lipgloss.Color
+	Orange    lipgloss.Color
+	None      lipgloss.Color
+	Highlight lipgloss.Color // selection/cursor background
+}
+
+// Package-level color variables. These are kept in sync with Default.Colors
+// by SetTheme so that existing call sites (theme.ColorBlue, etc.) continue
+// to work without changes.
+var (
+	ColorGreen     = lipgloss.Color("2")   // ANSI green — active borders, accents
+	ColorBlue      = lipgloss.Color("4")   // ANSI blue — help bar, selected bg
+	ColorRed       = lipgloss.Color("1")   // ANSI red — errors, unstaged
+	ColorYellow    = lipgloss.Color("3")   // ANSI yellow — warnings, in-progress
+	ColorCyan      = lipgloss.Color("6")   // ANSI cyan — search mode
+	ColorWhite     = lipgloss.Color("7")   // ANSI white (light gray)
+	ColorGray      = lipgloss.Color("8")   // ANSI bright black (dark gray)
+	ColorOrange    = lipgloss.Color("208") // ANSI 256 orange — secondary accent (names, metadata)
+	ColorNone      = lipgloss.Color("-1")  // default terminal color
+	ColorHighlight = lipgloss.Color("4")   // selection/cursor background (same as blue by default)
 )
 
 type Theme struct {
@@ -35,6 +54,9 @@ type Theme struct {
 	PriorityHigh   lipgloss.Style
 	PriorityMedium lipgloss.Style
 	PriorityLow    lipgloss.Style
+
+	Colors        ColorPalette
+	AuthorPalette []lipgloss.Color
 }
 
 // Default is the singleton theme instance
@@ -43,56 +65,141 @@ var Default = defaultTheme()
 // DefaultTheme returns the singleton theme. Kept for compatibility
 func DefaultTheme() *Theme { return Default }
 
+// defaultPalette returns the ANSI 16 color palette used by the default theme.
+func defaultPalette() ColorPalette {
+	return ColorPalette{
+		Green:     lipgloss.Color("2"),
+		Blue:      lipgloss.Color("4"),
+		Red:       lipgloss.Color("1"),
+		Yellow:    lipgloss.Color("3"),
+		Cyan:      lipgloss.Color("6"),
+		White:     lipgloss.Color("7"),
+		Gray:      lipgloss.Color("8"),
+		Orange:    lipgloss.Color("208"),
+		None:      lipgloss.Color("-1"),
+		Highlight: lipgloss.Color("4"), // same as blue for default theme
+	}
+}
+
+// defaultAuthorPalette returns the ANSI 256 author colors for the default theme.
+func defaultAuthorPalette() []lipgloss.Color {
+	return []lipgloss.Color{
+		lipgloss.Color("208"), // orange
+		lipgloss.Color("176"), // pink/magenta
+		lipgloss.Color("114"), // light green
+		lipgloss.Color("216"), // salmon
+		lipgloss.Color("81"),  // sky blue
+		lipgloss.Color("222"), // gold
+		lipgloss.Color("183"), // lavender
+		lipgloss.Color("150"), // sage
+		lipgloss.Color("209"), // coral
+		lipgloss.Color("117"), // light cyan
+		lipgloss.Color("180"), // tan
+		lipgloss.Color("147"), // periwinkle
+	}
+}
+
 func defaultTheme() *Theme {
+	return buildTheme(defaultPalette(), defaultAuthorPalette())
+}
+
+// buildTheme constructs a Theme from a color palette and author palette.
+func buildTheme(p ColorPalette, authors []lipgloss.Color) *Theme {
 	return &Theme{
 		Title: lipgloss.NewStyle().
 			Bold(true).
-			Foreground(ColorGreen),
+			Foreground(p.Green),
 
 		Subtitle: lipgloss.NewStyle().
-			Foreground(ColorGray),
+			Foreground(p.Gray),
 
 		HintBar: lipgloss.NewStyle().
-			Foreground(ColorGray),
+			Foreground(p.Gray),
 
 		SelectedItem: lipgloss.NewStyle().
 			Bold(true).
-			Background(ColorBlue),
+			Background(p.Highlight),
 
 		NormalItem: lipgloss.NewStyle(),
 
 		ActiveBorder: lipgloss.NewStyle().
 			Border(lipgloss.RoundedBorder()).
-			BorderForeground(ColorGreen),
+			BorderForeground(p.Green),
 
 		InactiveBorder: lipgloss.NewStyle().
 			Border(lipgloss.RoundedBorder()).
-			BorderForeground(ColorNone),
+			BorderForeground(p.None),
 
 		ErrorText: lipgloss.NewStyle().
-			Foreground(ColorRed).
+			Foreground(p.Red).
 			Bold(true),
 
 		SuccessText: lipgloss.NewStyle().
-			Foreground(ColorGreen),
+			Foreground(p.Green),
 
 		WarningText: lipgloss.NewStyle().
-			Foreground(ColorYellow),
+			Foreground(p.Yellow),
 
 		KeyStyle: lipgloss.NewStyle().
-			Foreground(ColorGreen),
+			Foreground(p.Green),
 
 		ValueStyle: lipgloss.NewStyle(),
 
 		PriorityHigh: lipgloss.NewStyle().
-			Foreground(ColorRed),
+			Foreground(p.Red),
 
 		PriorityMedium: lipgloss.NewStyle().
-			Foreground(ColorYellow),
+			Foreground(p.Yellow),
 
 		PriorityLow: lipgloss.NewStyle().
-			Foreground(ColorGreen),
+			Foreground(p.Green),
+
+		Colors:        p,
+		AuthorPalette: authors,
 	}
+}
+
+// syncColors updates the package-level color variables and the author palette
+// to match the current Default theme.
+func syncColors() {
+	ColorGreen = Default.Colors.Green
+	ColorBlue = Default.Colors.Blue
+	ColorRed = Default.Colors.Red
+	ColorYellow = Default.Colors.Yellow
+	ColorCyan = Default.Colors.Cyan
+	ColorWhite = Default.Colors.White
+	ColorGray = Default.Colors.Gray
+	ColorOrange = Default.Colors.Orange
+	ColorNone = Default.Colors.None
+	ColorHighlight = Default.Colors.Highlight
+
+	authorPalette = Default.AuthorPalette
+	authorCache = make(map[string]lipgloss.Style)
+}
+
+// SetTheme selects a theme by name and updates the global Default instance
+// along with all package-level color variables. Must be called before the
+// TUI starts.
+//
+// Supported names: "default", "catppuccin-latte", "catppuccin-frappe",
+// "catppuccin-macchiato", "catppuccin-mocha".
+func SetTheme(name string) error {
+	switch name {
+	case "", "default":
+		Default = defaultTheme()
+	case "catppuccin-latte":
+		Default = catppuccinLatte()
+	case "catppuccin-frappe":
+		Default = catppuccinFrappe()
+	case "catppuccin-macchiato":
+		Default = catppuccinMacchiato()
+	case "catppuccin-mocha":
+		Default = catppuccinMocha()
+	default:
+		return fmt.Errorf("unknown theme: %q", name)
+	}
+	syncColors()
+	return nil
 }
 
 // PriorityStyled applies priority color based on name

--- a/pkg/tui/theme/theme.go
+++ b/pkg/tui/theme/theme.go
@@ -15,6 +15,7 @@ type ColorPalette struct {
 	Red       lipgloss.Color
 	Yellow    lipgloss.Color
 	Cyan      lipgloss.Color
+	Magenta   lipgloss.Color
 	White     lipgloss.Color
 	Gray      lipgloss.Color
 	Orange    lipgloss.Color
@@ -31,6 +32,7 @@ var (
 	ColorRed       = lipgloss.Color("1")   // ANSI red — errors, unstaged
 	ColorYellow    = lipgloss.Color("3")   // ANSI yellow — warnings, in-progress
 	ColorCyan      = lipgloss.Color("6")   // ANSI cyan — search mode
+	ColorMagenta   = lipgloss.Color("5")   // ANSI magenta — JQL keywords
 	ColorWhite     = lipgloss.Color("7")   // ANSI white (light gray)
 	ColorGray      = lipgloss.Color("8")   // ANSI bright black (dark gray)
 	ColorOrange    = lipgloss.Color("208") // ANSI 256 orange — secondary accent (names, metadata)
@@ -73,6 +75,7 @@ func defaultPalette() ColorPalette {
 		Red:       lipgloss.Color("1"),
 		Yellow:    lipgloss.Color("3"),
 		Cyan:      lipgloss.Color("6"),
+		Magenta:   lipgloss.Color("5"),
 		White:     lipgloss.Color("7"),
 		Gray:      lipgloss.Color("8"),
 		Orange:    lipgloss.Color("208"),
@@ -167,6 +170,7 @@ func syncColors() {
 	ColorRed = Default.Colors.Red
 	ColorYellow = Default.Colors.Yellow
 	ColorCyan = Default.Colors.Cyan
+	ColorMagenta = Default.Colors.Magenta
 	ColorWhite = Default.Colors.White
 	ColorGray = Default.Colors.Gray
 	ColorOrange = Default.Colors.Orange

--- a/pkg/tui/theme/theme_test.go
+++ b/pkg/tui/theme/theme_test.go
@@ -1,0 +1,109 @@
+package theme
+
+import (
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+func TestSetThemeDefault(t *testing.T) {
+	// Ensure SetTheme("default") restores ANSI palette.
+	if err := SetTheme("default"); err != nil {
+		t.Fatalf("SetTheme(default): %v", err)
+	}
+	if ColorGreen != lipgloss.Color("2") {
+		t.Errorf("ColorGreen = %q, want %q", ColorGreen, "2")
+	}
+	if ColorBlue != lipgloss.Color("4") {
+		t.Errorf("ColorBlue = %q, want %q", ColorBlue, "4")
+	}
+}
+
+func TestSetThemeEmpty(t *testing.T) {
+	if err := SetTheme(""); err != nil {
+		t.Fatalf("SetTheme(''): %v", err)
+	}
+	if ColorGreen != lipgloss.Color("2") {
+		t.Errorf("ColorGreen = %q, want %q", ColorGreen, "2")
+	}
+}
+
+func TestSetThemeCatppuccinMocha(t *testing.T) {
+	if err := SetTheme("catppuccin-mocha"); err != nil {
+		t.Fatalf("SetTheme(catppuccin-mocha): %v", err)
+	}
+	if ColorGreen != lipgloss.Color("#a6e3a1") {
+		t.Errorf("ColorGreen = %q, want %q", ColorGreen, "#a6e3a1")
+	}
+	if ColorBlue != lipgloss.Color("#89b4fa") {
+		t.Errorf("ColorBlue = %q, want %q", ColorBlue, "#89b4fa")
+	}
+	if Default.Colors.Red != lipgloss.Color("#f38ba8") {
+		t.Errorf("Default.Colors.Red = %q, want %q", Default.Colors.Red, "#f38ba8")
+	}
+
+	// Restore default for other tests.
+	_ = SetTheme("default")
+}
+
+func TestSetThemeAllFlavors(t *testing.T) {
+	flavors := []string{
+		"catppuccin-latte",
+		"catppuccin-frappe",
+		"catppuccin-macchiato",
+		"catppuccin-mocha",
+	}
+	for _, name := range flavors {
+		t.Run(name, func(t *testing.T) {
+			if err := SetTheme(name); err != nil {
+				t.Fatalf("SetTheme(%s): %v", name, err)
+			}
+			// Verify palette is populated (not empty).
+			if Default.Colors.Green == "" {
+				t.Error("Colors.Green is empty")
+			}
+			if len(Default.AuthorPalette) != 12 {
+				t.Errorf("AuthorPalette has %d entries, want 12", len(Default.AuthorPalette))
+			}
+		})
+	}
+	_ = SetTheme("default")
+}
+
+func TestSetThemeUnknown(t *testing.T) {
+	err := SetTheme("nonexistent")
+	if err == nil {
+		t.Fatal("expected error for unknown theme")
+	}
+}
+
+func TestSetThemeSyncsColors(t *testing.T) {
+	_ = SetTheme("catppuccin-mocha")
+	// Package-level vars must match Default.Colors.
+	if ColorGreen != Default.Colors.Green {
+		t.Errorf("ColorGreen not synced: %q != %q", ColorGreen, Default.Colors.Green)
+	}
+	if ColorBlue != Default.Colors.Blue {
+		t.Errorf("ColorBlue not synced: %q != %q", ColorBlue, Default.Colors.Blue)
+	}
+	if ColorOrange != Default.Colors.Orange {
+		t.Errorf("ColorOrange not synced: %q != %q", ColorOrange, Default.Colors.Orange)
+	}
+	_ = SetTheme("default")
+}
+
+func TestSetThemeResetsAuthorCache(t *testing.T) {
+	_ = SetTheme("default")
+	// Prime the author cache.
+	_ = AuthorStyle("Alice")
+	if len(authorCache) == 0 {
+		t.Fatal("author cache should have an entry")
+	}
+
+	// Switching theme must clear the cache.
+	_ = SetTheme("catppuccin-mocha")
+	if len(authorCache) != 0 {
+		t.Error("author cache should be empty after theme switch")
+	}
+	_ = SetTheme("default")
+}

--- a/pkg/tui/theme/theme_test.go
+++ b/pkg/tui/theme/theme_test.go
@@ -89,6 +89,24 @@ func TestSetThemeSyncsColors(t *testing.T) {
 	if ColorOrange != Default.Colors.Orange {
 		t.Errorf("ColorOrange not synced: %q != %q", ColorOrange, Default.Colors.Orange)
 	}
+	if ColorMagenta != Default.Colors.Magenta {
+		t.Errorf("ColorMagenta not synced: %q != %q", ColorMagenta, Default.Colors.Magenta)
+	}
+	_ = SetTheme("default")
+}
+
+func TestSetThemeSyncsAuthorPalette(t *testing.T) {
+	_ = SetTheme("default")
+	defaultFirst := authorPalette[0]
+
+	_ = SetTheme("catppuccin-mocha")
+	if authorPalette[0] == defaultFirst {
+		t.Error("authorPalette did not switch when theme changed")
+	}
+	if len(authorPalette) != len(Default.AuthorPalette) {
+		t.Errorf("authorPalette length %d != Default.AuthorPalette length %d",
+			len(authorPalette), len(Default.AuthorPalette))
+	}
 	_ = SetTheme("default")
 }
 

--- a/pkg/tui/views/adf.go
+++ b/pkg/tui/views/adf.go
@@ -225,7 +225,7 @@ func (r *adfRenderer) renderInline(node any) string {
 	case adfInlineCard:
 		if attrs, ok := inline["attrs"].(map[string]any); ok {
 			if url, ok := attrs["url"].(string); ok {
-				return urlStyle.Render(url)
+				return urlStyle().Render(url)
 			}
 		}
 	}
@@ -286,7 +286,7 @@ func applyMarks(text string, marks []any) string {
 		case "strike":
 			text = lipgloss.NewStyle().Strikethrough(true).Render(text)
 		case "link":
-			text = urlStyle.Render(text)
+			text = urlStyle().Render(text)
 		case "textColor":
 			if attrs, ok := mark["attrs"].(map[string]any); ok {
 				if color, ok := attrs["color"].(string); ok {

--- a/pkg/tui/views/detail.go
+++ b/pkg/tui/views/detail.go
@@ -873,8 +873,8 @@ func isMultiSelectField(field string) bool {
 }
 
 func renderMultiSelectDiff(from, to string) []string {
-	red := lipgloss.NewStyle().Foreground(lipgloss.Color("1"))
-	green := lipgloss.NewStyle().Foreground(lipgloss.Color("2"))
+	red := lipgloss.NewStyle().Foreground(theme.ColorRed)
+	green := lipgloss.NewStyle().Foreground(theme.ColorGreen)
 
 	parseSet := func(s string) map[string]struct{} {
 		m := make(map[string]struct{})

--- a/pkg/tui/views/detail.go
+++ b/pkg/tui/views/detail.go
@@ -660,7 +660,9 @@ func (d *DetailView) renderDescription(width int) []string {
 	return lines
 }
 
-var urlStyle = lipgloss.NewStyle().Foreground(theme.ColorCyan).Underline(true)
+func urlStyle() lipgloss.Style {
+	return lipgloss.NewStyle().Foreground(theme.ColorCyan).Underline(true)
+}
 
 // colorURLs highlights http/https URLs in a single line with underlined cyan.
 func colorURLs(s string) string {
@@ -677,7 +679,7 @@ func colorURLs(s string) string {
 				end = len(rest)
 			}
 			rawURL := rest[:end]
-			colored := urlStyle.Render(rawURL)
+			colored := urlStyle().Render(rawURL)
 			result = result[:start] + colored + rest[end:]
 		}
 	}
@@ -694,11 +696,11 @@ func colorURLsWrapped(lines []string) []string {
 			// Previous line ended mid-URL — highlight continuation.
 			end := strings.IndexAny(line, " \t")
 			if end == -1 {
-				result[i] = urlStyle.Render(line)
+				result[i] = urlStyle().Render(line)
 				urlCont = true
 				continue
 			}
-			result[i] = urlStyle.Render(line[:end]) + colorURLs(line[end:])
+			result[i] = urlStyle().Render(line[:end]) + colorURLs(line[end:])
 		} else {
 			result[i] = colorURLs(line)
 		}

--- a/pkg/tui/views/infofields.go
+++ b/pkg/tui/views/infofields.go
@@ -252,7 +252,9 @@ func renderInfoRowPairs(issue *jira.Issue, cfgFields []config.FieldConfig, th *t
 	return
 }
 
-var noneStyle = lipgloss.NewStyle().Foreground(theme.ColorGray)
+func noneStyle() lipgloss.Style {
+	return lipgloss.NewStyle().Foreground(theme.ColorGray)
+}
 
 func renderFieldRows(fields []InfoField, issue *jira.Issue, th *theme.Theme, maxWidth int) []string {
 	if len(fields) == 0 {
@@ -283,7 +285,7 @@ func renderFieldRows(fields []InfoField, issue *jira.Issue, th *theme.Theme, max
 		isNone := val == noneLabelUpper || val == unknownLabel
 
 		if styled && isNone {
-			val = noneStyle.Render(val)
+			val = noneStyle().Render(val)
 		} else if styled {
 			switch f.FieldID {
 			case fieldStatus:


### PR DESCRIPTION
## What

Add catppuccin (https://github.com/catppuccin) themes support.

## Why

I'd like to have themes support so I can use my favourite theme.

## How to test

Set gui.theme to one of supported catppuccin themes or `default`.


Closes #58 