### PR TITLE
Feat/task status icons

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -51,6 +51,15 @@ gui:
         - status
         - summary
     selectCreatedIssue: true
+    typeIcons:
+        Bug: "🐞"
+        Story: "📖"
+        Sub-task: "📎"
+    statusIcons:
+        To do: "📋"
+        On hold: "⏸️"
+        Future: "🔜"
+
 keybinding:
     universal:
         quit: q
@@ -182,6 +191,26 @@ gui:
 ```yaml
 gui:
   selectCreatedIssue: true
+```
+
+`typeIcons` will have issue `type` names replaced by the emojis you set. Mappings are case-sensitive, and support not only emojis but also plaintext. Enable the field `type` under `issueListFields` to profit from this option.
+
+```
+gui:
+    typeIcons:
+        Bug: "🐞"
+        Story: "📖"
+        Sub-task: "📎"
+```
+
+`statusIcons` will have issue `status` indicators replaced by the emojis you set. Default indicators may be shared for similar states (e.g. To do / Future), so one may get more granularity from this option. Mappings are case-sensitive, and support not only emojis but also plaintext. Enable the field `status` under `issueListFields` to profit from this option.
+
+```
+gui:
+    statusIcons:
+        To do: "📋"
+        On hold: "⏸️"
+        Future: "🔜"
 ```
 
 ### Issue list fields

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -189,6 +189,7 @@ type GUIConfig struct {
 	PrefillFromTab       *bool             `yaml:"prefillFromTab"`
 	SelectCreatedIssue   *bool             `yaml:"selectCreatedIssue"`
 	TypeIcons            map[string]string `yaml:"typeIcons"`
+	StatusIcons          map[string]string `yaml:"statusIcons"`
 }
 
 // ShouldPrefillFromTab returns true when the creation form should prefill from tab JQL

--- a/pkg/tui/app.go
+++ b/pkg/tui/app.go
@@ -229,6 +229,9 @@ func NewAppWithAuth(cfg *config.Config, client jira.ClientInterface, authMethod 
 	if len(cfg.GUI.TypeIcons) > 0 {
 		issuesList.SetTypeIcons(cfg.GUI.TypeIcons)
 	}
+	if len(cfg.GUI.StatusIcons) > 0 {
+		issuesList.SetStatusIcons(cfg.GUI.StatusIcons)
+	}
 	issuesList.SetTabs(cfg.IssueTabs)
 	issuesList.SetFocused(true)
 	issuesList.SetUserEmail(cfg.Jira.Email)

--- a/pkg/tui/views/issues.go
+++ b/pkg/tui/views/issues.go
@@ -456,11 +456,7 @@ func (m *IssuesList) renderIssueRow(issue jira.Issue, width int, selected bool) 
 		case "key":
 			fixedWidth += m.keyColWidth
 		case fieldStatus:
-			if currStatusIcon != "" {
-				fixedWidth += m.statusIconCols
-			} else {
-				fixedWidth += 1
-			}
+			fixedWidth += max(1, m.statusIconCols)
 		case "priority":
 			fixedWidth += 8
 		case "assignee":
@@ -571,7 +567,7 @@ func typeIcon(icons map[string]string, issueType *jira.IssueType) string {
 	return icon
 }
 
-// statusIcon returns the configured icon for the given issue type, or empty string if none.
+// statusIcon returns the configured icon for the given status, or empty string if none.
 func statusIcon(icons map[string]string, status *jira.Status) string {
 	if status == nil {
 		return ""

--- a/pkg/tui/views/issues.go
+++ b/pkg/tui/views/issues.go
@@ -27,20 +27,22 @@ const statusOpen = "○"
 
 type IssuesList struct {
 	components.ListBase
-	issues       []jira.Issue
-	allIssues    []jira.Issue
-	filter       string
-	tabs         []config.IssueTabConfig
-	tab          int
-	tabCache     map[int][]jira.Issue
-	userEmail    string
-	keyColWidth  int
-	fields       []string
-	theme        *theme.Theme
-	typeIcons    map[string]string
-	typeIconCols int
-	jqlQuery     string
-	jqlTabIdx    int
+	issues         []jira.Issue
+	allIssues      []jira.Issue
+	filter         string
+	tabs           []config.IssueTabConfig
+	tab            int
+	tabCache       map[int][]jira.Issue
+	userEmail      string
+	keyColWidth    int
+	fields         []string
+	theme          *theme.Theme
+	typeIcons      map[string]string
+	typeIconCols   int
+	statusIcons    map[string]string
+	statusIconCols int
+	jqlQuery       string
+	jqlTabIdx      int
 }
 
 func NewIssuesList() *IssuesList {
@@ -57,6 +59,16 @@ func (m *IssuesList) SetTypeIcons(icons map[string]string) {
 		}
 	}
 	m.typeIconCols = max
+}
+func (m *IssuesList) SetStatusIcons(icons map[string]string) {
+	m.statusIcons = icons
+	max := 0
+	for _, icon := range icons {
+		if w := lipgloss.Width(icon); w > max {
+			max = w
+		}
+	}
+	m.statusIconCols = max
 }
 func (m *IssuesList) SetTabs(tabs []config.IssueTabConfig) { m.tabs = tabs }
 func (m *IssuesList) SetUserEmail(email string)            { m.userEmail = email }
@@ -432,7 +444,8 @@ func (m *IssuesList) renderIssueRow(issue jira.Issue, width int, selected bool) 
 		fields = []string{"key", fieldStatus, "summary"}
 	}
 
-	icon := typeIcon(m.typeIcons, issue.IssueType)
+	currTypeIcon := typeIcon(m.typeIcons, issue.IssueType)
+	currStatusIcon := statusIcon(m.statusIcons, issue.Status)
 
 	fixedWidth := 1
 	if len(fields) > 1 {
@@ -443,13 +456,17 @@ func (m *IssuesList) renderIssueRow(issue jira.Issue, width int, selected bool) 
 		case "key":
 			fixedWidth += m.keyColWidth
 		case fieldStatus:
-			fixedWidth += 1
+			if currStatusIcon != "" {
+				fixedWidth += m.statusIconCols
+			} else {
+				fixedWidth += 1
+			}
 		case "priority":
 			fixedWidth += 8
 		case "assignee":
 			fixedWidth += 12
 		case "type":
-			if icon != "" {
+			if currTypeIcon != "" {
 				fixedWidth += m.typeIconCols
 			} else {
 				fixedWidth += 10
@@ -469,10 +486,14 @@ func (m *IssuesList) renderIssueRow(issue jira.Issue, width int, selected bool) 
 		case "summary":
 			parts = append(parts, padRight(components.TruncateEnd(issue.Summary, summaryWidth), summaryWidth))
 		case fieldStatus:
-			if selected {
-				parts = append(parts, statusEmojiPlain(issue.Status))
+			if currStatusIcon != "" {
+				parts = append(parts, padRight(currStatusIcon, m.statusIconCols))
 			} else {
-				parts = append(parts, statusEmoji(issue.Status))
+                if selected {
+                    parts = append(parts, statusEmojiPlain(issue.Status))
+                } else {
+                    parts = append(parts, statusEmoji(issue.Status))
+                }
 			}
 		case "priority":
 			name := ""
@@ -487,8 +508,8 @@ func (m *IssuesList) renderIssueRow(issue jira.Issue, width int, selected bool) 
 			}
 			parts = append(parts, padRight(components.TruncateEnd(name, 12), 12))
 		case "type":
-			if icon != "" {
-				parts = append(parts, padRight(icon, m.typeIconCols))
+			if currTypeIcon != "" {
+				parts = append(parts, padRight(currTypeIcon, m.typeIconCols))
 			} else {
 				name := ""
 				if issue.IssueType != nil {
@@ -544,6 +565,18 @@ func typeIcon(icons map[string]string, issueType *jira.IssueType) string {
 		return ""
 	}
 	icon, ok := icons[issueType.Name]
+	if !ok || icon == "" {
+		return ""
+	}
+	return icon
+}
+
+// statusIcon returns the configured icon for the given issue type, or empty string if none.
+func statusIcon(icons map[string]string, status *jira.Status) string {
+	if status == nil {
+		return ""
+	}
+	icon, ok := icons[status.Name]
 	if !ok || icon == "" {
 		return ""
 	}

--- a/pkg/tui/views/issues.go
+++ b/pkg/tui/views/issues.go
@@ -490,9 +490,9 @@ func (m *IssuesList) renderIssueRow(issue jira.Issue, width int, selected bool) 
 				parts = append(parts, padRight(currStatusIcon, m.statusIconCols))
 			} else {
                 if selected {
-                    parts = append(parts, statusEmojiPlain(issue.Status))
+                    parts = append(parts, padRight(statusEmojiPlain(issue.Status), m.statusIconCols))
                 } else {
-                    parts = append(parts, statusEmoji(issue.Status))
+                    parts = append(parts, padRight(statusEmoji(issue.Status), m.statusIconCols))
                 }
 			}
 		case "priority":


### PR DESCRIPTION
Closes https://github.com/textfuel/lazyjira/issues/56: Helps identifying current pending/upcoming/reviewing work at a glance.

Adds an optional `gui.statusIcons` map. Statuses with a configured icon render as the icon in the issue list, unconfigured types keep their default. Empty by default. One could also write plaintext instead of icons.

```
gui:
  statusIcons:
    To do: "📋"
    On hold: "⏸️"
    Future: "🔜"
```

Thanks for the inspiration and boilerplate to @seflue, as this was basically copying his work