### PR TITLE
Show parent-link children in Sub tab on Cloud

### DIFF
--- a/pkg/jira/client.go
+++ b/pkg/jira/client.go
@@ -25,6 +25,7 @@ type ClientInterface interface {
 	GetProjects(ctx context.Context) ([]Project, error)
 	GetBoards(ctx context.Context) ([]Board, error)
 	GetBoardIssues(ctx context.Context, boardID int, jql string) ([]Issue, error)
+	GetChildren(ctx context.Context, parentKey string) ([]Issue, error)
 	UpdateIssue(ctx context.Context, issueKey string, fields map[string]any) error
 	GetPriorities(ctx context.Context) ([]Priority, error)
 	CreateIssue(ctx context.Context, fields map[string]any) (*Issue, error)
@@ -331,6 +332,20 @@ func (c *Client) SearchIssues(ctx context.Context, jql string, startAt, maxResul
 		c.fillSprintFromCustomField(&result.Issues[i], ri.Fields.RawExtra)
 	}
 	return result, nil
+}
+
+// GetChildren returns child issues of parentKey on Cloud (parent-link model).
+// Server/DC returns (nil, nil); classic subtasks live on Issue.Subtasks.
+func (c *Client) GetChildren(ctx context.Context, parentKey string) ([]Issue, error) {
+	if !c.isCloud {
+		return nil, nil
+	}
+	jql := "parent = " + parentKey
+	result, err := c.SearchIssues(ctx, jql, 0, 100)
+	if err != nil {
+		return nil, fmt.Errorf("get children of %s: %w", parentKey, err)
+	}
+	return result.Issues, nil
 }
 
 func (c *Client) GetMyIssues(ctx context.Context) ([]Issue, error) {

--- a/pkg/jira/client_test.go
+++ b/pkg/jira/client_test.go
@@ -1,6 +1,9 @@
 package jira
 
 import (
+	"context"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 )
@@ -47,6 +50,69 @@ func TestNewClientWithOpts_HostNormalization(t *testing.T) {
 		if c.hostURL != tt.want {
 			t.Errorf("Host %q: got %q, want %q", tt.input, c.hostURL, tt.want)
 		}
+	}
+}
+
+// countingRoundTripper records every HTTP call without performing one.
+type countingRoundTripper struct {
+	calls int
+}
+
+func (c *countingRoundTripper) RoundTrip(*http.Request) (*http.Response, error) {
+	c.calls++
+	return nil, http.ErrUseLastResponse // any error suffices; we only count
+}
+
+func TestClient_GetChildren_CloudFiresJQL(t *testing.T) {
+	var (
+		gotPath string
+		gotJQL  string
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotJQL = r.URL.Query().Get("jql")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"issues":[],"total":0,"maxResults":100,"startAt":0}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	c := NewClientWithOpts(ClientOpts{
+		Host:    srv.URL,
+		Email:   "u",
+		Token:   "t",
+		IsCloud: true,
+	})
+
+	if _, err := c.GetChildren(context.Background(), "PROJ-123"); err != nil {
+		t.Fatalf("GetChildren returned error: %v", err)
+	}
+
+	if !strings.HasSuffix(gotPath, "/search/jql") {
+		t.Errorf("Cloud: expected /search/jql, got %s", gotPath)
+	}
+	if gotJQL != "parent = PROJ-123" {
+		t.Errorf("Cloud JQL: got %q, want %q", gotJQL, "parent = PROJ-123")
+	}
+}
+
+func TestClient_GetChildren_ServerDCNoCall(t *testing.T) {
+	rt := &countingRoundTripper{}
+	c := NewClientWithOpts(ClientOpts{
+		Host:       "https://jira.corp.example",
+		Token:      "pat",
+		IsCloud:    false,
+		HTTPClient: &http.Client{Transport: rt},
+	})
+
+	issues, err := c.GetChildren(context.Background(), "PROJ-123")
+	if err != nil {
+		t.Fatalf("Server/DC GetChildren: unexpected error %v", err)
+	}
+	if issues != nil {
+		t.Errorf("Server/DC GetChildren: expected nil slice, got %v", issues)
+	}
+	if rt.calls != 0 {
+		t.Errorf("Server/DC GetChildren: expected 0 HTTP calls, got %d", rt.calls)
 	}
 }
 

--- a/pkg/jira/jiratest/fake.go
+++ b/pkg/jira/jiratest/fake.go
@@ -61,6 +61,11 @@ type GetBoardIssuesCall struct {
 	JQL     string
 }
 
+type GetChildrenCall struct {
+	Ctx       context.Context
+	ParentKey string
+}
+
 type UpdateIssueCall struct {
 	Ctx    context.Context
 	Key    string
@@ -147,6 +152,7 @@ type FakeClient struct {
 	GetProjectsFunc                   func(ctx context.Context) ([]jira.Project, error)
 	GetBoardsFunc                     func(ctx context.Context) ([]jira.Board, error)
 	GetBoardIssuesFunc                func(ctx context.Context, boardID int, jql string) ([]jira.Issue, error)
+	GetChildrenFunc                   func(ctx context.Context, parentKey string) ([]jira.Issue, error)
 	UpdateIssueFunc                   func(ctx context.Context, key string, fields map[string]any) error
 	GetPrioritiesFunc                 func(ctx context.Context) ([]jira.Priority, error)
 	CreateIssueFunc                   func(ctx context.Context, fields map[string]any) (*jira.Issue, error)
@@ -179,6 +185,7 @@ type FakeClient struct {
 	GetProjectsCalls                   []context.Context
 	GetBoardsCalls                     []context.Context
 	GetBoardIssuesCalls                []GetBoardIssuesCall
+	GetChildrenCalls                   []GetChildrenCall
 	UpdateIssueCalls                   []UpdateIssueCall
 	GetPrioritiesCalls                 []context.Context
 	CreateIssueCalls                   []CreateIssueCall
@@ -304,6 +311,15 @@ func (f *FakeClient) GetBoardIssues(ctx context.Context, boardID int, jql string
 		return nil, nil
 	}
 	return f.GetBoardIssuesFunc(ctx, boardID, jql)
+}
+
+func (f *FakeClient) GetChildren(ctx context.Context, parentKey string) ([]jira.Issue, error) {
+	f.GetChildrenCalls = append(f.GetChildrenCalls, GetChildrenCall{Ctx: ctx, ParentKey: parentKey})
+	if f.GetChildrenFunc == nil {
+		f.fatal("GetChildren")
+		return nil, nil
+	}
+	return f.GetChildrenFunc(ctx, parentKey)
 }
 
 func (f *FakeClient) UpdateIssue(ctx context.Context, key string, fields map[string]any) error {

--- a/pkg/tui/app.go
+++ b/pkg/tui/app.go
@@ -176,6 +176,7 @@ type App struct {
 	currentUser     *jira.User
 	usersCache      map[string][]jira.User
 	issueCache      map[string]*jira.Issue
+	childrenCache   map[string][]jira.Issue
 	createMetaCache map[string][]jira.CreateMetaField
 	// previewKey identifies the issue displayed in the right-side views.
 	// Empty means nothing is displayed.
@@ -323,6 +324,7 @@ func NewAppWithAuth(cfg *config.Config, client jira.ClientInterface, authMethod 
 		logFlag:         logFlag,
 		usersCache:      make(map[string][]jira.User),
 		issueCache:      make(map[string]*jira.Issue),
+		childrenCache:   make(map[string][]jira.Issue),
 		createMetaCache: make(map[string][]jira.CreateMetaField),
 	}
 	app.ctx, app.cancel = context.WithCancel(context.Background()) //nolint:gosec // cancel is called in Shutdown()
@@ -607,6 +609,10 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if !a.isCloud || msg.Key == "" {
 			return a, nil
 		}
+		if cached, ok := a.childrenCache[msg.Key]; ok {
+			a.infoPanel.SetChildren(msg.Key, cached)
+			return a, nil
+		}
 		a.childrenEpoch++
 		return a, fetchChildren(a.client, msg.Key, a.childrenEpoch)
 
@@ -619,6 +625,7 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			a.infoPanel.SetChildrenError(msg.key, msg.err.Error())
 			return a, nil
 		}
+		a.childrenCache[msg.key] = msg.issues
 		a.infoPanel.SetChildren(msg.key, msg.issues)
 		return a, nil
 

--- a/pkg/tui/app.go
+++ b/pkg/tui/app.go
@@ -627,7 +627,7 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		a.childrenCache[msg.key] = msg.issues
 		a.infoPanel.SetChildren(msg.key, msg.issues)
-		return a, nil
+		return a, a.prefetchChildrenDetails(msg.issues)
 
 	case previewDetailLoadedMsg:
 		if msg.epoch != a.previewEpoch {

--- a/pkg/tui/app.go
+++ b/pkg/tui/app.go
@@ -249,6 +249,9 @@ func NewAppWithAuth(cfg *config.Config, client jira.ClientInterface, authMethod 
 	issuesList.SetFocused(true)
 	issuesList.SetUserEmail(cfg.Jira.Email)
 	infoPanel := views.NewInfoPanel()
+	if len(cfg.GUI.TypeIcons) > 0 {
+		infoPanel.SetTypeIcons(cfg.GUI.TypeIcons)
+	}
 	projectList := views.NewProjectList()
 	detailView := views.NewDetailView()
 	logPanel := views.NewLogPanel()

--- a/pkg/tui/app.go
+++ b/pkg/tui/app.go
@@ -103,6 +103,15 @@ type previewDebounceMsg struct {
 	epoch int
 }
 
+// childrenLoadedMsg carries the response of a Cloud GetChildren fetch.
+// See App.childrenEpoch.
+type childrenLoadedMsg struct {
+	key    string
+	issues []jira.Issue
+	err    error
+	epoch  int
+}
+
 type transitionDoneMsg struct{}
 type errorMsg struct{ err error }
 type projectsLoadedMsg struct{ projects []jira.Project }
@@ -177,7 +186,11 @@ type App struct {
 	// is how we simulate "cancel the previous intent", which bubbletea
 	// does not provide natively for tea.Cmd.
 	previewEpoch int
-	createCtx    createCtx
+	// childrenEpoch is the analogous counter for Cloud Sub-tab GetChildren
+	// fetches. Bumped on every ChildrenRequestMsg; responses with stale
+	// epoch are dropped.
+	childrenEpoch int
+	createCtx     createCtx
 
 	gitRepoPath    string
 	gitBranch      string
@@ -313,6 +326,7 @@ func NewAppWithAuth(cfg *config.Config, client jira.ClientInterface, authMethod 
 	navResolver := app.keymap.MatchNav
 	app.issuesList.ResolveNav = navResolver
 	app.infoPanel.ResolveNav = navResolver
+	app.infoPanel.SetCloud(app.isCloud)
 	app.projectList.ResolveNav = navResolver
 	app.detailView.ResolveNav = navResolver
 
@@ -565,7 +579,7 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			a.detailView.SetIssue(msg.Issue)
 			a.infoPanel.SetIssue(msg.Issue)
 		}
-		return a, a.prefetchRelated(msg.Issue)
+		return a, tea.Batch(a.prefetchRelated(msg.Issue), a.infoPanel.MaybeChildrenRequest())
 
 	case views.PreviewRequestMsg:
 		a.previewKey = msg.Key
@@ -585,6 +599,25 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return a, nil
 		}
 		return a, fetchPreviewDetail(a.client, msg.key, a.previewEpoch)
+
+	case views.ChildrenRequestMsg:
+		if !a.isCloud || msg.Key == "" {
+			return a, nil
+		}
+		a.childrenEpoch++
+		return a, fetchChildren(a.client, msg.Key, a.childrenEpoch)
+
+	case childrenLoadedMsg:
+		if msg.epoch != a.childrenEpoch {
+			return a, nil
+		}
+		if msg.err != nil {
+			a.statusPanel.SetError("Failed to load children: " + msg.err.Error())
+			a.infoPanel.SetChildrenError(msg.key, msg.err.Error())
+			return a, nil
+		}
+		a.infoPanel.SetChildren(msg.key, msg.issues)
+		return a, nil
 
 	case previewDetailLoadedMsg:
 		if msg.epoch != a.previewEpoch {

--- a/pkg/tui/children_test.go
+++ b/pkg/tui/children_test.go
@@ -3,6 +3,7 @@ package tui
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -198,6 +199,58 @@ func TestChildrenRequestMsg_CacheMiss_PopulatesCacheOnLoad(t *testing.T) {
 	}
 	if len(cached) != 2 || cached[0].Key != "C-1" {
 		t.Errorf("cached entry = %+v, want %+v", cached, want)
+	}
+}
+
+func TestChildrenLoadedMsg_PrefetchesChildDetails(t *testing.T) {
+	fake := &jiratest.FakeClient{T: t}
+	var seenJQL string
+	fake.SearchIssuesFunc = func(_ context.Context, jql string, _, _ int) (*jira.SearchResult, error) {
+		seenJQL = jql
+		return &jira.SearchResult{}, nil
+	}
+
+	a := newAppWithFake(t, fake)
+	a.isCloud = true
+	a.infoPanel.SetCloud(true)
+	a.infoPanel.SetIssue(&jira.Issue{Key: "EPIC-1"})
+	a.childrenEpoch = 1
+
+	_, cmd := a.Update(childrenLoadedMsg{
+		key:    "EPIC-1",
+		issues: []jira.Issue{{Key: "C-1"}, {Key: "C-2"}},
+		epoch:  1,
+	})
+	if cmd == nil {
+		t.Fatal("expected prefetch cmd, got nil")
+	}
+	cmd()
+
+	if seenJQL == "" {
+		t.Fatal("expected SearchIssues call for prefetch")
+	}
+	if !strings.Contains(seenJQL, "C-1") || !strings.Contains(seenJQL, "C-2") {
+		t.Errorf("prefetch JQL %q must include both child keys", seenJQL)
+	}
+}
+
+func TestChildrenLoadedMsg_PrefetchSkipsAlreadyCached(t *testing.T) {
+	fake := &jiratest.FakeClient{T: t}
+	a := newAppWithFake(t, fake)
+	a.isCloud = true
+	a.infoPanel.SetCloud(true)
+	a.infoPanel.SetIssue(&jira.Issue{Key: "EPIC-1"})
+	a.issueCache["C-1"] = &jira.Issue{Key: "C-1"}
+	a.issueCache["C-2"] = &jira.Issue{Key: "C-2"}
+	a.childrenEpoch = 1
+
+	_, cmd := a.Update(childrenLoadedMsg{
+		key:    "EPIC-1",
+		issues: []jira.Issue{{Key: "C-1"}, {Key: "C-2"}},
+		epoch:  1,
+	})
+	if cmd != nil {
+		t.Errorf("all children cached: expected nil cmd, got non-nil")
 	}
 }
 

--- a/pkg/tui/children_test.go
+++ b/pkg/tui/children_test.go
@@ -148,6 +148,119 @@ func TestIssueSelectedMsg_OnFieldsTab_NoChildrenRequest(t *testing.T) {
 	}
 }
 
+func TestChildrenRequestMsg_CacheHit_NoClientCall(t *testing.T) {
+	fake := &jiratest.FakeClient{T: t}
+	// No GetChildrenFunc — any call would t.Fatalf via fake.fatal.
+
+	a := newAppWithFake(t, fake)
+	a.isCloud = true
+	a.infoPanel.SetCloud(true)
+	a.infoPanel.SetIssue(&jira.Issue{Key: "EPIC-1"})
+	a.childrenCache["EPIC-1"] = []jira.Issue{{Key: "C-1", Summary: "cached"}}
+
+	_, cmd := a.Update(views.ChildrenRequestMsg{Key: "EPIC-1"})
+	if cmd != nil {
+		t.Errorf("cache hit: expected nil cmd, got non-nil")
+	}
+	if len(fake.GetChildrenCalls) != 0 {
+		t.Errorf("cache hit: expected 0 GetChildren calls, got %d", len(fake.GetChildrenCalls))
+	}
+	got := a.infoPanel.Children()
+	if len(got) != 1 || got[0].Key != "C-1" {
+		t.Errorf("cache hit: InfoPanel children = %+v, want one C-1", got)
+	}
+}
+
+func TestChildrenRequestMsg_CacheMiss_PopulatesCacheOnLoad(t *testing.T) {
+	fake := &jiratest.FakeClient{T: t}
+	want := []jira.Issue{{Key: "C-1"}, {Key: "C-2"}}
+	fake.GetChildrenFunc = func(_ context.Context, _ string) ([]jira.Issue, error) {
+		return want, nil
+	}
+
+	a := newAppWithFake(t, fake)
+	a.isCloud = true
+	a.infoPanel.SetCloud(true)
+	a.infoPanel.SetIssue(&jira.Issue{Key: "EPIC-1"})
+
+	_, cmd := a.Update(views.ChildrenRequestMsg{Key: "EPIC-1"})
+	if cmd == nil {
+		t.Fatal("cache miss: expected fetch cmd, got nil")
+	}
+	if _, ok := a.childrenCache["EPIC-1"]; ok {
+		t.Error("cache miss: cache should still be empty before response")
+	}
+	_, _ = a.Update(cmd())
+
+	cached, ok := a.childrenCache["EPIC-1"]
+	if !ok {
+		t.Fatal("after load: expected cache entry for EPIC-1")
+	}
+	if len(cached) != 2 || cached[0].Key != "C-1" {
+		t.Errorf("cached entry = %+v, want %+v", cached, want)
+	}
+}
+
+func TestActRefresh_ClearsChildrenCacheForPreviewKey(t *testing.T) {
+	fake := &jiratest.FakeClient{T: t}
+	fake.GetIssueFunc = func(_ context.Context, _ string) (*jira.Issue, error) {
+		return &jira.Issue{Key: "EPIC-1"}, nil
+	}
+	a := newAppWithFake(t, fake)
+	a.isCloud = true
+	a.previewKey = "EPIC-1"
+	a.childrenCache["EPIC-1"] = []jira.Issue{{Key: "STALE"}}
+	a.childrenCache["OTHER"] = []jira.Issue{{Key: "OTHER-CHILD"}}
+
+	_, _, _ = a.handleIssueAction(ActRefresh)
+
+	if _, ok := a.childrenCache["EPIC-1"]; ok {
+		t.Error("refresh: expected EPIC-1 entry to be cleared")
+	}
+	if _, ok := a.childrenCache["OTHER"]; !ok {
+		t.Error("refresh: unrelated cache entry must survive")
+	}
+}
+
+// ActRefresh on a Cloud issue refetches children.
+func TestActRefresh_OnCloud_RefetchesChildren(t *testing.T) {
+	fake := &jiratest.FakeClient{T: t}
+	stubFullIssueFetch(fake, &jira.Issue{Key: "REFRESH-1"})
+	a := newAppWithFake(t, fake)
+	a.isCloud = true
+	a.infoPanel.SetCloud(true)
+	a.infoPanel.SetIssue(&jira.Issue{Key: "REFRESH-1"})
+	a.previewKey = "REFRESH-1"
+	a.childrenCache["REFRESH-1"] = []jira.Issue{{Key: "STALE"}}
+
+	_, cmd, handled := a.handleIssueAction(ActRefresh)
+	if !handled {
+		t.Fatal("ActRefresh was not handled")
+	}
+	if !batchContainsChildrenRequest(cmd, "REFRESH-1") {
+		t.Error("expected ChildrenRequestMsg{Key: REFRESH-1} in cmd batch")
+	}
+}
+
+// ActRefresh on a Server/DC issue does not refetch children.
+func TestActRefresh_OnServerDC_NoChildrenRequest(t *testing.T) {
+	fake := &jiratest.FakeClient{T: t}
+	stubFullIssueFetch(fake, &jira.Issue{Key: "REFRESH-2"})
+	a := newAppWithFake(t, fake)
+	a.isCloud = false
+	a.infoPanel.SetCloud(false)
+	a.infoPanel.SetIssue(&jira.Issue{Key: "REFRESH-2"})
+	a.previewKey = "REFRESH-2"
+
+	_, cmd, handled := a.handleIssueAction(ActRefresh)
+	if !handled {
+		t.Fatal("ActRefresh was not handled")
+	}
+	if batchContainsChildrenRequest(cmd, "REFRESH-2") {
+		t.Error("Server/DC: ActRefresh must not dispatch ChildrenRequestMsg")
+	}
+}
+
 func batchContainsChildrenRequest(cmd tea.Cmd, key string) bool {
 	if cmd == nil {
 		return false

--- a/pkg/tui/children_test.go
+++ b/pkg/tui/children_test.go
@@ -1,0 +1,167 @@
+package tui
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/textfuel/lazyjira/v2/pkg/jira"
+	"github.com/textfuel/lazyjira/v2/pkg/jira/jiratest"
+	"github.com/textfuel/lazyjira/v2/pkg/tui/views"
+)
+
+// TestChildrenRequestMsg_Cloud_FiresGetChildren pins the happy path: a
+// ChildrenRequestMsg on a Cloud app dispatches GetChildren with the right
+// key and routes the loaded children into InfoPanel.
+func TestChildrenRequestMsg_Cloud_FiresGetChildren(t *testing.T) {
+	fake := &jiratest.FakeClient{T: t}
+	want := []jira.Issue{{Key: "C-1", Summary: "first"}, {Key: "C-2", Summary: "second"}}
+	fake.GetChildrenFunc = func(_ context.Context, _ string) ([]jira.Issue, error) {
+		return want, nil
+	}
+
+	a := newAppWithFake(t, fake)
+	a.isCloud = true
+	a.infoPanel.SetCloud(true)
+	a.infoPanel.SetIssue(&jira.Issue{Key: "EPIC-1"})
+
+	_, cmd := a.Update(views.ChildrenRequestMsg{Key: "EPIC-1"})
+	if cmd == nil {
+		t.Fatal("expected fetch Cmd, got nil")
+	}
+	loadedMsg := cmd()
+
+	if len(fake.GetChildrenCalls) != 1 {
+		t.Fatalf("expected 1 GetChildren call, got %d", len(fake.GetChildrenCalls))
+	}
+	if got := fake.GetChildrenCalls[0].ParentKey; got != "EPIC-1" {
+		t.Errorf("GetChildren ParentKey = %q, want EPIC-1", got)
+	}
+
+	_, _ = a.Update(loadedMsg)
+
+	got := a.infoPanel.Children()
+	if len(got) != 2 || got[0].Key != "C-1" || got[1].Key != "C-2" {
+		t.Errorf("InfoPanel children = %+v, want %+v", got, want)
+	}
+}
+
+// TestChildrenRequestMsg_ServerDC_NoCall pins the Server/DC fast-path: the
+// app shortcircuits before touching the client when isCloud=false.
+func TestChildrenRequestMsg_ServerDC_NoCall(t *testing.T) {
+	fake := &jiratest.FakeClient{T: t}
+	// No GetChildrenFunc — any call would t.Fatalf via fake.fatal.
+
+	a := newAppWithFake(t, fake)
+	a.isCloud = false
+	a.infoPanel.SetCloud(false)
+	a.infoPanel.SetIssue(&jira.Issue{Key: "EPIC-1"})
+
+	_, cmd := a.Update(views.ChildrenRequestMsg{Key: "EPIC-1"})
+	if cmd != nil {
+		t.Errorf("Server/DC: expected nil cmd, got non-nil")
+	}
+	if len(fake.GetChildrenCalls) != 0 {
+		t.Errorf("Server/DC: expected 0 GetChildren calls, got %d", len(fake.GetChildrenCalls))
+	}
+}
+
+// TestChildrenLoadedMsg_StaleEpochDropped pins the stale-drop invariant: a
+// childrenLoadedMsg with a stale epoch (because a newer ChildrenRequestMsg
+// has bumped the counter) is ignored.
+func TestChildrenLoadedMsg_StaleEpochDropped(t *testing.T) {
+	fake := &jiratest.FakeClient{T: t}
+	a := newAppWithFake(t, fake)
+	a.isCloud = true
+	a.infoPanel.SetCloud(true)
+	a.infoPanel.SetIssue(&jira.Issue{Key: "EPIC-1"})
+
+	a.childrenEpoch = 5
+
+	stale := childrenLoadedMsg{
+		key:    "EPIC-1",
+		issues: []jira.Issue{{Key: "STALE-CHILD"}},
+		epoch:  3,
+	}
+	_, _ = a.Update(stale)
+
+	if got := a.infoPanel.Children(); got != nil {
+		t.Errorf("stale response: expected nil children, got %+v", got)
+	}
+}
+
+// TestChildrenLoadedMsg_FetchError_SetsStatusPanelError pins the error path:
+// a non-nil err lands as a StatusPanel error message and propagates to
+// InfoPanel for the error row.
+func TestChildrenLoadedMsg_FetchError_SetsStatusPanelError(t *testing.T) {
+	fake := &jiratest.FakeClient{T: t}
+	a := newAppWithFake(t, fake)
+	a.isCloud = true
+	a.infoPanel.SetCloud(true)
+	a.infoPanel.SetIssue(&jira.Issue{Key: "EPIC-1"})
+
+	a.childrenEpoch = 1
+	_, _ = a.Update(childrenLoadedMsg{
+		key:   "EPIC-1",
+		err:   errors.New("network down"),
+		epoch: 1,
+	})
+
+	if a.statusPanel.ErrorMessage() == "" {
+		t.Error("StatusPanel error should be set on fetch failure")
+	}
+}
+
+func TestIssueSelectedMsg_OnSubTab_DispatchesChildrenRequest(t *testing.T) {
+	fake := &jiratest.FakeClient{T: t}
+	a := newAppWithFake(t, fake)
+	a.isCloud = true
+	a.infoPanel.SetCloud(true)
+
+	a.infoPanel.SetIssue(&jira.Issue{Key: "OLD"})
+	for a.infoPanel.ActiveTab() != views.InfoTabSubtasks {
+		a.infoPanel.NextTab()
+	}
+
+	_, cmd := a.Update(views.IssueSelectedMsg{Issue: &jira.Issue{Key: "EPIC-1"}})
+	if cmd == nil {
+		t.Fatal("expected batch cmd, got nil")
+	}
+
+	if !batchContainsChildrenRequest(cmd, "EPIC-1") {
+		t.Error("expected ChildrenRequestMsg{Key: EPIC-1} in cmd batch")
+	}
+}
+
+func TestIssueSelectedMsg_OnFieldsTab_NoChildrenRequest(t *testing.T) {
+	fake := &jiratest.FakeClient{T: t}
+	a := newAppWithFake(t, fake)
+	a.isCloud = true
+	a.infoPanel.SetCloud(true)
+	a.infoPanel.SetIssue(&jira.Issue{Key: "OLD"})
+
+	_, cmd := a.Update(views.IssueSelectedMsg{Issue: &jira.Issue{Key: "EPIC-1"}})
+	if batchContainsChildrenRequest(cmd, "EPIC-1") {
+		t.Error("Fields tab should not dispatch ChildrenRequestMsg")
+	}
+}
+
+func batchContainsChildrenRequest(cmd tea.Cmd, key string) bool {
+	if cmd == nil {
+		return false
+	}
+	msg := cmd()
+	if m, ok := msg.(views.ChildrenRequestMsg); ok && m.Key == key {
+		return true
+	}
+	if batch, ok := msg.(tea.BatchMsg); ok {
+		for _, sub := range batch {
+			if batchContainsChildrenRequest(sub, key) {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/pkg/tui/commands.go
+++ b/pkg/tui/commands.go
@@ -120,6 +120,16 @@ func fetchPreviewDetail(client jira.ClientInterface, key string, epoch int) tea.
 	})
 }
 
+// fetchChildren issues a Cloud GetChildren request and tags the response
+// with the caller's epoch so that stale responses can be dropped.
+// See App.childrenEpoch.
+func fetchChildren(client jira.ClientInterface, key string, epoch int) tea.Cmd {
+	return func() tea.Msg {
+		issues, err := client.GetChildren(context.Background(), key)
+		return childrenLoadedMsg{key: key, issues: issues, err: err, epoch: epoch}
+	}
+}
+
 func fetchProjects(client jira.ClientInterface) tea.Cmd {
 	return func() tea.Msg {
 		projects, err := client.GetProjects(context.Background())

--- a/pkg/tui/custom_commands.go
+++ b/pkg/tui/custom_commands.go
@@ -304,6 +304,7 @@ func (a *App) handleCustomCommandFinished(msg customCommandFinishedMsg) (tea.Mod
 	if msg.refresh {
 		if cur := a.currentIssue(); cur != nil {
 			delete(a.issueCache, cur.Key)
+			delete(a.childrenCache, cur.Key)
 			cmds = append(cmds, fetchIssueDetail(a.client, cur.Key))
 		}
 	}

--- a/pkg/tui/handlers.go
+++ b/pkg/tui/handlers.go
@@ -85,6 +85,7 @@ func (a *App) selectProject(p *jira.Project) tea.Cmd {
 	a.projectList.SetActiveKey(p.Key)
 	a.issuesList.InvalidateTabCache()
 	a.issueCache = make(map[string]*jira.Issue)
+	a.childrenCache = make(map[string][]jira.Issue)
 	a.createMetaCache = make(map[string][]jira.CreateMetaField)
 	a.infoPanel.SetIssue(nil)
 	a.resolveBoardID()

--- a/pkg/tui/handlers_data.go
+++ b/pkg/tui/handlers_data.go
@@ -407,6 +407,26 @@ func (a *App) prefetchRelated(issue *jira.Issue) tea.Cmd {
 	return batchPrefetch(a.client, keys)
 }
 
+// prefetchChildrenDetails warms issueCache for the given children so that
+// drilling into one from the Sub tab doesn't require a per-key fetch. Skips
+// keys that are already cached.
+func (a *App) prefetchChildrenDetails(children []jira.Issue) tea.Cmd {
+	var keys []string
+	for _, c := range children {
+		if c.Key == "" {
+			continue
+		}
+		if _, ok := a.issueCache[c.Key]; ok {
+			continue
+		}
+		keys = append(keys, c.Key)
+	}
+	if len(keys) == 0 {
+		return nil
+	}
+	return batchPrefetch(a.client, keys)
+}
+
 // handleBatchPrefetched caches all issues from a batch prefetch
 func (a *App) handleBatchPrefetched(msg batchPrefetchedMsg) (tea.Model, tea.Cmd) {
 	for i := range msg.issues {

--- a/pkg/tui/handlers_keys.go
+++ b/pkg/tui/handlers_keys.go
@@ -439,8 +439,14 @@ func (a *App) handleIssueAction(action Action) (tea.Model, tea.Cmd, bool) {
 	case ActRefresh:
 		if a.previewKey != "" {
 			delete(a.issueCache, a.previewKey)
+			delete(a.childrenCache, a.previewKey)
 			*a.logFlag = true
-			return a, fetchIssueDetail(a.client, a.previewKey), true
+			cmds := []tea.Cmd{fetchIssueDetail(a.client, a.previewKey)}
+			if a.isCloud {
+				key := a.previewKey
+				cmds = append(cmds, func() tea.Msg { return views.ChildrenRequestMsg{Key: key} })
+			}
+			return a, tea.Batch(cmds...), true
 		}
 		return a, nil, true
 

--- a/pkg/tui/handlers_keys.go
+++ b/pkg/tui/handlers_keys.go
@@ -313,7 +313,7 @@ func (a *App) handleTabAction(action Action) (tea.Model, tea.Cmd, bool) {
 			return a, a.previewSelectedIssue(), true
 		case a.side == sideLeft && a.leftFocus == focusInfo:
 			a.infoPanel.PrevTab()
-			return a, a.previewForInfoTab(), true
+			return a, tea.Batch(a.previewForInfoTab(), a.infoPanel.MaybeChildrenRequest()), true
 		}
 		return a, nil, true
 
@@ -329,7 +329,7 @@ func (a *App) handleTabAction(action Action) (tea.Model, tea.Cmd, bool) {
 			return a, a.previewSelectedIssue(), true
 		case a.side == sideLeft && a.leftFocus == focusInfo:
 			a.infoPanel.NextTab()
-			return a, a.previewForInfoTab(), true
+			return a, tea.Batch(a.previewForInfoTab(), a.infoPanel.MaybeChildrenRequest()), true
 		}
 		return a, nil, true
 

--- a/pkg/tui/mouse.go
+++ b/pkg/tui/mouse.go
@@ -167,9 +167,9 @@ func (a *App) mouseClick(panel panelID, relY int, x int) (tea.Model, tea.Cmd) {
 		a.updateFocusState()
 		if relY == 0 {
 			a.infoPanel.ClickTabAt(x)
-		} else {
-			a.infoPanel.ClickAt(relY)
+			return a, a.infoPanel.MaybeChildrenRequest()
 		}
+		a.infoPanel.ClickAt(relY)
 
 	case panelProjects:
 		a.side = sideLeft

--- a/pkg/tui/navigation.go
+++ b/pkg/tui/navigation.go
@@ -60,7 +60,7 @@ func (a *App) previewSelectedIssue() tea.Cmd {
 		a.detailView.SetIssue(sel)
 		a.infoPanel.SetIssue(sel)
 	}
-	return a.prefetchRelated(sel)
+	return tea.Batch(a.prefetchRelated(sel), a.infoPanel.MaybeChildrenRequest())
 }
 
 // previewForInfoTab refreshes the preview for the current InfoPanel tab, so

--- a/pkg/tui/refresh_test.go
+++ b/pkg/tui/refresh_test.go
@@ -25,6 +25,7 @@ func newAppWithFake(t *testing.T, fake *jiratest.FakeClient) *App {
 	a.statusPanel = views.NewStatusPanel("", "", "")
 	a.logPanel = views.NewLogPanel()
 	a.issueCache = map[string]*jira.Issue{}
+	a.childrenCache = map[string][]jira.Issue{}
 	return a
 }
 

--- a/pkg/tui/views/infopanel.go
+++ b/pkg/tui/views/infopanel.go
@@ -49,7 +49,6 @@ func (p *InfoPanel) SetIssue(issue *jira.Issue) {
 	if issue == nil || issue.Key != prevKey {
 		p.Cursor = 0
 		p.Offset = 0
-		p.activeTab = InfoTabFields
 	}
 	p.syncItemCount()
 }

--- a/pkg/tui/views/infopanel.go
+++ b/pkg/tui/views/infopanel.go
@@ -17,6 +17,12 @@ import (
 // different issue in the Sub or Lnk tab, requesting a detail preview fetch.
 type PreviewRequestMsg struct{ Key string }
 
+// ChildrenRequestMsg is dispatched when the Sub tab becomes active for a
+// Cloud issue and the children for its key have not been loaded yet. The
+// app handles it by calling jira.Client.GetChildren and feeding the result
+// back via InfoPanel.SetChildren / SetChildrenError.
+type ChildrenRequestMsg struct{ Key string }
+
 // InfoPanelTab identifies a tab within the Info panel
 type InfoPanelTab int
 
@@ -34,6 +40,19 @@ type InfoPanel struct {
 	activeTab       InfoPanelTab
 	theme           *theme.Theme
 	filteredIndices []int
+
+	// cloud toggles the Cloud parent-link Children path. When true, the
+	// Sub tab renders children loaded via SetChildren; when false, it
+	// falls back to issue.Subtasks.
+	cloud bool
+	// Children state for the Cloud path. childrenForKey identifies which
+	// issue's children currently sit in children. childrenLoaded is the
+	// "we have an answer" flag (an empty slice still counts as loaded).
+	// childrenError carries the last fetch error, if any.
+	childrenForKey string
+	children       []jira.Issue
+	childrenLoaded bool
+	childrenError  string
 }
 
 func NewInfoPanel() *InfoPanel {
@@ -49,8 +68,66 @@ func (p *InfoPanel) SetIssue(issue *jira.Issue) {
 	if issue == nil || issue.Key != prevKey {
 		p.Cursor = 0
 		p.Offset = 0
+		p.resetChildren()
 	}
 	p.syncItemCount()
+}
+
+// SetCloud toggles the Cloud parent-link Children rendering path.
+func (p *InfoPanel) SetCloud(cloud bool) { p.cloud = cloud }
+
+// SetChildren stores children for parentKey. If parentKey doesn't match the
+// currently displayed issue, the call is dropped (stale response).
+func (p *InfoPanel) SetChildren(parentKey string, issues []jira.Issue) {
+	if p.issue == nil || p.issue.Key != parentKey {
+		return
+	}
+	p.childrenForKey = parentKey
+	p.children = issues
+	p.childrenLoaded = true
+	p.childrenError = ""
+	p.syncItemCount()
+}
+
+// SetChildrenError records a fetch error for parentKey. Stale errors (key
+// mismatch) are dropped.
+func (p *InfoPanel) SetChildrenError(parentKey, msg string) {
+	if p.issue == nil || p.issue.Key != parentKey {
+		return
+	}
+	p.childrenForKey = parentKey
+	p.children = nil
+	p.childrenLoaded = false
+	p.childrenError = msg
+	p.syncItemCount()
+}
+
+// MaybeChildrenRequest returns a Cmd that emits ChildrenRequestMsg when the
+// Sub tab is active on a Cloud issue and the children have neither been
+// loaded nor failed for the current key. Returns nil otherwise.
+func (p *InfoPanel) MaybeChildrenRequest() tea.Cmd {
+	if !p.cloud || p.issue == nil {
+		return nil
+	}
+	if p.activeTab != InfoTabSubtasks {
+		return nil
+	}
+	if p.childrenForKey == p.issue.Key && (p.childrenLoaded || p.childrenError != "") {
+		return nil
+	}
+	key := p.issue.Key
+	return func() tea.Msg { return ChildrenRequestMsg{Key: key} }
+}
+
+// Children exposes the loaded Cloud children for tests and callers that need
+// the resolved sub-tab list.
+func (p *InfoPanel) Children() []jira.Issue { return p.children }
+
+func (p *InfoPanel) resetChildren() {
+	p.childrenForKey = ""
+	p.children = nil
+	p.childrenLoaded = false
+	p.childrenError = ""
 }
 
 // IssueKey returns the key of the currently displayed issue
@@ -151,10 +228,23 @@ func (p *InfoPanel) SelectedSubtaskKey() string {
 		return ""
 	}
 	idx := p.resolveOriginalIndex()
-	if idx >= 0 && idx < len(p.issue.Subtasks) {
-		return p.issue.Subtasks[idx].Key
+	subs := p.subtaskList()
+	if idx >= 0 && idx < len(subs) {
+		return subs[idx].Key
 	}
 	return ""
+}
+
+// subtaskList returns the list backing the Sub tab: Cloud children when
+// loaded, otherwise the legacy Subtasks slice.
+func (p *InfoPanel) subtaskList() []jira.Issue {
+	if p.cloud && p.childrenLoaded && p.childrenForKey != "" && p.issue != nil && p.childrenForKey == p.issue.Key {
+		return p.children
+	}
+	if p.issue == nil {
+		return nil
+	}
+	return p.issue.Subtasks
 }
 
 func (p *InfoPanel) ContentHeight() int {
@@ -217,7 +307,7 @@ func (p *InfoPanel) tabItemCount() int {
 		}
 		return count
 	case InfoTabSubtasks:
-		return len(p.issue.Subtasks)
+		return len(p.subtaskList())
 	}
 	return 0
 }
@@ -417,9 +507,22 @@ func (p *InfoPanel) renderLinkRowPairs(width int) (styled, plain []string) {
 }
 
 func (p *InfoPanel) renderSubtaskRowPairs(width int) (styled, plain []string) {
-	styled = make([]string, 0, len(p.issue.Subtasks))
-	plain = make([]string, 0, len(p.issue.Subtasks))
-	for _, sub := range p.issue.Subtasks {
+	subs := p.subtaskList()
+	if p.cloud && p.childrenForKey == p.issue.Key {
+		if p.childrenError != "" {
+			pl := " Failed to load children: " + p.childrenError
+			s := lipgloss.NewStyle().Foreground(theme.ColorRed).Render(pl)
+			return []string{components.TruncateEnd(s, width-1)}, []string{components.TruncateEnd(pl, width-1)}
+		}
+		if p.childrenLoaded && len(subs) == 0 {
+			pl := " No children"
+			s := lipgloss.NewStyle().Foreground(theme.ColorGray).Render(pl)
+			return []string{components.TruncateEnd(s, width-1)}, []string{components.TruncateEnd(pl, width-1)}
+		}
+	}
+	styled = make([]string, 0, len(subs))
+	plain = make([]string, 0, len(subs))
+	for _, sub := range subs {
 		emoji := statusEmoji(sub.Status)
 		emojiPlain := statusEmojiPlain(sub.Status)
 		s := fmt.Sprintf(" %s %s: %s", emoji, sub.Key, sub.Summary)

--- a/pkg/tui/views/infopanel.go
+++ b/pkg/tui/views/infopanel.go
@@ -53,7 +53,11 @@ type InfoPanel struct {
 	children       []jira.Issue
 	childrenLoaded bool
 	childrenError  string
+
+	typeIcons map[string]string
 }
+
+func (p *InfoPanel) SetTypeIcons(icons map[string]string) { p.typeIcons = icons }
 
 func NewInfoPanel() *InfoPanel {
 	return &InfoPanel{theme: theme.Default}
@@ -525,10 +529,21 @@ func (p *InfoPanel) renderSubtaskRowPairs(width int) (styled, plain []string) {
 	for _, sub := range subs {
 		emoji := statusEmoji(sub.Status)
 		emojiPlain := statusEmojiPlain(sub.Status)
-		s := fmt.Sprintf(" %s %s: %s", emoji, sub.Key, sub.Summary)
-		pl := fmt.Sprintf(" %s %s: %s", emojiPlain, sub.Key, sub.Summary)
+		marker := p.issueTypeMarker(sub.IssueType)
+		s := fmt.Sprintf(" %s %s%s: %s", emoji, marker, sub.Key, sub.Summary)
+		pl := fmt.Sprintf(" %s %s%s: %s", emojiPlain, marker, sub.Key, sub.Summary)
 		styled = append(styled, components.TruncateEnd(s, width-1))
 		plain = append(plain, components.TruncateEnd(pl, width-1))
 	}
 	return
+}
+
+func (p *InfoPanel) issueTypeMarker(t *jira.IssueType) string {
+	if t == nil || t.Name == "" {
+		return ""
+	}
+	if icon := typeIcon(p.typeIcons, t); icon != "" {
+		return icon + " "
+	}
+	return "[" + t.Name + "] "
 }

--- a/pkg/tui/views/infopanel_children_test.go
+++ b/pkg/tui/views/infopanel_children_test.go
@@ -1,0 +1,198 @@
+package views
+
+import (
+	"testing"
+
+	"github.com/textfuel/lazyjira/v2/pkg/jira"
+)
+
+// TestInfoPanel_RenderSubtaskRowPairs_FallbackToSubtasks pins the Server/DC
+// path: cloud=false → Sub tab uses issue.Subtasks even if SetChildren has
+// never been called.
+func TestInfoPanel_RenderSubtaskRowPairs_FallbackToSubtasks(t *testing.T) {
+	p := makeInfoPanelFocused()
+	issue := &jira.Issue{Key: "MAIN-1", Subtasks: []jira.Issue{{Key: "SUB-1", Summary: "s1"}}}
+	p.SetIssue(issue)
+	for p.activeTab != InfoTabSubtasks {
+		p.NextTab()
+	}
+
+	if got := p.tabItemCount(); got != 1 {
+		t.Errorf("Server/DC fallback: tabItemCount = %d, want 1 (issue.Subtasks)", got)
+	}
+	if got := p.SelectedSubtaskKey(); got != "SUB-1" {
+		t.Errorf("Server/DC fallback: SelectedSubtaskKey = %q, want SUB-1", got)
+	}
+}
+
+// TestInfoPanel_RenderSubtaskRowPairs_UsesChildrenSlice pins the Cloud path:
+// after SetChildren the Sub tab renders the children, ignoring Subtasks.
+func TestInfoPanel_RenderSubtaskRowPairs_UsesChildrenSlice(t *testing.T) {
+	p := makeInfoPanelFocused()
+	p.SetCloud(true)
+	issue := &jira.Issue{
+		Key:      "EPIC-1",
+		Subtasks: []jira.Issue{{Key: "OLD-SUB", Summary: "should not show"}},
+	}
+	p.SetIssue(issue)
+	p.SetChildren("EPIC-1", []jira.Issue{{Key: "CHILD-1", Summary: "first"}, {Key: "CHILD-2", Summary: "second"}})
+	for p.activeTab != InfoTabSubtasks {
+		p.NextTab()
+	}
+
+	if got := p.tabItemCount(); got != 2 {
+		t.Errorf("Cloud children: tabItemCount = %d, want 2", got)
+	}
+	if got := p.SelectedSubtaskKey(); got != "CHILD-1" {
+		t.Errorf("Cloud children: SelectedSubtaskKey = %q, want CHILD-1", got)
+	}
+}
+
+// TestInfoPanel_MaybeChildrenRequest_CloudFiresOnSubTab verifies the request
+// trigger: cloud + Sub tab + no children loaded → emits ChildrenRequestMsg.
+func TestInfoPanel_MaybeChildrenRequest_CloudFiresOnSubTab(t *testing.T) {
+	p := makeInfoPanelFocused()
+	p.SetCloud(true)
+	p.SetIssue(&jira.Issue{Key: "EPIC-1"})
+	for p.activeTab != InfoTabSubtasks {
+		p.NextTab()
+	}
+
+	cmd := p.MaybeChildrenRequest()
+	if cmd == nil {
+		t.Fatal("Cloud + SubTab + no children: expected non-nil Cmd")
+	}
+	msg := cmd()
+	req, ok := msg.(ChildrenRequestMsg)
+	if !ok {
+		t.Fatalf("expected ChildrenRequestMsg, got %T", msg)
+	}
+	if req.Key != "EPIC-1" {
+		t.Errorf("ChildrenRequestMsg.Key = %q, want EPIC-1", req.Key)
+	}
+}
+
+// TestInfoPanel_MaybeChildrenRequest_ServerDCNoFire pins the Server/DC path:
+// cloud=false → never emits ChildrenRequestMsg, even on Sub tab.
+func TestInfoPanel_MaybeChildrenRequest_ServerDCNoFire(t *testing.T) {
+	p := makeInfoPanelFocused()
+	p.SetIssue(&jira.Issue{Key: "EPIC-1"})
+	for p.activeTab != InfoTabSubtasks {
+		p.NextTab()
+	}
+
+	if cmd := p.MaybeChildrenRequest(); cmd != nil {
+		t.Errorf("Server/DC: expected nil Cmd, got non-nil")
+	}
+}
+
+// TestInfoPanel_MaybeChildrenRequest_NotOnFieldsTab pins that the request
+// only fires on the Sub tab, not on Fields/Links.
+func TestInfoPanel_MaybeChildrenRequest_NotOnFieldsTab(t *testing.T) {
+	p := makeInfoPanelFocused()
+	p.SetCloud(true)
+	p.SetIssue(&jira.Issue{Key: "EPIC-1"})
+	// activeTab defaults to InfoTabFields after SetIssue.
+
+	if cmd := p.MaybeChildrenRequest(); cmd != nil {
+		t.Errorf("Fields tab: expected nil Cmd, got non-nil")
+	}
+}
+
+// TestInfoPanel_MaybeChildrenRequest_AlreadyLoadedNoFire pins that once
+// children are loaded for the current key, no further request fires.
+func TestInfoPanel_MaybeChildrenRequest_AlreadyLoadedNoFire(t *testing.T) {
+	p := makeInfoPanelFocused()
+	p.SetCloud(true)
+	p.SetIssue(&jira.Issue{Key: "EPIC-1"})
+	p.SetChildren("EPIC-1", []jira.Issue{{Key: "C-1"}})
+	for p.activeTab != InfoTabSubtasks {
+		p.NextTab()
+	}
+
+	if cmd := p.MaybeChildrenRequest(); cmd != nil {
+		t.Errorf("Already-loaded: expected nil Cmd, got non-nil")
+	}
+}
+
+// TestInfoPanel_SetChildren_StaleKeyDropped pins the stale-drop invariant at
+// the panel boundary: a SetChildren call for a key other than the currently
+// displayed issue is ignored.
+func TestInfoPanel_SetChildren_StaleKeyDropped(t *testing.T) {
+	p := makeInfoPanelFocused()
+	p.SetCloud(true)
+	p.SetIssue(&jira.Issue{Key: "NEW-EPIC"})
+
+	p.SetChildren("OLD-EPIC", []jira.Issue{{Key: "STALE-CHILD"}})
+
+	if got := p.Children(); got != nil {
+		t.Errorf("Stale SetChildren: expected nil children, got %+v", got)
+	}
+}
+
+// TestInfoPanel_SetChildrenError_RendersErrorRow pins that fetch errors
+// surface as a single error row in the Sub tab.
+func TestInfoPanel_SetChildrenError_RendersErrorRow(t *testing.T) {
+	p := makeInfoPanelFocused()
+	p.SetCloud(true)
+	p.SetIssue(&jira.Issue{Key: "EPIC-1"})
+	p.SetChildrenError("EPIC-1", "boom")
+	for p.activeTab != InfoTabSubtasks {
+		p.NextTab()
+	}
+
+	_, plain := p.renderSubtaskRowPairs(40)
+	if len(plain) != 1 {
+		t.Fatalf("error path: expected 1 row, got %d (%v)", len(plain), plain)
+	}
+	if plain[0] == "" || plain[0][0:5] != " Fail" {
+		t.Errorf("error row content = %q, want prefix ' Fail'", plain[0])
+	}
+}
+
+// TestInfoPanel_EmptyChildren_RendersEmptyState pins the 0-children empty
+// state for the Cloud path.
+func TestInfoPanel_EmptyChildren_RendersEmptyState(t *testing.T) {
+	p := makeInfoPanelFocused()
+	p.SetCloud(true)
+	p.SetIssue(&jira.Issue{Key: "EPIC-1"})
+	p.SetChildren("EPIC-1", []jira.Issue{}) // empty but loaded
+	for p.activeTab != InfoTabSubtasks {
+		p.NextTab()
+	}
+
+	_, plain := p.renderSubtaskRowPairs(40)
+	if len(plain) != 1 {
+		t.Fatalf("empty state: expected 1 placeholder row, got %d (%v)", len(plain), plain)
+	}
+	if plain[0] != " No children" {
+		t.Errorf("empty row = %q, want %q", plain[0], " No children")
+	}
+}
+
+// TestInfoPanel_SetIssue_ResetsChildrenState pins that switching to a new
+// issue clears any previously loaded children — so MaybeChildrenRequest
+// fires again for the new key.
+func TestInfoPanel_SetIssue_ResetsChildrenState(t *testing.T) {
+	p := makeInfoPanelFocused()
+	p.SetCloud(true)
+	p.SetIssue(&jira.Issue{Key: "EPIC-1"})
+	p.SetChildren("EPIC-1", []jira.Issue{{Key: "C-1"}})
+
+	p.SetIssue(&jira.Issue{Key: "EPIC-2"})
+	for p.activeTab != InfoTabSubtasks {
+		p.NextTab()
+	}
+
+	if got := p.Children(); got != nil {
+		t.Errorf("after issue switch: expected nil children, got %+v", got)
+	}
+	cmd := p.MaybeChildrenRequest()
+	if cmd == nil {
+		t.Fatal("after issue switch: expected MaybeChildrenRequest to re-fire")
+	}
+	msg := cmd().(ChildrenRequestMsg)
+	if msg.Key != "EPIC-2" {
+		t.Errorf("re-fire key = %q, want EPIC-2", msg.Key)
+	}
+}

--- a/pkg/tui/views/infopanel_children_test.go
+++ b/pkg/tui/views/infopanel_children_test.go
@@ -1,6 +1,7 @@
 package views
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/textfuel/lazyjira/v2/pkg/jira"
@@ -194,5 +195,57 @@ func TestInfoPanel_SetIssue_ResetsChildrenState(t *testing.T) {
 	msg := cmd().(ChildrenRequestMsg)
 	if msg.Key != "EPIC-2" {
 		t.Errorf("re-fire key = %q, want EPIC-2", msg.Key)
+	}
+}
+
+func TestInfoPanel_RenderSubtaskRowPairs_PrependsIssueTypeMarker(t *testing.T) {
+	p := makeInfoPanelFocused()
+	p.SetCloud(true)
+	p.SetIssue(&jira.Issue{Key: "EPIC-1"})
+	p.SetChildren("EPIC-1", []jira.Issue{
+		{Key: "FOO-1", Summary: "with type", IssueType: &jira.IssueType{Name: "Story"}},
+		{Key: "FOO-2", Summary: "without type"},
+	})
+	for p.activeTab != InfoTabSubtasks {
+		p.NextTab()
+	}
+
+	_, plain := p.renderSubtaskRowPairs(80)
+	if len(plain) != 2 {
+		t.Fatalf("expected 2 rows, got %d", len(plain))
+	}
+	if !strings.Contains(plain[0], "[Story] FOO-1") {
+		t.Errorf("row 0 = %q, want containing %q", plain[0], "[Story] FOO-1")
+	}
+	if strings.Contains(plain[1], "[]") {
+		t.Errorf("row 1 = %q, must not contain empty marker %q", plain[1], "[]")
+	}
+	if !strings.Contains(plain[1], "FOO-2: without type") {
+		t.Errorf("row 1 = %q, want containing %q", plain[1], "FOO-2: without type")
+	}
+}
+
+func TestInfoPanel_RenderSubtaskRowPairs_TypeIconReplacesNameMarker(t *testing.T) {
+	p := makeInfoPanelFocused()
+	p.SetCloud(true)
+	p.SetTypeIcons(map[string]string{"Story": "📖", "Bug": "🐞"})
+	p.SetIssue(&jira.Issue{Key: "EPIC-1"})
+	p.SetChildren("EPIC-1", []jira.Issue{
+		{Key: "FOO-1", Summary: "story", IssueType: &jira.IssueType{Name: "Story"}},
+		{Key: "FOO-2", Summary: "task", IssueType: &jira.IssueType{Name: "Task"}},
+	})
+	for p.activeTab != InfoTabSubtasks {
+		p.NextTab()
+	}
+
+	_, plain := p.renderSubtaskRowPairs(80)
+	if !strings.Contains(plain[0], "📖 FOO-1") {
+		t.Errorf("row 0 = %q, want containing %q", plain[0], "📖 FOO-1")
+	}
+	if strings.Contains(plain[0], "[Story]") {
+		t.Errorf("row 0 = %q, must drop [Story] when icon configured", plain[0])
+	}
+	if !strings.Contains(plain[1], "[Task] FOO-2") {
+		t.Errorf("row 1 = %q, want fallback marker [Task] FOO-2", plain[1])
 	}
 }

--- a/pkg/tui/views/infopanel_test.go
+++ b/pkg/tui/views/infopanel_test.go
@@ -140,6 +140,85 @@ func TestInfoPanel_LnkTab_CursorMove_InwardLink(t *testing.T) {
 	}
 }
 
+func TestInfoPanel_SetIssue_PreservesActiveTab(t *testing.T) {
+	p := makeInfoPanelFocused()
+
+	issueA := &jira.Issue{
+		Key: "MAIN-1",
+		Subtasks: []jira.Issue{
+			{Key: "SUB-1", Summary: "first subtask"},
+			{Key: "SUB-2", Summary: "second subtask"},
+		},
+	}
+	p.SetIssue(issueA)
+
+	for p.activeTab != InfoTabSubtasks {
+		p.NextTab()
+	}
+
+	p.Update(pressJ())
+	if p.Cursor == 0 {
+		t.Fatalf("setup: expected cursor > 0 after nav, got 0")
+	}
+
+	issueB := &jira.Issue{
+		Key: "MAIN-2",
+		Subtasks: []jira.Issue{
+			{Key: "OTHER-1", Summary: "different subtask"},
+		},
+	}
+	p.SetIssue(issueB)
+
+	if p.ActiveTab() != InfoTabSubtasks {
+		t.Errorf("ActiveTab = %v, want InfoTabSubtasks", p.ActiveTab())
+	}
+	if p.Cursor != 0 {
+		t.Errorf("Cursor = %d, want 0", p.Cursor)
+	}
+	if p.Offset != 0 {
+		t.Errorf("Offset = %d, want 0", p.Offset)
+	}
+}
+
+func TestInfoPanel_SetIssue_SameKey_PreservesCursor(t *testing.T) {
+	p := makeInfoPanelFocused()
+
+	issue := &jira.Issue{
+		Key: "MAIN-1",
+		Subtasks: []jira.Issue{
+			{Key: "SUB-1", Summary: "first subtask"},
+			{Key: "SUB-2", Summary: "second subtask"},
+		},
+	}
+	p.SetIssue(issue)
+
+	for p.activeTab != InfoTabSubtasks {
+		p.NextTab()
+	}
+
+	p.Update(pressJ())
+	cursorBefore := p.Cursor
+	if cursorBefore == 0 {
+		t.Fatalf("setup: expected cursor > 0 after nav, got 0")
+	}
+
+	refreshed := &jira.Issue{
+		Key: "MAIN-1",
+		Subtasks: []jira.Issue{
+			{Key: "SUB-1", Summary: "first subtask"},
+			{Key: "SUB-2", Summary: "second subtask"},
+		},
+	}
+	p.SetIssue(refreshed)
+
+	if p.Cursor != cursorBefore {
+		t.Errorf("Cursor = %d, want %d", p.Cursor, cursorBefore)
+	}
+	if p.ActiveTab() != InfoTabSubtasks {
+		t.Errorf("ActiveTab = %v, want InfoTabSubtasks", p.ActiveTab())
+	}
+}
+
 // TestInfoPanel_FieldsTab_CursorMove_NoPreviewRequestMsg verifies that cursor
 // movement in the Fields tab does NOT dispatch PreviewRequestMsg.
 func TestInfoPanel_FieldsTab_CursorMove_NoPreviewRequestMsg(t *testing.T) {

--- a/pkg/tui/views/status.go
+++ b/pkg/tui/views/status.go
@@ -34,6 +34,7 @@ func NewStatusPanel(project, user, host string) *StatusPanel {
 func (s *StatusPanel) SetProject(project string) { s.project = project }
 func (s *StatusPanel) SetOnline(online bool)     { s.online = online }
 func (s *StatusPanel) SetError(err string)       { s.errText = err }
+func (s *StatusPanel) ErrorMessage() string      { return s.errText }
 func (s *StatusPanel) SetSize(w, h int)          { s.width = w; s.height = h }
 func (s *StatusPanel) SetFocused(focused bool)   { s.focused = focused }
 


### PR DESCRIPTION
Closes #65

On Cloud, the Sub tab is now sourced from `parent = <KEY>`
instead of `Issue.Subtasks`. Epics show their Stories (and any
other parent-link children that don't surface as classic
subtasks). Stories with subtasks render the same as before. DC
is untouched: `GetChildren` is a no-op there and the tab keeps
reading `Issue.Subtasks`. The DC equivalent (`"Epic Link" = KEY`)
is left for a follow-up since I can't test it.

Two changes that ride along:

- Sub rows now show the issue type. Children can be any type the
  user has configured in their Jira instance (Story, Bug, ...),
  so the bare key isn't enough to tell what you're looking at.
- The active info tab persists across issue selection. Lets you
  skim through Epics with the Sub tab open to scan their
  children.

Notes:

- `App.childrenEpoch` mirrors the existing `previewEpoch` pattern
  for dropping stale responses on rapid selection.
- `InfoPanel.MaybeChildrenRequest` is the gating: fetch only when
  Sub is active and the current key is neither loaded nor errored.
- Children cached per parent key for the session; child detail is
  prefetched after the list arrives so Enter is instant.