### PR TITLE
Reach parents and children from the task list

### DIFF
--- a/pkg/tui/app.go
+++ b/pkg/tui/app.go
@@ -197,10 +197,7 @@ type App struct {
 	// fetches. Bumped on every ChildrenRequestMsg; responses with stale
 	// epoch are dropped.
 	childrenEpoch int
-	// pendingWalkKey is the issue the user is waiting to walk into
-	// while a Cloud children-fetch is in flight. Empty when no walk
-	// is pending.
-	pendingWalkKey string
+	pendingWalk pendingWalk
 	createCtx  createCtx
 
 	gitRepoPath    string
@@ -632,6 +629,14 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		a.childrenEpoch++
 		return a, fetchChildren(a.client, msg.Key, a.childrenEpoch)
+
+	case childrenWalkRequestMsg:
+		if !a.isCloud || msg.key == "" {
+			return a, nil
+		}
+		a.childrenEpoch++
+		a.pendingWalk = pendingWalk{key: msg.key, epoch: a.childrenEpoch}
+		return a, fetchChildren(a.client, msg.key, a.childrenEpoch)
 
 	case childrenLoadedMsg:
 		return a.handleChildrenLoaded(msg)

--- a/pkg/tui/app.go
+++ b/pkg/tui/app.go
@@ -11,6 +11,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 
+	"github.com/textfuel/lazyjira/v2/pkg/tui/navstack"
 	"github.com/textfuel/lazyjira/v2/pkg/config"
 	"github.com/textfuel/lazyjira/v2/pkg/git"
 	"github.com/textfuel/lazyjira/v2/pkg/jira"
@@ -187,11 +188,20 @@ type App struct {
 	// is how we simulate "cancel the previous intent", which bubbletea
 	// does not provide natively for tea.Cmd.
 	previewEpoch int
+	// parentEpoch is bumped on every showParent invocation. fetchParent
+	// responses carry the epoch of the intent that spawned them; the
+	// parentLoadedMsg handler drops anything whose epoch no longer
+	// matches. Same staleness-cancellation pattern as previewEpoch.
+	parentEpoch int
 	// childrenEpoch is the analogous counter for Cloud Sub-tab GetChildren
 	// fetches. Bumped on every ChildrenRequestMsg; responses with stale
 	// epoch are dropped.
 	childrenEpoch int
-	createCtx     createCtx
+	// pendingWalkKey is the issue the user is waiting to walk into
+	// while a Cloud children-fetch is in flight. Empty when no walk
+	// is pending.
+	pendingWalkKey string
+	createCtx  createCtx
 
 	gitRepoPath    string
 	gitBranch      string
@@ -576,22 +586,29 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if msg.Issue == nil {
 			return a, nil
 		}
-		a.previewKey = msg.Issue.Key
 		if cached, ok := a.issueCache[msg.Issue.Key]; ok {
-			a.detailView.SetIssue(cached)
 			a.infoPanel.SetIssue(cached)
 		} else {
-			a.detailView.SetIssue(msg.Issue)
 			a.infoPanel.SetIssue(msg.Issue)
 		}
-		return a, tea.Batch(a.prefetchRelated(msg.Issue), a.infoPanel.MaybeChildrenRequest())
+		_, previewCmd := a.Update(views.PreviewRequestMsg{Key: msg.Issue.Key})
+		return a, tea.Batch(previewCmd, a.prefetchRelated(msg.Issue), a.infoPanel.MaybeChildrenRequest())
 
 	case views.PreviewRequestMsg:
 		a.previewKey = msg.Key
 		a.previewEpoch++
+		sel := a.issuesList.SelectedIssue()
+		mainListMatches := sel != nil && sel.Key == msg.Key
 		if cached, ok := a.issueCache[msg.Key]; ok && cached != nil {
 			a.detailView.UpdateIssueData(cached)
+			if mainListMatches {
+				a.infoPanel.SetIssue(cached)
+			}
 			return a, nil
+		}
+		if mainListMatches {
+			a.detailView.SetIssue(sel)
+			a.infoPanel.SetIssue(sel)
 		}
 		epoch := a.previewEpoch
 		key := msg.Key
@@ -617,17 +634,17 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return a, fetchChildren(a.client, msg.Key, a.childrenEpoch)
 
 	case childrenLoadedMsg:
-		if msg.epoch != a.childrenEpoch {
+		return a.handleChildrenLoaded(msg)
+
+	case parentLoadedMsg:
+		if msg.epoch != a.parentEpoch {
 			return a, nil
 		}
-		if msg.err != nil {
-			a.statusPanel.SetError("Failed to load children: " + msg.err.Error())
-			a.infoPanel.SetChildrenError(msg.key, msg.err.Error())
+		if msg.err != nil || msg.parent == nil {
 			return a, nil
 		}
-		a.childrenCache[msg.key] = msg.issues
-		a.infoPanel.SetChildren(msg.key, msg.issues)
-		return a, a.prefetchChildrenDetails(msg.issues)
+		a.pushNav("Parent", msg.parent.Key, navstack.SourceParent, []jira.Issue{*msg.parent})
+		return a, a.previewAfterNav()
 
 	case previewDetailLoadedMsg:
 		if msg.epoch != a.previewEpoch {

--- a/pkg/tui/handlers.go
+++ b/pkg/tui/handlers.go
@@ -87,6 +87,7 @@ func (a *App) selectProject(p *jira.Project) tea.Cmd {
 	a.issueCache = make(map[string]*jira.Issue)
 	a.childrenCache = make(map[string][]jira.Issue)
 	a.createMetaCache = make(map[string][]jira.CreateMetaField)
+	a.invalidateInFlight()
 	a.infoPanel.SetIssue(nil)
 	a.resolveBoardID()
 	if !a.demoMode {

--- a/pkg/tui/handlers_data.go
+++ b/pkg/tui/handlers_data.go
@@ -222,6 +222,13 @@ func (a *App) handleBoardsLoaded(msg boardsLoadedMsg) (tea.Model, tea.Cmd) {
 	return a, nil
 }
 
+func (a *App) invalidateInFlight() {
+	a.parentEpoch++
+	a.childrenEpoch++
+	a.previewEpoch++
+	a.pendingWalk = pendingWalk{}
+}
+
 func (a *App) resolveBoardID() {
 	a.boardID = 0
 	for _, b := range a.boards {
@@ -683,8 +690,10 @@ func (a *App) buildCreateFields(meta []jira.CreateMetaField) []components.Create
 	return fields
 }
 
-const schemaArray = "array"
-const schemaUser = "user"
+const (
+	schemaArray = "array"
+	schemaUser  = "user"
+)
 
 // metaToFormField converts one CreateMetaField to CreateFormField
 func (a *App) metaToFormField(mf jira.CreateMetaField) components.CreateFormField {

--- a/pkg/tui/handlers_keys.go
+++ b/pkg/tui/handlers_keys.go
@@ -27,6 +27,14 @@ func (a *App) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 	action := a.keymap.Match(msg.String())
 
+	// In the hierarchy tab, ActFocusLeft pops a NavFrame instead of
+	// shifting focus.
+	if action == ActFocusLeft {
+		if cmd, ok := a.goBack(); ok {
+			return a, cmd
+		}
+	}
+
 	switch action { //nolint:exhaustive
 	case ActQuit:
 		return a, tea.Quit
@@ -49,6 +57,11 @@ func (a *App) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return a.handleActionEdit()
 	case ActCreateBranch:
 		return a.handleActionCreateBranch()
+	case ActShowParent:
+		if cmd, ok := a.showParent(); ok {
+			return a, cmd
+		}
+		return a, nil
 	}
 
 	if m, cmd, ok := a.handleFocusAction(action); ok {
@@ -485,6 +498,9 @@ func (a *App) startCreateIssue() (tea.Model, tea.Cmd) {
 }
 
 func (a *App) handleActionSelect() (tea.Model, tea.Cmd) {
+	if cmd, ok := a.showChildren(); ok {
+		return a, cmd
+	}
 	switch {
 	case a.side == sideLeft && a.leftFocus == focusIssues:
 		return a.openIssueDetail()

--- a/pkg/tui/hierarchy.go
+++ b/pkg/tui/hierarchy.go
@@ -1,0 +1,227 @@
+package tui
+
+import (
+	"context"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/textfuel/lazyjira/v2/pkg/jira"
+	"github.com/textfuel/lazyjira/v2/pkg/tui/navstack"
+	"github.com/textfuel/lazyjira/v2/pkg/tui/views"
+)
+
+type parentLoadedMsg struct {
+	childKey string
+	parent   *jira.Issue
+	epoch    int
+	err      error
+}
+
+func fetchParent(client jira.ClientInterface, childKey, parentKey string, epoch int) tea.Cmd {
+	return func() tea.Msg {
+		iss, err := client.GetIssue(context.Background(), parentKey)
+		return parentLoadedMsg{childKey: childKey, parent: iss, epoch: epoch, err: err}
+	}
+}
+
+// Returns handled=false to fall through to the caller's default Enter behavior.
+func (a *App) showChildren() (tea.Cmd, bool) {
+	if a.side != sideLeft {
+		return nil, false
+	}
+	switch a.leftFocus { //nolint:exhaustive
+	case focusIssues:
+		return a.showChildrenFromList()
+	case focusInfo:
+		return a.showFromInfoPanel()
+	}
+	return nil, false
+}
+
+func (a *App) showChildrenFromList() (tea.Cmd, bool) {
+	sel := a.issuesList.SelectedIssue()
+	if sel == nil {
+		return nil, false
+	}
+	children, resolved := a.childrenForList(sel)
+	if !resolved {
+		a.pendingWalkKey = sel.Key
+		return func() tea.Msg { return views.ChildrenRequestMsg{Key: sel.Key} }, true
+	}
+	if len(children) == 0 {
+		return nil, false
+	}
+	a.pushNav("Children", sel.Key, navstack.SourceFromList, children)
+	return a.previewAfterNav(), true
+}
+
+// childrenForList returns the children to walk into and a flag
+// indicating whether the answer is known synchronously. Cloud cache
+// miss returns (nil, false) — caller is expected to dispatch an async
+// fetch.
+func (a *App) childrenForList(sel *jira.Issue) ([]jira.Issue, bool) {
+	if a.isCloud {
+		cached, ok := a.childrenCache[sel.Key]
+		return cached, ok
+	}
+	return sel.Subtasks, true
+}
+
+func (a *App) showFromInfoPanel() (tea.Cmd, bool) {
+	var picked *jira.Issue
+	var title string
+	var src navstack.Source
+	switch a.infoPanel.ActiveTab() {
+	case views.InfoTabSubtasks:
+		picked = a.infoPanel.SelectedSubtaskIssue()
+		title = "Children"
+		src = navstack.SourceFromInfoSub
+	case views.InfoTabLinks:
+		picked = a.infoPanel.SelectedLinkIssue()
+		title = "Link"
+		src = navstack.SourceFromInfoLink
+	default:
+		return nil, false
+	}
+	if picked == nil || picked.Key == "" {
+		return nil, false
+	}
+	// Prefer a fully-loaded cache entry over the InfoPanel stub so the
+	// hierarchy row carries summary/status etc. immediately.
+	entry := *picked
+	if cached, ok := a.issueCache[picked.Key]; ok && cached != nil {
+		entry = *cached
+	}
+	a.pushNav(title, picked.Key, src, []jira.Issue{entry})
+	return a.previewAfterNav(), true
+}
+
+func (a *App) handleChildrenLoaded(msg childrenLoadedMsg) (tea.Model, tea.Cmd) {
+	if msg.epoch != a.childrenEpoch {
+		return a, nil
+	}
+	walkPending := a.pendingWalkKey == msg.key
+	a.pendingWalkKey = ""
+
+	if msg.err != nil {
+		a.statusPanel.SetError("Failed to load children: " + msg.err.Error())
+		a.infoPanel.SetChildrenError(msg.key, msg.err.Error())
+		return a, nil
+	}
+	a.childrenCache[msg.key] = msg.issues
+	a.infoPanel.SetChildren(msg.key, msg.issues)
+	cmds := []tea.Cmd{a.prefetchChildrenDetails(msg.issues)}
+	if walkPending {
+		if len(msg.issues) == 0 {
+			_, openCmd := a.openIssueDetail()
+			cmds = append(cmds, openCmd)
+		} else {
+			a.pushNav("Children", msg.key, navstack.SourceFromList, msg.issues)
+			cmds = append(cmds, a.previewAfterNav())
+		}
+	}
+	return a, tea.Batch(cmds...)
+}
+
+func (a *App) previewAfterNav() tea.Cmd {
+	sel := a.issuesList.SelectedIssue()
+	if sel == nil {
+		return nil
+	}
+	key := sel.Key
+	return func() tea.Msg {
+		return views.PreviewRequestMsg{Key: key}
+	}
+}
+
+// Returns (cmd, true) on async parent fetch; the hierarchy tab is only
+// pushed when the resulting parentLoadedMsg is dispatched.
+func (a *App) showParent() (tea.Cmd, bool) {
+	sel := a.currentIssue()
+	if sel == nil || sel.Parent == nil || sel.Parent.Key == "" {
+		return nil, false
+	}
+	a.parentEpoch++
+	return fetchParent(a.client, sel.Key, sel.Parent.Key, a.parentEpoch), true
+}
+
+func (a *App) pushNav(title, parentKey string, src navstack.Source, issues []jira.Issue) {
+	frame := navstack.NavFrame{
+		Issues:       a.issuesList.CurrentIssues(),
+		SelectedIdx:  a.issuesList.Cursor,
+		FocusPanel:   navstack.FocusPanel(a.leftFocus),
+		InfoTab:      int(a.infoPanel.ActiveTab()),
+		InfoCursor:   a.infoPanel.Cursor,
+		Source:       src,
+		ParentKey:    parentKey,
+		OriginTabIdx: a.issuesList.GetTabIndex(),
+	}
+
+	idx := a.issuesList.AddHierarchyTab(title, issues)
+	stack := a.issuesList.HierarchyStack()
+	if stack == nil {
+		a.leftFocus = focusIssues
+		a.updateFocusState()
+		return
+	}
+
+	stack.Push(frame)
+	a.issuesList.SetTabIndex(idx)
+	a.leftFocus = focusIssues
+	a.updateFocusState()
+}
+
+// Pops the top NavFrame and restores it; removes the hierarchy tab when the stack empties.
+func (a *App) goBack() (tea.Cmd, bool) {
+	if a.side != sideLeft || !a.issuesList.IsHierarchyTab() {
+		return nil, false
+	}
+	stack := a.issuesList.HierarchyStack()
+	if stack == nil || stack.Depth() == 0 {
+		return nil, false
+	}
+	popped := stack.Pop()
+	a.restoreFromFrame(popped, stack)
+	return nil, true
+}
+
+// Empty stack closes the hierarchy tab; otherwise the tab is rewritten
+// from the new top's Source. The InfoPanel is rehydrated synchronously
+// so the snapshot's active tab survives — the async PreviewRequestMsg
+// path would let SetIssue reset it to InfoTabFields.
+func (a *App) restoreFromFrame(popped navstack.NavFrame, stack *navstack.NavStack) {
+	if stack.Depth() == 0 {
+		a.issuesList.RemoveHierarchyTab()
+		a.issuesList.SetTabIndex(popped.OriginTabIdx)
+	} else {
+		newTopTitle := titleForNavSource(stack.Peek().Source)
+		a.issuesList.ReplaceHierarchyTabContent(newTopTitle, popped.Issues)
+	}
+	a.issuesList.Cursor = popped.SelectedIdx
+	if sel := a.issuesList.SelectedIssue(); sel != nil {
+		a.previewKey = sel.Key
+		issue := sel
+		if cached, ok := a.issueCache[sel.Key]; ok && cached != nil {
+			issue = cached
+		}
+		a.infoPanel.SetIssue(issue)
+		a.detailView.SetIssue(issue)
+	}
+	a.infoPanel.SetActiveTab(views.InfoPanelTab(popped.InfoTab))
+	a.infoPanel.Cursor = popped.InfoCursor
+	a.leftFocus = focusPanel(popped.FocusPanel)
+	a.updateFocusState()
+}
+
+// Avoids storing a title in each NavFrame.
+func titleForNavSource(src navstack.Source) string {
+	switch src {
+	case navstack.SourceParent:
+		return "Parent"
+	case navstack.SourceFromInfoLink:
+		return "Link"
+	case navstack.SourceFromList, navstack.SourceFromInfoSub:
+		return "Children"
+	}
+	return ""
+}

--- a/pkg/tui/hierarchy.go
+++ b/pkg/tui/hierarchy.go
@@ -17,6 +17,17 @@ type parentLoadedMsg struct {
 	err      error
 }
 
+// childrenWalkRequestMsg triggers a children fetch and asks the
+// handler to push a hierarchy frame once the response arrives.
+type childrenWalkRequestMsg struct{ key string }
+
+// pendingWalk binds a walk to one specific children fetch via its
+// epoch; a later bump implicitly invalidates the walk.
+type pendingWalk struct {
+	key   string
+	epoch int
+}
+
 func fetchParent(client jira.ClientInterface, childKey, parentKey string, epoch int) tea.Cmd {
 	return func() tea.Msg {
 		iss, err := client.GetIssue(context.Background(), parentKey)
@@ -45,8 +56,7 @@ func (a *App) showChildrenFromList() (tea.Cmd, bool) {
 	}
 	children, resolved := a.childrenForList(sel)
 	if !resolved {
-		a.pendingWalkKey = sel.Key
-		return func() tea.Msg { return views.ChildrenRequestMsg{Key: sel.Key} }, true
+		return func() tea.Msg { return childrenWalkRequestMsg{key: sel.Key} }, true
 	}
 	if len(children) == 0 {
 		return nil, false
@@ -100,8 +110,8 @@ func (a *App) handleChildrenLoaded(msg childrenLoadedMsg) (tea.Model, tea.Cmd) {
 	if msg.epoch != a.childrenEpoch {
 		return a, nil
 	}
-	walkPending := a.pendingWalkKey == msg.key
-	a.pendingWalkKey = ""
+	walkPending := a.pendingWalk.key == msg.key && a.pendingWalk.epoch == msg.epoch
+	a.pendingWalk = pendingWalk{}
 
 	if msg.err != nil {
 		a.statusPanel.SetError("Failed to load children: " + msg.err.Error())

--- a/pkg/tui/hierarchy.go
+++ b/pkg/tui/hierarchy.go
@@ -183,7 +183,7 @@ func (a *App) pushNav(title, parentKey string, src navstack.Source, issues []jir
 
 // Pops the top NavFrame and restores it; removes the hierarchy tab when the stack empties.
 func (a *App) goBack() (tea.Cmd, bool) {
-	if a.side != sideLeft || !a.issuesList.IsHierarchyTab() {
+	if a.side != sideLeft || a.leftFocus != focusIssues || !a.issuesList.IsHierarchyTab() {
 		return nil, false
 	}
 	stack := a.issuesList.HierarchyStack()

--- a/pkg/tui/hierarchy_test.go
+++ b/pkg/tui/hierarchy_test.go
@@ -303,9 +303,9 @@ func TestHierarchy_Cloud_ChildrenWalk_CacheHit_PushesImmediately(t *testing.T) {
 	}
 }
 
-// On Cloud, a cache miss dispatches a ChildrenRequestMsg and marks
-// pendingWalkKey; the eventual childrenLoadedMsg pushes the hierarchy
-// frame and primes the cache.
+// On Cloud, a cache miss dispatches a childrenWalkRequestMsg whose
+// handler tags pendingWalk with the active childrenEpoch; the eventual
+// childrenLoadedMsg pushes the hierarchy frame and primes the cache.
 func TestHierarchy_Cloud_ChildrenWalk_CacheMiss_FetchesThenPushes(t *testing.T) {
 	fake := &jiratest.FakeClient{T: t}
 	fake.GetChildrenFunc = func(_ context.Context, parentKey string) ([]jira.Issue, error) {
@@ -320,19 +320,19 @@ func TestHierarchy_Cloud_ChildrenWalk_CacheMiss_FetchesThenPushes(t *testing.T) 
 		t.Fatalf("showChildren() handled = false, want true")
 	}
 	if cmd == nil {
-		t.Fatalf("showChildren() cmd = nil, want ChildrenRequestMsg cmd")
-	}
-	if a.pendingWalkKey != "EPIC-1" {
-		t.Errorf("pendingWalkKey = %q, want EPIC-1", a.pendingWalkKey)
+		t.Fatalf("showChildren() cmd = nil, want childrenWalkRequestMsg cmd")
 	}
 
-	req, ok := cmd().(views.ChildrenRequestMsg)
+	req, ok := cmd().(childrenWalkRequestMsg)
 	if !ok {
-		t.Fatalf("cmd produced %T, want views.ChildrenRequestMsg", cmd())
+		t.Fatalf("cmd produced %T, want childrenWalkRequestMsg", cmd())
 	}
 	_, fetchCmd := a.Update(req)
 	if fetchCmd == nil {
-		t.Fatalf("ChildrenRequestMsg produced nil cmd, want fetch cmd")
+		t.Fatalf("childrenWalkRequestMsg produced nil cmd, want fetch cmd")
+	}
+	if a.pendingWalk.key != "EPIC-1" || a.pendingWalk.epoch != a.childrenEpoch {
+		t.Errorf("pendingWalk = %+v, want {EPIC-1, %d}", a.pendingWalk, a.childrenEpoch)
 	}
 
 	loaded, ok := fetchCmd().(childrenLoadedMsg)
@@ -350,8 +350,8 @@ func TestHierarchy_Cloud_ChildrenWalk_CacheMiss_FetchesThenPushes(t *testing.T) 
 	if cached, ok := a.childrenCache["EPIC-1"]; !ok || len(cached) != 1 {
 		t.Errorf("childrenCache[EPIC-1] = %+v, want 1 entry", cached)
 	}
-	if a.pendingWalkKey != "" {
-		t.Errorf("pendingWalkKey = %q, want \"\" after consume", a.pendingWalkKey)
+	if a.pendingWalk != (pendingWalk{}) {
+		t.Errorf("pendingWalk = %+v, want zero after consume", a.pendingWalk)
 	}
 }
 
@@ -368,7 +368,7 @@ func TestHierarchy_Cloud_ChildrenWalk_EmptyResult_OpensDetail(t *testing.T) {
 	a.issuesList.SetIssues([]jira.Issue{{Key: "EPIC-1"}})
 
 	cmd, _ := a.showChildren()
-	req := cmd().(views.ChildrenRequestMsg)
+	req := cmd().(childrenWalkRequestMsg)
 	_, fetchCmd := a.Update(req)
 	loaded := fetchCmd().(childrenLoadedMsg)
 	_, _ = a.Update(loaded)
@@ -379,11 +379,70 @@ func TestHierarchy_Cloud_ChildrenWalk_EmptyResult_OpensDetail(t *testing.T) {
 	if a.side != sideRight {
 		t.Errorf("side = %v, want sideRight (detail opened)", a.side)
 	}
-	if a.pendingWalkKey != "" {
-		t.Errorf("pendingWalkKey = %q, want \"\" after consume", a.pendingWalkKey)
+	if a.pendingWalk != (pendingWalk{}) {
+		t.Errorf("pendingWalk = %+v, want zero after consume", a.pendingWalk)
 	}
 }
 
+// A passive Sub-tab fetch for the same key as an in-flight walk
+// must not be treated as a walk when its response arrives.
+func TestHierarchy_Cloud_ChildrenWalk_NoLeakIntoPassiveFetchSameKey(t *testing.T) {
+	fake := &jiratest.FakeClient{T: t}
+	fake.GetChildrenFunc = func(_ context.Context, _ string) ([]jira.Issue, error) {
+		return []jira.Issue{{Key: "C-1"}}, nil
+	}
+	a := newAppWithFake(t, fake)
+	a.isCloud = true
+	a.issuesList.SetIssues([]jira.Issue{{Key: "X"}})
+
+	cmd, _ := a.showChildren()
+	req := cmd().(childrenWalkRequestMsg)
+	_, fetch1 := a.Update(req)
+	loaded1 := fetch1().(childrenLoadedMsg)
+
+	_, fetch2 := a.Update(views.ChildrenRequestMsg{Key: "X"})
+	loaded2 := fetch2().(childrenLoadedMsg)
+
+	_, _ = a.Update(loaded1)
+	if a.issuesList.HasHierarchyTab() {
+		t.Errorf("stale walk response pushed a hierarchy tab")
+	}
+
+	_, _ = a.Update(loaded2)
+	if a.issuesList.HasHierarchyTab() {
+		t.Errorf("passive response for same key was treated as walk (leak)")
+	}
+}
+
+// Project switch invalidates an in-flight walk; its stale response
+// must not push a hierarchy frame on the new project.
+func TestHierarchy_Cloud_SelectProject_InvalidatesInFlightWalk(t *testing.T) {
+	fake := &jiratest.FakeClient{T: t}
+	fake.GetChildrenFunc = func(_ context.Context, _ string) ([]jira.Issue, error) {
+		return []jira.Issue{{Key: "C-1"}}, nil
+	}
+	a := newAppWithFake(t, fake)
+	a.isCloud = true
+	a.demoMode = true
+	a.usersCache = map[string][]jira.User{"OLD": nil, "NEW": nil}
+	a.issuesList.SetIssues([]jira.Issue{{Key: "EPIC-1"}})
+
+	cmd, _ := a.showChildren()
+	req := cmd().(childrenWalkRequestMsg)
+	_, fetchCmd := a.Update(req)
+	loaded := fetchCmd().(childrenLoadedMsg)
+
+	_ = a.selectProject(&jira.Project{ID: "2", Key: "NEW"})
+
+	if a.pendingWalk != (pendingWalk{}) {
+		t.Fatalf("selectProject left pendingWalk = %+v", a.pendingWalk)
+	}
+
+	_, _ = a.Update(loaded)
+	if a.issuesList.HasHierarchyTab() {
+		t.Errorf("stale walk response after project switch pushed a hierarchy tab")
+	}
+}
 
 func TestHierarchy_Backspace_PushesEvenWhenTopMatches(t *testing.T) {
 	fake := &jiratest.FakeClient{T: t}

--- a/pkg/tui/hierarchy_test.go
+++ b/pkg/tui/hierarchy_test.go
@@ -1,0 +1,766 @@
+package tui
+
+import (
+	"context"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/textfuel/lazyjira/v2/pkg/config"
+	"github.com/textfuel/lazyjira/v2/pkg/jira"
+	"github.com/textfuel/lazyjira/v2/pkg/jira/jiratest"
+	"github.com/textfuel/lazyjira/v2/pkg/tui/components"
+	"github.com/textfuel/lazyjira/v2/pkg/tui/navstack"
+	"github.com/textfuel/lazyjira/v2/pkg/tui/views"
+)
+
+const hierarchyTitleChildren = "Children"
+
+// Enter on issue with Subtasks creates hierarchy tab populated
+// from the in-memory Subtasks slice; no API call.
+func TestHierarchy_EnterWithSubtasks_CreatesHierarchyTab(t *testing.T) {
+	fake := &jiratest.FakeClient{T: t}
+	a := newAppWithFake(t, fake)
+
+	parent := jira.Issue{
+		Key: "PARENT-1",
+		Subtasks: []jira.Issue{
+			{Key: "SUB-1", Summary: "first"},
+			{Key: "SUB-2", Summary: "second"},
+		},
+	}
+	a.issuesList.SetIssues([]jira.Issue{parent})
+
+	_, handled := a.showChildren()
+	if !handled {
+		t.Fatalf("showChildren() handled = false, want true (subtasks present)")
+	}
+	if !a.issuesList.HasHierarchyTab() {
+		t.Fatalf("HasHierarchyTab() = false after showChildren")
+	}
+	if got := a.issuesList.HierarchyTitle(); got != hierarchyTitleChildren {
+		t.Errorf("HierarchyTitle() = %q, want %q", got, hierarchyTitleChildren)
+	}
+	if sel := a.issuesList.SelectedIssue(); sel == nil || sel.Key != "SUB-1" {
+		t.Errorf("SelectedIssue() = %+v, want SUB-1", sel)
+	}
+	if d := a.issuesList.HierarchyStack().Depth(); d != 1 {
+		t.Errorf("HierarchyStack.Depth() = %d, want 1", d)
+	}
+	if len(fake.SearchIssuesCalls) != 0 {
+		t.Errorf("SearchIssues called %d times, want 0 (Subtasks path)", len(fake.SearchIssuesCalls))
+	}
+}
+
+// Enter on leaf issue (no Subtasks) does not create a hierarchy tab;
+// handleActionSelect falls through to openIssueDetail which focuses the
+// right side. SearchIssues is never called (lookup is sync via
+// Issue.Subtasks only).
+func TestHierarchy_EnterWithoutChildren_FocusesDetail(t *testing.T) {
+	fake := &jiratest.FakeClient{T: t}
+	a := newAppWithFake(t, fake)
+	a.issuesList.SetIssues([]jira.Issue{{Key: "LEAF-1"}})
+
+	_, _ = a.handleActionSelect()
+
+	if a.issuesList.HasHierarchyTab() {
+		t.Errorf("HasHierarchyTab() = true, want false (no children)")
+	}
+	if a.side != sideRight {
+		t.Errorf("a.side = %v after Enter on leaf, want sideRight", a.side)
+	}
+	if got := len(fake.SearchIssuesCalls); got != 0 {
+		t.Errorf("SearchIssues calls = %d, want 0 (no API for children lookup)", got)
+	}
+}
+
+// Enter from InfoPanel Subtasks tab creates a hierarchy tab
+// containing the single selected subtask issue (title hierarchyTitleChildren).
+func TestHierarchy_EnterFromInfoPanelSub_OneElementList(t *testing.T) {
+	fake := &jiratest.FakeClient{T: t}
+	a := newAppWithFake(t, fake)
+	a.leftFocus = focusInfo
+
+	issue := &jira.Issue{
+		Key:      "MAIN-1",
+		Subtasks: []jira.Issue{{Key: "SUB-7", Summary: "x"}},
+	}
+	a.infoPanel.SetIssue(issue)
+	// SetIssue resets to InfoTabFields; advance to Subtasks.
+	a.infoPanel.NextTab() // Links
+	a.infoPanel.NextTab() // Subtasks
+	if a.infoPanel.ActiveTab() != views.InfoTabSubtasks {
+		t.Fatalf("precondition: ActiveTab = %v, want InfoTabSubtasks", a.infoPanel.ActiveTab())
+	}
+
+	_, handled := a.showChildren()
+	if !handled {
+		t.Fatalf("showChildren() handled = false, want true")
+	}
+	if got := a.issuesList.HierarchyTitle(); got != hierarchyTitleChildren {
+		t.Errorf("HierarchyTitle() = %q, want %q", got, hierarchyTitleChildren)
+	}
+	if sel := a.issuesList.SelectedIssue(); sel == nil || sel.Key != "SUB-7" {
+		t.Errorf("SelectedIssue() = %+v, want SUB-7", sel)
+	}
+	if d := a.issuesList.HierarchyStack().Depth(); d != 1 {
+		t.Errorf("HierarchyStack.Depth() = %d, want 1", d)
+	}
+}
+
+// Enter from InfoPanel Links tab creates a hierarchy tab with
+// the single linked issue (title "Link").
+func TestHierarchy_EnterFromInfoPanelLink_OneElementList(t *testing.T) {
+	fake := &jiratest.FakeClient{T: t}
+	a := newAppWithFake(t, fake)
+	a.leftFocus = focusInfo
+
+	issue := &jira.Issue{
+		Key: "MAIN-1",
+		IssueLinks: []jira.IssueLink{
+			{
+				Type:         &jira.IssueLinkType{Name: "Blocks"},
+				OutwardIssue: &jira.Issue{Key: "LNK-9"},
+			},
+		},
+	}
+	a.infoPanel.SetIssue(issue)
+	a.infoPanel.NextTab() // Links
+	if a.infoPanel.ActiveTab() != views.InfoTabLinks {
+		t.Fatalf("precondition: ActiveTab = %v, want InfoTabLinks", a.infoPanel.ActiveTab())
+	}
+
+	_, handled := a.showChildren()
+	if !handled {
+		t.Fatalf("showChildren() handled = false, want true")
+	}
+	if got := a.issuesList.HierarchyTitle(); got != "Link" {
+		t.Errorf("HierarchyTitle() = %q, want %q", got, "Link")
+	}
+	if sel := a.issuesList.SelectedIssue(); sel == nil || sel.Key != "LNK-9" {
+		t.Errorf("SelectedIssue() = %+v, want LNK-9", sel)
+	}
+}
+
+// The hierarchy row inherits the summary already attached to the link
+// payload, so the user sees the issue title and not just the key while
+// the detail fetch is still in flight.
+func TestHierarchy_LinkRowCarriesSummaryFromInfoPanel(t *testing.T) {
+	fake := &jiratest.FakeClient{T: t}
+	a := newAppWithFake(t, fake)
+	a.leftFocus = focusInfo
+
+	issue := &jira.Issue{
+		Key: "MAIN-1",
+		IssueLinks: []jira.IssueLink{
+			{
+				Type:         &jira.IssueLinkType{Name: "Blocks"},
+				OutwardIssue: &jira.Issue{Key: "LNK-9", Summary: "linked work"},
+			},
+		},
+	}
+	a.infoPanel.SetIssue(issue)
+	a.infoPanel.NextTab() // Links
+
+	if _, handled := a.showChildren(); !handled {
+		t.Fatalf("showChildren() handled = false, want true")
+	}
+	sel := a.issuesList.SelectedIssue()
+	if sel == nil {
+		t.Fatalf("SelectedIssue() = nil")
+	}
+	if sel.Summary != "linked work" {
+		t.Errorf("Summary = %q, want %q (info-panel payload should be preserved)", sel.Summary, "linked work")
+	}
+}
+
+// A pre-cached version of the targeted issue wins over the InfoPanel
+// stub: the hierarchy row reflects whatever fields the cache holds,
+// even when the in-flight fetch hasn't returned yet.
+func TestHierarchy_LinkRowPrefersCacheOverStub(t *testing.T) {
+	fake := &jiratest.FakeClient{T: t}
+	a := newAppWithFake(t, fake)
+	a.leftFocus = focusInfo
+
+	const cachedSummary = "rich cached summary"
+	a.issueCache["LNK-7"] = &jira.Issue{Key: "LNK-7", Summary: cachedSummary}
+
+	issue := &jira.Issue{
+		Key: "MAIN-2",
+		IssueLinks: []jira.IssueLink{
+			{
+				Type:         &jira.IssueLinkType{Name: "Relates"},
+				OutwardIssue: &jira.Issue{Key: "LNK-7", Summary: "stale summary"},
+			},
+		},
+	}
+	a.infoPanel.SetIssue(issue)
+	a.infoPanel.NextTab() // Links
+
+	if _, handled := a.showChildren(); !handled {
+		t.Fatalf("showChildren() handled = false, want true")
+	}
+	sel := a.issuesList.SelectedIssue()
+	if sel == nil {
+		t.Fatalf("SelectedIssue() = nil")
+	}
+	if sel.Summary != cachedSummary {
+		t.Errorf("Summary = %q, want %q (cache should win over info-panel stub)", sel.Summary, cachedSummary)
+	}
+}
+
+// Backspace on issue with Parent dispatches an async
+// fetchParent cmd. Executing the cmd yields a parentLoadedMsg.
+// Dispatching that msg through Update creates the hierarchy tab.
+func TestHierarchy_BackspaceWithParent_ShowsParent(t *testing.T) {
+	fake := &jiratest.FakeClient{T: t}
+	fake.GetIssueFunc = func(_ context.Context, key string) (*jira.Issue, error) {
+		return &jira.Issue{Key: key, Summary: "parent issue"}, nil
+	}
+	a := newAppWithFake(t, fake)
+	a.issuesList.SetIssues([]jira.Issue{
+		{Key: "CHILD-1", Parent: &jira.Issue{Key: "PARENT-1"}},
+	})
+
+	cmd, handled := a.showParent()
+	if !handled {
+		t.Fatalf("showParent() handled = false, want true")
+	}
+	if cmd == nil {
+		t.Fatalf("showParent() cmd = nil, want async fetch cmd")
+	}
+	if a.issuesList.HasHierarchyTab() {
+		t.Fatalf("HasHierarchyTab() = true before msg dispatch, want false")
+	}
+
+	msg := cmd()
+	loaded, ok := msg.(parentLoadedMsg)
+	if !ok {
+		t.Fatalf("cmd produced %T, want parentLoadedMsg", msg)
+	}
+	if loaded.parent == nil || loaded.parent.Key != "PARENT-1" {
+		t.Fatalf("loaded.parent = %+v, want PARENT-1", loaded.parent)
+	}
+
+	_, _ = a.Update(loaded)
+
+	if !a.issuesList.HasHierarchyTab() {
+		t.Fatalf("HasHierarchyTab() = false after dispatching loaded msg")
+	}
+	if got := a.issuesList.HierarchyTitle(); got != "Parent" {
+		t.Errorf("HierarchyTitle() = %q, want %q", got, "Parent")
+	}
+	if sel := a.issuesList.SelectedIssue(); sel == nil || sel.Key != "PARENT-1" {
+		t.Errorf("SelectedIssue() = %+v, want PARENT-1", sel)
+	}
+	if got := len(fake.GetIssueCalls); got != 1 || fake.GetIssueCalls[0].Key != "PARENT-1" {
+		t.Errorf("GetIssue calls = %+v, want 1 call for PARENT-1", fake.GetIssueCalls)
+	}
+}
+
+// Backspace on issue without Parent is a no-op.
+func TestHierarchy_BackspaceWithoutParent_NoOp(t *testing.T) {
+	fake := &jiratest.FakeClient{T: t}
+	a := newAppWithFake(t, fake)
+	a.issuesList.SetIssues([]jira.Issue{{Key: "ORPHAN-1"}})
+
+	_, handled := a.showParent()
+	if handled {
+		t.Errorf("showParent() handled = true, want false (no parent)")
+	}
+	if a.issuesList.HasHierarchyTab() {
+		t.Errorf("HasHierarchyTab() = true, want false")
+	}
+	if len(fake.GetIssueCalls) != 0 {
+		t.Errorf("GetIssue called %d times, want 0", len(fake.GetIssueCalls))
+	}
+}
+
+// On Cloud, showChildrenFromList ignores Issue.Subtasks: a cache hit
+// pushes immediately from a.childrenCache.
+func TestHierarchy_Cloud_ChildrenWalk_CacheHit_PushesImmediately(t *testing.T) {
+	fake := &jiratest.FakeClient{T: t}
+	a := newAppWithFake(t, fake)
+	a.isCloud = true
+	a.issuesList.SetIssues([]jira.Issue{{Key: "EPIC-1"}})
+	a.childrenCache["EPIC-1"] = []jira.Issue{{Key: "WALK-1", Summary: "first"}}
+
+	cmd, handled := a.showChildren()
+	if !handled {
+		t.Fatalf("showChildren() handled = false, want true")
+	}
+	if cmd == nil {
+		t.Fatalf("expected previewAfterNav cmd, got nil")
+	}
+	if !a.issuesList.HasHierarchyTab() {
+		t.Fatalf("HasHierarchyTab() = false")
+	}
+	if sel := a.issuesList.SelectedIssue(); sel == nil || sel.Key != "WALK-1" {
+		t.Errorf("SelectedIssue() = %+v, want C-1", sel)
+	}
+	if len(fake.GetChildrenCalls) != 0 {
+		t.Errorf("GetChildren called %d times, want 0 (cache hit)", len(fake.GetChildrenCalls))
+	}
+}
+
+// On Cloud, a cache miss dispatches a ChildrenRequestMsg and marks
+// pendingWalkKey; the eventual childrenLoadedMsg pushes the hierarchy
+// frame and primes the cache.
+func TestHierarchy_Cloud_ChildrenWalk_CacheMiss_FetchesThenPushes(t *testing.T) {
+	fake := &jiratest.FakeClient{T: t}
+	fake.GetChildrenFunc = func(_ context.Context, parentKey string) ([]jira.Issue, error) {
+		return []jira.Issue{{Key: "C-9", Summary: "nine"}}, nil
+	}
+	a := newAppWithFake(t, fake)
+	a.isCloud = true
+	a.issuesList.SetIssues([]jira.Issue{{Key: "EPIC-1"}})
+
+	cmd, handled := a.showChildren()
+	if !handled {
+		t.Fatalf("showChildren() handled = false, want true")
+	}
+	if cmd == nil {
+		t.Fatalf("showChildren() cmd = nil, want ChildrenRequestMsg cmd")
+	}
+	if a.pendingWalkKey != "EPIC-1" {
+		t.Errorf("pendingWalkKey = %q, want EPIC-1", a.pendingWalkKey)
+	}
+
+	req, ok := cmd().(views.ChildrenRequestMsg)
+	if !ok {
+		t.Fatalf("cmd produced %T, want views.ChildrenRequestMsg", cmd())
+	}
+	_, fetchCmd := a.Update(req)
+	if fetchCmd == nil {
+		t.Fatalf("ChildrenRequestMsg produced nil cmd, want fetch cmd")
+	}
+
+	loaded, ok := fetchCmd().(childrenLoadedMsg)
+	if !ok {
+		t.Fatalf("fetch produced %T, want childrenLoadedMsg", fetchCmd())
+	}
+	_, _ = a.Update(loaded)
+
+	if !a.issuesList.HasHierarchyTab() {
+		t.Errorf("HasHierarchyTab() = false after childrenLoadedMsg")
+	}
+	if sel := a.issuesList.SelectedIssue(); sel == nil || sel.Key != "C-9" {
+		t.Errorf("SelectedIssue() = %+v, want C-9", sel)
+	}
+	if cached, ok := a.childrenCache["EPIC-1"]; !ok || len(cached) != 1 {
+		t.Errorf("childrenCache[EPIC-1] = %+v, want 1 entry", cached)
+	}
+	if a.pendingWalkKey != "" {
+		t.Errorf("pendingWalkKey = %q, want \"\" after consume", a.pendingWalkKey)
+	}
+}
+
+// On Cloud, an empty GetChildren result opens the detail view instead
+// of pushing a hierarchy frame — matching the Server/DC and cache-hit
+// empty paths.
+func TestHierarchy_Cloud_ChildrenWalk_EmptyResult_OpensDetail(t *testing.T) {
+	fake := &jiratest.FakeClient{T: t}
+	fake.GetChildrenFunc = func(_ context.Context, _ string) ([]jira.Issue, error) {
+		return nil, nil
+	}
+	a := newAppWithFake(t, fake)
+	a.isCloud = true
+	a.issuesList.SetIssues([]jira.Issue{{Key: "EPIC-1"}})
+
+	cmd, _ := a.showChildren()
+	req := cmd().(views.ChildrenRequestMsg)
+	_, fetchCmd := a.Update(req)
+	loaded := fetchCmd().(childrenLoadedMsg)
+	_, _ = a.Update(loaded)
+
+	if a.issuesList.HasHierarchyTab() {
+		t.Errorf("HasHierarchyTab() = true, want false on empty result")
+	}
+	if a.side != sideRight {
+		t.Errorf("side = %v, want sideRight (detail opened)", a.side)
+	}
+	if a.pendingWalkKey != "" {
+		t.Errorf("pendingWalkKey = %q, want \"\" after consume", a.pendingWalkKey)
+	}
+}
+
+
+func TestHierarchy_Backspace_PushesEvenWhenTopMatches(t *testing.T) {
+	fake := &jiratest.FakeClient{T: t}
+	fake.GetIssueFunc = func(_ context.Context, key string) (*jira.Issue, error) {
+		return &jira.Issue{Key: key}, nil
+	}
+	a := newAppWithFake(t, fake)
+
+	a.issuesList.AddHierarchyTab(hierarchyTitleChildren, []jira.Issue{
+		{Key: "CHILD-1", Parent: &jira.Issue{Key: "FOO-1"}},
+	})
+	a.issuesList.HierarchyStack().Push(navstack.NavFrame{ParentKey: "FOO-1"})
+	if d := a.issuesList.HierarchyStack().Depth(); d != 1 {
+		t.Fatalf("precondition: stack depth = %d, want 1", d)
+	}
+
+	cmd, handled := a.showParent()
+	if !handled {
+		t.Fatalf("showParent() handled = false, want true")
+	}
+	if cmd == nil {
+		t.Fatalf("showParent() cmd = nil, want async fetch cmd")
+	}
+
+	_, _ = a.Update(cmd().(parentLoadedMsg))
+
+	if !a.issuesList.HasHierarchyTab() {
+		t.Errorf("HasHierarchyTab() = false, want true (stack should not collapse)")
+	}
+	if d := a.issuesList.HierarchyStack().Depth(); d != 2 {
+		t.Errorf("HierarchyStack.Depth() = %d, want 2 (existing + new push)", d)
+	}
+}
+
+// Two rapid Backspaces bump parentEpoch to 2. A
+// parentLoadedMsg carrying epoch=1 (stale) must be dropped — no
+// hierarchy tab is created.
+func TestHierarchy_StaleParent_Dropped(t *testing.T) {
+	fake := &jiratest.FakeClient{T: t}
+	fake.GetIssueFunc = func(_ context.Context, key string) (*jira.Issue, error) {
+		return &jira.Issue{Key: key}, nil
+	}
+	a := newAppWithFake(t, fake)
+	a.issuesList.SetIssues([]jira.Issue{
+		{Key: "CHILD-1", Parent: &jira.Issue{Key: "PARENT-1"}},
+	})
+
+	// Two rapid showParent invocations advance the epoch to 2.
+	if _, ok := a.showParent(); !ok {
+		t.Fatal("first showParent() handled = false")
+	}
+	if _, ok := a.showParent(); !ok {
+		t.Fatal("second showParent() handled = false")
+	}
+	if a.parentEpoch != 2 {
+		t.Fatalf("parentEpoch = %d after two showParent(), want 2", a.parentEpoch)
+	}
+
+	// Stale msg from the first request (epoch=1) arrives after the second
+	// request has already bumped the epoch.
+	stale := parentLoadedMsg{
+		childKey: "CHILD-1",
+		parent:   &jira.Issue{Key: "PARENT-1", Summary: "stale"},
+		epoch:    1,
+	}
+	_, _ = a.Update(stale)
+
+	if a.issuesList.HasHierarchyTab() {
+		t.Errorf("HasHierarchyTab() = true after stale msg, want false (dropped)")
+	}
+}
+
+// seedHierarchyTab prepares an active hierarchy tab plus the tab 0 origin so tests
+// that exercise goBack / hard-replace have a stable baseline.
+func seedHierarchyTab(t *testing.T, a *App) {
+	t.Helper()
+	a.issuesList.SetTabs([]config.IssueTabConfig{{Name: "My", JQL: ""}})
+	a.issuesList.AddHierarchyTab(hierarchyTitleChildren, []jira.Issue{{Key: "DRILL-0"}})
+}
+
+// Esc in hierarchy tab with Depth>1 pops the top frame (the
+// pre-hierarchy snapshot of level 1) and restores its UI snapshot. The new
+// top's Source determines the hierarchy tab title.
+func TestHierarchy_Esc_PopsFrame(t *testing.T) {
+	fake := &jiratest.FakeClient{T: t}
+	a := newAppWithFake(t, fake)
+	seedHierarchyTab(t, a)
+	stack := a.issuesList.HierarchyStack()
+
+	// originFrame: snapshot of origin JQL tab (bottom of stack). Its
+	// Source drives the hierarchy tab title after the level-1 pop.
+	stack.Push(navstack.NavFrame{
+		ParentKey: "P1",
+		Source:    navstack.SourceFromList,
+		Issues:    []jira.Issue{{Key: "ORIG-A"}},
+	})
+	// level1Frame: pre-hierarchy snapshot of level 1 (gets popped on Esc and
+	// its data is restored into the hierarchy tab).
+	stack.Push(navstack.NavFrame{
+		ParentKey:   "P2",
+		Source:      navstack.SourceFromList,
+		Issues:      []jira.Issue{{Key: "L1-A"}, {Key: "L1-B"}},
+		SelectedIdx: 1,
+		FocusPanel:  navstack.FocusPanel(focusInfo),
+		InfoTab:     int(views.InfoTabSubtasks),
+		InfoCursor:  3,
+	})
+	if d := stack.Depth(); d != 2 {
+		t.Fatalf("setup: stack depth = %d, want 2", d)
+	}
+
+	cmd, handled := a.goBack()
+	if !handled {
+		t.Fatalf("goBack() handled = false, want true")
+	}
+	_ = cmd
+
+	if !a.issuesList.HasHierarchyTab() {
+		t.Errorf("HasHierarchyTab() = false, want true after pop with depth>1")
+	}
+	if d := a.issuesList.HierarchyStack().Depth(); d != 1 {
+		t.Errorf("stack depth = %d, want 1", d)
+	}
+	if sel := a.issuesList.SelectedIssue(); sel == nil || sel.Key != "L1-B" {
+		t.Errorf("SelectedIssue() = %+v, want L1-B", sel)
+	}
+	if a.infoPanel.ActiveTab() != views.InfoTabSubtasks {
+		t.Errorf("info tab = %v, want InfoTabSubtasks", a.infoPanel.ActiveTab())
+	}
+	if a.infoPanel.Cursor != 3 {
+		t.Errorf("info cursor = %d, want 3", a.infoPanel.Cursor)
+	}
+	if a.leftFocus != focusInfo {
+		t.Errorf("leftFocus = %v, want focusInfo", a.leftFocus)
+	}
+}
+
+// Esc with Depth==1 pops the last frame (origin snapshot),
+// closes the hierarchy tab and restores the origin cursor/focus.
+func TestHierarchy_Esc_LastFrame_ClosesTab(t *testing.T) {
+	fake := &jiratest.FakeClient{T: t}
+	a := newAppWithFake(t, fake)
+	seedHierarchyTab(t, a)
+	a.issuesList.HierarchyStack().Push(navstack.NavFrame{
+		ParentKey:   "P1",
+		Source:      navstack.SourceFromList,
+		Issues:      []jira.Issue{{Key: "ORIG-A"}, {Key: "ORIG-B"}},
+		SelectedIdx: 1,
+		FocusPanel:  navstack.FocusPanel(focusIssues),
+	})
+
+	_, handled := a.goBack()
+	if !handled {
+		t.Fatalf("goBack() handled = false, want true")
+	}
+	if a.issuesList.HasHierarchyTab() {
+		t.Errorf("HasHierarchyTab() = true, want false after last pop")
+	}
+	if a.leftFocus != focusIssues {
+		t.Errorf("leftFocus = %v, want focusIssues", a.leftFocus)
+	}
+	if a.issuesList.Cursor != 1 {
+		t.Errorf("Cursor = %d, want 1", a.issuesList.Cursor)
+	}
+}
+
+// Showing children from the issues list captures a pre-hierarchy
+// snapshot; popping restores the origin cursor, info tab, info cursor
+// and focus.
+func TestHierarchy_SnapshotPreservesContext(t *testing.T) {
+	fake := &jiratest.FakeClient{T: t}
+	a := newAppWithFake(t, fake)
+
+	parent := jira.Issue{
+		Key:      "PARENT-3",
+		Subtasks: []jira.Issue{{Key: "SUB-X"}},
+	}
+	a.issuesList.SetIssues([]jira.Issue{
+		{Key: "A"}, {Key: "B"}, parent,
+	})
+	a.issuesList.Cursor = 2
+	a.leftFocus = focusIssues
+
+	a.infoPanel.SetIssue(&parent)
+	a.infoPanel.NextTab() // Links
+	a.infoPanel.NextTab() // Subtasks
+	if a.infoPanel.ActiveTab() != views.InfoTabSubtasks {
+		t.Fatalf("setup: ActiveTab = %v, want Subtasks", a.infoPanel.ActiveTab())
+	}
+	a.infoPanel.Cursor = 1
+
+	cmd, handled := a.showChildren()
+	if !handled {
+		t.Fatalf("showChildren() handled = false")
+	}
+	if !a.issuesList.IsHierarchyTab() {
+		t.Fatalf("IsHierarchyTab() = false after showChildren")
+	}
+	// Drive the returned cmd through Update so PreviewRequestMsg fires
+	// and SetIssue runs — that path resets the Info tab if the snapshot
+	// is not rehydrated correctly on goBack.
+	if cmd != nil {
+		_, _ = a.Update(cmd())
+	}
+
+	cmd, handled = a.goBack()
+	if !handled {
+		t.Fatalf("goBack() handled = false")
+	}
+	if cmd != nil {
+		_, _ = a.Update(cmd())
+	}
+
+	if a.issuesList.Cursor != 2 {
+		t.Errorf("Cursor = %d, want 2", a.issuesList.Cursor)
+	}
+	if a.infoPanel.ActiveTab() != views.InfoTabSubtasks {
+		t.Errorf("ActiveTab = %v, want Subtasks", a.infoPanel.ActiveTab())
+	}
+	if a.infoPanel.Cursor != 1 {
+		t.Errorf("infoPanel.Cursor = %d, want 1", a.infoPanel.Cursor)
+	}
+	if a.leftFocus != focusIssues {
+		t.Errorf("leftFocus = %v, want focusIssues", a.leftFocus)
+	}
+	if a.issuesList.HasHierarchyTab() {
+		t.Errorf("HasHierarchyTab() = true, want false after last pop")
+	}
+}
+
+// Esc outside the hierarchy tab falls through to the default
+// ActFocusLeft mapping (sideRight -> sideLeft); no goBack side effects.
+func TestHierarchy_Esc_OutsideHierarchyTab(t *testing.T) {
+	fake := &jiratest.FakeClient{T: t}
+	a := newAppWithFake(t, fake)
+	a.keymap = DefaultKeymap()
+	a.issuesList.SetTabs([]config.IssueTabConfig{{Name: "My", JQL: ""}})
+	a.side = sideRight
+
+	_, _ = a.handleKeyMsg(tea.KeyMsg{Type: tea.KeyEsc})
+
+	if a.side != sideLeft {
+		t.Errorf("a.side = %v, want sideLeft (default Esc behavior)", a.side)
+	}
+	if a.issuesList.HasHierarchyTab() {
+		t.Errorf("Esc outside hierarchy accidentally created hierarchy tab")
+	}
+}
+
+// Triggering a hierarchy from a non-hierarchy JQL tab while a hierarchy tab
+// already exists clears the old stack, replaces the tab content, and
+// focuses the hierarchy tab (hard-replace).
+// Pushing a new hierarchy view from a non-hierarchy tab adds onto the
+// existing stack and refocuses the hierarchy tab.
+func TestHierarchy_NavFromDifferentJQLTab_StacksUp(t *testing.T) {
+	fake := &jiratest.FakeClient{T: t}
+	a := newAppWithFake(t, fake)
+	a.issuesList.SetTabs([]config.IssueTabConfig{{Name: "My", JQL: ""}})
+
+	a.issuesList.AddHierarchyTab(hierarchyTitleChildren, []jira.Issue{{Key: "OLD-1"}})
+	hierarchyIdx := a.issuesList.GetTabIndex()
+	stack := a.issuesList.HierarchyStack()
+	stack.Push(navstack.NavFrame{ParentKey: "P1", Issues: []jira.Issue{{Key: "OLD-1"}}})
+	stack.Push(navstack.NavFrame{ParentKey: "P2", Issues: []jira.Issue{{Key: "OLD-1"}}})
+	stack.Push(navstack.NavFrame{ParentKey: "P3", Issues: []jira.Issue{{Key: "OLD-1"}}})
+	if d := stack.Depth(); d != 3 {
+		t.Fatalf("setup: stack depth = %d, want 3", d)
+	}
+
+	a.issuesList.SetTabIndex(0)
+	a.issuesList.SetIssues([]jira.Issue{
+		{Key: "NEW-PARENT", Subtasks: []jira.Issue{{Key: "SUB-A", Summary: "a"}}},
+	})
+
+	_, handled := a.showChildren()
+	if !handled {
+		t.Fatalf("showChildren() handled = false, want true")
+	}
+
+	if a.issuesList.GetTabIndex() != hierarchyIdx {
+		t.Errorf("GetTabIndex() = %d, want hierarchy tab %d", a.issuesList.GetTabIndex(), hierarchyIdx)
+	}
+	if d := a.issuesList.HierarchyStack().Depth(); d != 4 {
+		t.Errorf("HierarchyStack.Depth() = %d, want 4 (3 existing + 1 new push)", d)
+	}
+	if sel := a.issuesList.SelectedIssue(); sel == nil || sel.Key != "SUB-A" {
+		t.Errorf("SelectedIssue() = %+v, want SUB-A", sel)
+	}
+}
+
+func findHelpItem(items []components.HelpItem, desc string) (components.HelpItem, bool) {
+	for _, it := range items {
+		if it.Description == desc {
+			return it, true
+		}
+	}
+	return components.HelpItem{}, false
+}
+
+// The help-bar advertises "parent" only when the current
+// issue has a Parent.
+func TestHelpBar_Backspace_OnlyWhenParent(t *testing.T) {
+	fake := &jiratest.FakeClient{T: t}
+	a := newAppWithFake(t, fake)
+	a.keymap = DefaultKeymap()
+
+	a.issuesList.SetIssues([]jira.Issue{{Key: "A1"}})
+	if _, ok := findHelpItem(a.helpBarItems(), "parent"); ok {
+		t.Errorf("help bar shows 'parent' without a parent issue")
+	}
+
+	a.issuesList.SetIssues([]jira.Issue{{Key: "A1", Parent: &jira.Issue{Key: "P1"}}})
+	it, ok := findHelpItem(a.helpBarItems(), "parent")
+	if !ok {
+		t.Fatalf("help bar missing 'parent' entry when parent exists")
+	}
+	if it.Key != "backspace" {
+		t.Errorf("parent help key = %q, want %q", it.Key, "backspace")
+	}
+}
+
+// The help-bar advertises the ActSelect key as "children" when
+// the current issue has Subtasks, and "detail" otherwise.
+func TestHelpBar_Enter_ChildrenVsDetail(t *testing.T) {
+	fake := &jiratest.FakeClient{T: t}
+	a := newAppWithFake(t, fake)
+	a.keymap = DefaultKeymap()
+
+	a.issuesList.SetIssues([]jira.Issue{
+		{Key: "A1", Subtasks: []jira.Issue{{Key: "S1"}}},
+	})
+	if _, ok := findHelpItem(a.helpBarItems(), "children"); !ok {
+		t.Errorf("help bar missing 'children' entry when subtasks exist")
+	}
+	if _, ok := findHelpItem(a.helpBarItems(), "detail"); ok {
+		t.Errorf("help bar shows 'detail' when subtasks exist")
+	}
+
+	a.issuesList.SetIssues([]jira.Issue{{Key: "A1"}})
+	if _, ok := findHelpItem(a.helpBarItems(), "detail"); !ok {
+		t.Errorf("help bar missing 'detail' entry for leaf issue")
+	}
+	if _, ok := findHelpItem(a.helpBarItems(), "children"); ok {
+		t.Errorf("help bar shows 'children' for leaf issue")
+	}
+}
+
+// Navigating from a non-first JQL tab and fully popping the
+// hierarchy-stack must return the user to the origin tab.
+func TestHierarchy_FullPop_RestoresOriginTab(t *testing.T) {
+	fake := &jiratest.FakeClient{T: t}
+	a := newAppWithFake(t, fake)
+	a.issuesList.SetTabs([]config.IssueTabConfig{
+		{Name: "My", JQL: ""},
+		{Name: "Watched", JQL: ""},
+	})
+	a.issuesList.SetTabIndex(1)
+	parent := jira.Issue{
+		Key:      "PARENT-42",
+		Subtasks: []jira.Issue{{Key: "SUB-1"}},
+	}
+	a.issuesList.SetIssues([]jira.Issue{parent})
+
+	if _, handled := a.showChildren(); !handled {
+		t.Fatalf("showChildren() handled = false")
+	}
+	if !a.issuesList.IsHierarchyTab() {
+		t.Fatalf("IsHierarchyTab() = false after showChildren")
+	}
+
+	if _, handled := a.goBack(); !handled {
+		t.Fatalf("goBack() handled = false")
+	}
+	if a.issuesList.HasHierarchyTab() {
+		t.Fatalf("HasHierarchyTab() = true after full pop, want false")
+	}
+	if got := a.issuesList.GetTabIndex(); got != 1 {
+		t.Errorf("GetTabIndex() = %d, want 1 (origin tab 'Watched')", got)
+	}
+}

--- a/pkg/tui/hierarchy_test.go
+++ b/pkg/tui/hierarchy_test.go
@@ -444,6 +444,30 @@ func TestHierarchy_Cloud_SelectProject_InvalidatesInFlightWalk(t *testing.T) {
 	}
 }
 
+// goBack only fires when the Issues panel itself has focus; on the
+// other left panels h/Esc/Left fall through to their natural behavior.
+func TestHierarchy_GoBack_SkipsWhenLeftFocusNotIssues(t *testing.T) {
+	fake := &jiratest.FakeClient{T: t}
+	a := newAppWithFake(t, fake)
+	a.issuesList.AddHierarchyTab(hierarchyTitleChildren, []jira.Issue{{Key: "CHILD-1"}})
+	a.issuesList.HierarchyStack().Push(navstack.NavFrame{ParentKey: "P-1"})
+
+	for _, focus := range []focusPanel{focusInfo, focusStatus, focusProjects} {
+		a.leftFocus = focus
+		if _, handled := a.goBack(); handled {
+			t.Errorf("leftFocus=%v: goBack() handled=true, want false", focus)
+		}
+		if !a.issuesList.HasHierarchyTab() {
+			t.Errorf("leftFocus=%v: hierarchy tab disappeared", focus)
+		}
+	}
+
+	a.leftFocus = focusIssues
+	if _, handled := a.goBack(); !handled {
+		t.Errorf("leftFocus=focusIssues: goBack() handled=false, want true")
+	}
+}
+
 func TestHierarchy_Backspace_PushesEvenWhenTopMatches(t *testing.T) {
 	fake := &jiratest.FakeClient{T: t}
 	fake.GetIssueFunc = func(_ context.Context, key string) (*jira.Issue, error) {

--- a/pkg/tui/keybindings.go
+++ b/pkg/tui/keybindings.go
@@ -204,6 +204,18 @@ func (a *App) helpBarItems() []components.HelpItem {
 		if a.issuesList.IsJQLTab() {
 			items = append(items, components.HelpItem{Key: km.Keys(ActCloseJQLTab), Description: "close JQL"})
 		}
+		cur := a.currentIssue()
+		enterDesc := "detail"
+		if cur != nil {
+			children, resolved := a.childrenForList(cur)
+			if resolved && len(children) > 0 {
+				enterDesc = "children"
+			}
+		}
+		items = append(items, components.HelpItem{Key: km.Keys(ActSelect), Description: enterDesc})
+		if cur != nil && cur.Parent != nil && cur.Parent.Key != "" {
+			items = append(items, components.HelpItem{Key: km.Keys(ActShowParent), Description: "parent"})
+		}
 		items = append(items,
 			components.HelpItem{Key: km.Keys(ActEdit), Description: "edit"},
 			components.HelpItem{Key: km.Keys(ActTransition), Description: "transition"},

--- a/pkg/tui/keymap.go
+++ b/pkg/tui/keymap.go
@@ -44,6 +44,7 @@ const (
 	ActCreateBranch   Action = "createBranch"
 	ActCreateIssue    Action = "createIssue"
 	ActDuplicateIssue Action = "duplicateIssue"
+	ActShowParent     Action = "showParent"
 
 	ActNavDown     Action = "navDown"
 	ActNavUp       Action = "navUp"
@@ -95,6 +96,7 @@ func DefaultKeymap() Keymap {
 		ActCloseJQLTab:    {"x"},
 		ActCreateBranch:   {"b"},
 		ActDuplicateIssue: {"ctrl+n"},
+		ActShowParent:     {"backspace"},
 
 		ActNavDown:     {"j", "down", "ctrl+j"},
 		ActNavUp:       {"k", "up", "ctrl+k"},

--- a/pkg/tui/navstack/navstack.go
+++ b/pkg/tui/navstack/navstack.go
@@ -1,0 +1,64 @@
+package navstack
+
+import "github.com/textfuel/lazyjira/v2/pkg/jira"
+
+// Opaque panel identifier stored in NavFrame. The semantic mapping
+// (which int = which panel) lives in the tui package; this package
+// treats it as opaque snapshot data.
+type FocusPanel int
+
+type Source int
+
+const (
+	SourceFromList Source = iota
+	SourceFromInfoSub
+	SourceFromInfoLink
+	SourceParent
+)
+
+type NavFrame struct {
+	Issues       []jira.Issue
+	SelectedIdx  int
+	FocusPanel   FocusPanel
+	InfoTab      int
+	InfoCursor   int
+	Source       Source
+	ParentKey    string
+	OriginTabIdx int
+}
+
+type NavStack struct {
+	frames []NavFrame
+}
+
+func NewNavStack() *NavStack {
+	return &NavStack{}
+}
+
+func (s *NavStack) Push(frame NavFrame) {
+	s.frames = append(s.frames, frame)
+}
+
+func (s *NavStack) Clear() {
+	s.frames = nil
+}
+
+func (s *NavStack) Depth() int {
+	return len(s.frames)
+}
+
+func (s *NavStack) Peek() NavFrame {
+	if len(s.frames) == 0 {
+		return NavFrame{}
+	}
+	return s.frames[len(s.frames)-1]
+}
+
+func (s *NavStack) Pop() NavFrame {
+	if len(s.frames) == 0 {
+		return NavFrame{}
+	}
+	top := s.frames[len(s.frames)-1]
+	s.frames = s.frames[:len(s.frames)-1]
+	return top
+}

--- a/pkg/tui/navstack/navstack_test.go
+++ b/pkg/tui/navstack/navstack_test.go
@@ -1,0 +1,141 @@
+package navstack
+
+import (
+	"testing"
+
+	"github.com/textfuel/lazyjira/v2/pkg/jira"
+)
+
+func TestNavStack_NewStack_IsEmpty(t *testing.T) {
+	s := NewNavStack()
+	if got := s.Depth(); got != 0 {
+		t.Fatalf("Depth() = %d, want 0", got)
+	}
+}
+
+func TestNavStack_Pop_OnEmpty_ReturnsZeroFrame(t *testing.T) {
+	s := NewNavStack()
+	got := s.Pop()
+	if !isZeroFrame(got) {
+		t.Fatalf("Pop() on empty = %+v, want zero frame", got)
+	}
+	if s.Depth() != 0 {
+		t.Fatalf("Depth() after Pop on empty = %d, want 0", s.Depth())
+	}
+}
+
+func TestNavStack_Peek_OnEmpty_ReturnsZeroFrame(t *testing.T) {
+	s := NewNavStack()
+	got := s.Peek()
+	if !isZeroFrame(got) {
+		t.Fatalf("Peek() on empty = %+v, want zero frame", got)
+	}
+	if s.Depth() != 0 {
+		t.Fatalf("Depth() after Peek on empty = %d, want 0", s.Depth())
+	}
+}
+
+func TestNavStack_Push_IncreasesDepth(t *testing.T) {
+	s := NewNavStack()
+	s.Push(makeFrame("FOO-1", 0, SourceFromList))
+	if s.Depth() != 1 {
+		t.Fatalf("Depth after 1 push = %d, want 1", s.Depth())
+	}
+	s.Push(makeFrame("FOO-2", 0, SourceFromList))
+	if s.Depth() != 2 {
+		t.Fatalf("Depth after 2 pushes = %d, want 2", s.Depth())
+	}
+}
+
+func TestNavStack_Peek_ReturnsTop(t *testing.T) {
+	s := NewNavStack()
+	s.Push(makeFrame("A", 1, SourceFromList))
+	s.Push(makeFrame("B", 2, SourceFromList))
+	top := s.Peek()
+	if top.ParentKey != "B" || top.SelectedIdx != 2 {
+		t.Fatalf("Peek = %+v, want ParentKey=B SelectedIdx=2", top)
+	}
+	if s.Depth() != 2 {
+		t.Fatalf("Peek mutated Depth to %d", s.Depth())
+	}
+}
+
+func TestNavStack_Pop_ReturnsLastPushedFrame(t *testing.T) {
+	s := NewNavStack()
+	s.Push(makeFrame("A", 0, SourceFromList))
+	s.Push(makeFrame("B", 5, SourceFromList))
+	got := s.Pop()
+	if got.ParentKey != "B" || got.SelectedIdx != 5 {
+		t.Fatalf("Pop = %+v, want ParentKey=B SelectedIdx=5", got)
+	}
+	if s.Depth() != 1 {
+		t.Fatalf("Depth after Pop = %d, want 1", s.Depth())
+	}
+	if s.Peek().ParentKey != "A" {
+		t.Fatalf("Top after Pop = %q, want A", s.Peek().ParentKey)
+	}
+}
+
+func TestNavStack_Pop_MultipleTimes_UntilEmpty(t *testing.T) {
+	s := NewNavStack()
+	s.Push(makeFrame("A", 0, SourceFromList))
+	s.Push(makeFrame("B", 0, SourceFromList))
+	_ = s.Pop()
+	_ = s.Pop()
+	got := s.Pop()
+	if !isZeroFrame(got) {
+		t.Fatalf("Pop past empty = %+v, want zero frame", got)
+	}
+	if s.Depth() != 0 {
+		t.Fatalf("Depth = %d, want 0", s.Depth())
+	}
+}
+
+func TestNavStack_Push_DifferentParentKeys_Appends(t *testing.T) {
+	s := NewNavStack()
+	s.Push(makeFrame("FOO-1", 0, SourceFromList))
+	s.Push(makeFrame("FOO-2", 0, SourceFromList))
+	if s.Depth() != 2 {
+		t.Fatalf("Depth after two different pushes = %d, want 2", s.Depth())
+	}
+}
+
+func TestNavStack_Clear_EmptiesStack(t *testing.T) {
+	s := NewNavStack()
+	s.Push(makeFrame("A", 0, SourceFromList))
+	s.Push(makeFrame("B", 0, SourceFromList))
+	s.Clear()
+	if s.Depth() != 0 {
+		t.Fatalf("Depth after Clear = %d, want 0", s.Depth())
+	}
+	if !isZeroFrame(s.Peek()) {
+		t.Fatalf("Peek after Clear = %+v, want zero frame", s.Peek())
+	}
+}
+
+// testFocusIssues is a dummy non-zero FocusPanel value used in test fixtures.
+// The semantic mapping lives in the tui package; for NavStack tests any
+// non-zero int suffices.
+const testFocusIssues FocusPanel = 1
+
+func makeFrame(parentKey string, selectedIdx int, source Source) NavFrame {
+	return NavFrame{
+		Issues:      []jira.Issue{{Key: parentKey + "-dummy"}},
+		SelectedIdx: selectedIdx,
+		FocusPanel:  testFocusIssues,
+		InfoTab:     0,
+		InfoCursor:  0,
+		Source:      source,
+		ParentKey:   parentKey,
+	}
+}
+
+func isZeroFrame(f NavFrame) bool {
+	return f.Issues == nil &&
+		f.SelectedIdx == 0 &&
+		f.FocusPanel == FocusPanel(0) &&
+		f.InfoTab == 0 &&
+		f.InfoCursor == 0 &&
+		f.Source == Source(0) &&
+		f.ParentKey == ""
+}

--- a/pkg/tui/prefetch_test.go
+++ b/pkg/tui/prefetch_test.go
@@ -5,10 +5,26 @@ import (
 	"strings"
 	"testing"
 
+	tea "github.com/charmbracelet/bubbletea"
+
 	"github.com/textfuel/lazyjira/v2/pkg/jira"
 	"github.com/textfuel/lazyjira/v2/pkg/jira/jiratest"
 	"github.com/textfuel/lazyjira/v2/pkg/tui/views"
 )
+
+// runAll executes a tea.Cmd, recursively expanding tea.BatchMsg so callers
+// can assert on side effects from individual commands.
+func runAll(cmd tea.Cmd) {
+	if cmd == nil {
+		return
+	}
+	msg := cmd()
+	if batch, ok := msg.(tea.BatchMsg); ok {
+		for _, c := range batch {
+			runAll(c)
+		}
+	}
+}
 
 // TestPrefetchRelated_IncludesParent ensures the parent key is fetched along
 // with subtasks and links so that navigating up the hierarchy feels the same
@@ -65,7 +81,7 @@ func TestIssueSelectedMsg_PrefetchesRelated(t *testing.T) {
 	if cmd == nil {
 		t.Fatal("expected a prefetch cmd from IssueSelectedMsg, got nil")
 	}
-	cmd()
+	runAll(cmd)
 
 	if !strings.Contains(got, subKey1) {
 		t.Errorf("SearchIssues JQL %q does not contain %q", got, subKey1)

--- a/pkg/tui/preview_cursor_test.go
+++ b/pkg/tui/preview_cursor_test.go
@@ -1,0 +1,226 @@
+package tui
+
+import (
+	"context"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/textfuel/lazyjira/v2/pkg/jira"
+	"github.com/textfuel/lazyjira/v2/pkg/jira/jiratest"
+	"github.com/textfuel/lazyjira/v2/pkg/tui/components"
+	"github.com/textfuel/lazyjira/v2/pkg/tui/views"
+)
+
+// navResolverJK resolves a minimal j/k keymap used to drive list cursor
+// movement in tests without loading the full app keymap.
+func navResolverJK(key string) components.NavAction {
+	switch key {
+	case "j":
+		return components.NavDown
+	case "k":
+		return components.NavUp
+	}
+	return components.NavNone
+}
+
+// TestPreviewFollowsCursor_IssuesList_Down verifies that IssueSelectedMsg
+// (emitted by the main list on a down-cursor move) delegates to the preview
+// pipeline: previewKey follows the new selection and previewEpoch bumps so
+// the debounce+cancel mechanics engage.
+func TestPreviewFollowsCursor_IssuesList_Down(t *testing.T) {
+	fake := &jiratest.FakeClient{T: t}
+	a := newAppWithFake(t, fake)
+	issues := []jira.Issue{{Key: mainKey}, {Key: "ABC-2"}}
+	a.issuesList.SetIssues(issues)
+
+	_, cmd := a.Update(views.IssueSelectedMsg{Issue: &issues[1]})
+
+	if a.previewKey != "ABC-2" {
+		t.Errorf("previewKey = %q, want %q", a.previewKey, "ABC-2")
+	}
+	if a.previewEpoch != 1 {
+		t.Errorf("previewEpoch = %d, want 1 (IssueSelectedMsg must delegate to PreviewRequestMsg)", a.previewEpoch)
+	}
+	if cmd == nil {
+		t.Fatal("expected non-nil cmd (debounce tick), got nil")
+	}
+}
+
+// TestPreviewFollowsCursor_IssuesList_Up covers the symmetric up-cursor path
+// and also pins that the epoch advances once per move.
+func TestPreviewFollowsCursor_IssuesList_Up(t *testing.T) {
+	fake := &jiratest.FakeClient{T: t}
+	a := newAppWithFake(t, fake)
+	issues := []jira.Issue{{Key: mainKey}, {Key: "ABC-2"}}
+	a.issuesList.SetIssues(issues)
+
+	_, _ = a.Update(views.IssueSelectedMsg{Issue: &issues[1]})
+	_, _ = a.Update(views.IssueSelectedMsg{Issue: &issues[0]})
+
+	if a.previewKey != mainKey {
+		t.Errorf("previewKey = %q, want %q", a.previewKey, mainKey)
+	}
+	if a.previewEpoch != 2 {
+		t.Errorf("previewEpoch = %d, want 2", a.previewEpoch)
+	}
+}
+
+// TestPreviewFollowsCursor_InfoSubtasks_ExistingPath verifies that cursor
+// movement inside the InfoPanel Subtasks tab dispatches a PreviewRequestMsg
+// carrying the newly-selected subtask key.
+func TestPreviewFollowsCursor_InfoSubtasks_ExistingPath(t *testing.T) {
+	fake := &jiratest.FakeClient{T: t}
+	a := newAppWithFake(t, fake)
+	main := &jira.Issue{
+		Key:      mainKey,
+		Subtasks: []jira.Issue{{Key: "SUB-1"}, {Key: "SUB-2"}},
+	}
+	a.infoPanel.SetIssue(main)
+	a.infoPanel.SetActiveTab(views.InfoTabSubtasks)
+	a.infoPanel.SetFocused(true)
+	a.infoPanel.ResolveNav = navResolverJK
+
+	_, cmd := a.infoPanel.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
+	if cmd == nil {
+		t.Fatal("expected PreviewRequestMsg cmd from Subtasks cursor move, got nil")
+	}
+	msg := cmd()
+	pr, ok := msg.(views.PreviewRequestMsg)
+	if !ok {
+		t.Fatalf("expected PreviewRequestMsg, got %T", msg)
+	}
+	if pr.Key != "SUB-2" {
+		t.Errorf("PreviewRequestMsg.Key = %q, want %q", pr.Key, "SUB-2")
+	}
+}
+
+// TestPreviewFollowsCursor_InfoLinks_ExistingPath is the Links-tab analog of
+// the Subtasks cursor test above.
+func TestPreviewFollowsCursor_InfoLinks_ExistingPath(t *testing.T) {
+	const linkKey1 = "LNK-1"
+	const linkKey2 = "LNK-2"
+
+	fake := &jiratest.FakeClient{T: t}
+	a := newAppWithFake(t, fake)
+	main := &jira.Issue{
+		Key: mainKey,
+		IssueLinks: []jira.IssueLink{
+			{Type: &jira.IssueLinkType{Name: "relates to"}, OutwardIssue: &jira.Issue{Key: linkKey1}},
+			{Type: &jira.IssueLinkType{Name: "relates to"}, OutwardIssue: &jira.Issue{Key: linkKey2}},
+		},
+	}
+	a.infoPanel.SetIssue(main)
+	a.infoPanel.SetActiveTab(views.InfoTabLinks)
+	a.infoPanel.SetFocused(true)
+	a.infoPanel.ResolveNav = navResolverJK
+
+	_, cmd := a.infoPanel.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
+	if cmd == nil {
+		t.Fatal("expected PreviewRequestMsg cmd from Links cursor move, got nil")
+	}
+	msg := cmd()
+	pr, ok := msg.(views.PreviewRequestMsg)
+	if !ok {
+		t.Fatalf("expected PreviewRequestMsg, got %T", msg)
+	}
+	if pr.Key != linkKey2 {
+		t.Errorf("PreviewRequestMsg.Key = %q, want %q", pr.Key, linkKey2)
+	}
+}
+
+// TestPreviewFollowsCursor_RapidCursor_OnlyLastFetch pins the debounce
+// guarantee through the IssueSelectedMsg path: five rapid moves advance the
+// epoch to 5, stale debounce ticks from epochs 1-4 are dropped, only the
+// fresh tick for epoch 5 issues a GetIssue call.
+func TestPreviewFollowsCursor_RapidCursor_OnlyLastFetch(t *testing.T) {
+	const lastKey = "ABC-5"
+
+	fake := &jiratest.FakeClient{T: t}
+	fake.GetIssueFunc = func(_ context.Context, key string) (*jira.Issue, error) {
+		if key != lastKey {
+			t.Errorf("unexpected GetIssue(%q); only %q should reach the client", key, lastKey)
+		}
+		return &jira.Issue{Key: key}, nil
+	}
+	fake.GetCommentsFunc = func(_ context.Context, _ string) ([]jira.Comment, error) { return nil, nil }
+	fake.GetChangelogFunc = func(_ context.Context, _ string) ([]jira.ChangelogEntry, error) { return nil, nil }
+
+	a := newAppWithFake(t, fake)
+	issues := []jira.Issue{
+		{Key: "ABC-1"}, {Key: "ABC-2"}, {Key: "ABC-3"}, {Key: "ABC-4"}, {Key: lastKey},
+	}
+	a.issuesList.SetIssues(issues)
+
+	for i := range issues {
+		_, _ = a.Update(views.IssueSelectedMsg{Issue: &issues[i]})
+	}
+	if a.previewEpoch != 5 {
+		t.Fatalf("previewEpoch = %d after 5 moves, want 5", a.previewEpoch)
+	}
+
+	for epoch := 1; epoch <= 4; epoch++ {
+		_, stale := a.Update(previewDebounceMsg{key: issues[epoch-1].Key, epoch: epoch})
+		if stale != nil {
+			stale()
+		}
+	}
+	if len(fake.GetIssueCalls) != 0 {
+		t.Errorf("stale debounce ticks caused %d GetIssue call(s), want 0", len(fake.GetIssueCalls))
+	}
+
+	_, fetchCmd := a.Update(previewDebounceMsg{key: lastKey, epoch: 5})
+	if fetchCmd == nil {
+		t.Fatal("expected fetch cmd from fresh debounce tick, got nil")
+	}
+	fetchCmd()
+	if len(fake.GetIssueCalls) != 1 {
+		t.Fatalf("expected 1 GetIssue call after fresh tick, got %d", len(fake.GetIssueCalls))
+	}
+	if got := fake.GetIssueCalls[0].Key; got != lastKey {
+		t.Errorf("GetIssue called with key %q, want %q", got, lastKey)
+	}
+}
+
+// TestPreviewFollowsCursor_Projects verifies that ProjectHoveredMsg routes
+// the hovered project into DetailView in project mode. The hover message
+// is emitted by ProjectList on every cursor move (see views.ProjectList.Update).
+func TestPreviewFollowsCursor_Projects(t *testing.T) {
+	fake := &jiratest.FakeClient{T: t}
+	a := newAppWithFake(t, fake)
+	projects := []jira.Project{{Key: "P1", Name: "Project One"}, {Key: "P2", Name: "Project Two"}}
+
+	_, _ = a.Update(views.ProjectHoveredMsg{Project: &projects[1]})
+
+	if got := a.detailView.Mode(); got != views.ModeProject {
+		t.Errorf("detailView.Mode = %v, want ModeProject", got)
+	}
+	// The detailView keeps a copy of the project; verify via re-render path
+	// would couple to View() output. Instead, hover with nil and confirm
+	// no panic and mode stays.
+	_, _ = a.Update(views.ProjectHoveredMsg{Project: nil})
+	if got := a.detailView.Mode(); got != views.ModeProject {
+		t.Errorf("nil hover changed mode away from ModeProject (got %v)", got)
+	}
+}
+
+// TestPreviewFollowsCursor_UnknownKey_FallsBackToContext verifies the
+// content-fallback chain: when a preview is requested for a key that is
+// neither cached nor matches the main-list selection (e.g. a sub/link key
+// without cache), the DetailView keeps showing the previously displayed
+// context issue rather than blanking out. The spec calls for "letzter
+// Content bleibt stehen" until the fetch resolves.
+func TestPreviewFollowsCursor_UnknownKey_FallsBackToContext(t *testing.T) {
+	fake := &jiratest.FakeClient{T: t}
+	a := newAppWithFake(t, fake)
+	main := &jira.Issue{Key: mainKey, Summary: "main issue"}
+	a.issuesList.SetIssues([]jira.Issue{*main})
+	a.detailView.SetIssue(main)
+
+	_, _ = a.Update(views.PreviewRequestMsg{Key: "UNKNOWN-99"})
+
+	if got := a.detailView.IssueKey(); got != mainKey {
+		t.Errorf("DetailView.IssueKey = %q, want context fallback %q", got, mainKey)
+	}
+}
+

--- a/pkg/tui/views/infopanel.go
+++ b/pkg/tui/views/infopanel.go
@@ -170,6 +170,12 @@ func (p *InfoPanel) ActiveTab() InfoPanelTab {
 	return p.activeTab
 }
 
+// Does not reset Cursor/Offset; callers must do so themselves if needed.
+func (p *InfoPanel) SetActiveTab(tab InfoPanelTab) {
+	p.activeTab = tab
+	p.syncItemCount()
+}
+
 func (p *InfoPanel) Fields() []InfoField {
 	return buildInfoFields(p.issue, p.fields)
 }
@@ -198,12 +204,22 @@ func (p *InfoPanel) resolveOriginalIndex() int {
 
 // SelectedLinkKey returns the issue key of the selected link
 func (p *InfoPanel) SelectedLinkKey() string {
+	if iss := p.SelectedLinkIssue(); iss != nil {
+		return iss.Key
+	}
+	return ""
+}
+
+// SelectedLinkIssue returns the linked issue currently under cursor (with
+// whatever fields the parent payload carried, typically key + summary +
+// status), or nil when no link is selected.
+func (p *InfoPanel) SelectedLinkIssue() *jira.Issue {
 	if p.issue == nil || p.activeTab != InfoTabLinks {
-		return ""
+		return nil
 	}
 	target := p.resolveOriginalIndex()
 	if target < 0 {
-		return ""
+		return nil
 	}
 	idx := 0
 	for _, link := range p.issue.IssueLinks {
@@ -212,31 +228,41 @@ func (p *InfoPanel) SelectedLinkKey() string {
 		}
 		if link.OutwardIssue != nil {
 			if idx == target {
-				return link.OutwardIssue.Key
+				return link.OutwardIssue
 			}
 			idx++
 		}
 		if link.InwardIssue != nil {
 			if idx == target {
-				return link.InwardIssue.Key
+				return link.InwardIssue
 			}
 			idx++
 		}
 	}
-	return ""
+	return nil
 }
 
 // SelectedSubtaskKey returns the issue key of the selected subtask
 func (p *InfoPanel) SelectedSubtaskKey() string {
+	if iss := p.SelectedSubtaskIssue(); iss != nil {
+		return iss.Key
+	}
+	return ""
+}
+
+// SelectedSubtaskIssue returns the subtask under cursor (with whatever
+// fields the parent payload carried, typically key + summary + status),
+// or nil when no subtask is selected.
+func (p *InfoPanel) SelectedSubtaskIssue() *jira.Issue {
 	if p.issue == nil || p.activeTab != InfoTabSubtasks {
-		return ""
+		return nil
 	}
 	idx := p.resolveOriginalIndex()
 	subs := p.subtaskList()
 	if idx >= 0 && idx < len(subs) {
-		return subs[idx].Key
+		return &subs[idx]
 	}
-	return ""
+	return nil
 }
 
 // subtaskList returns the list backing the Sub tab: Cloud children when

--- a/pkg/tui/views/issues.go
+++ b/pkg/tui/views/issues.go
@@ -12,6 +12,7 @@ import (
 	"github.com/textfuel/lazyjira/v2/pkg/config"
 	"github.com/textfuel/lazyjira/v2/pkg/jira"
 	"github.com/textfuel/lazyjira/v2/pkg/tui/components"
+	"github.com/textfuel/lazyjira/v2/pkg/tui/navstack"
 	"github.com/textfuel/lazyjira/v2/pkg/tui/theme"
 )
 
@@ -27,26 +28,29 @@ const statusOpen = "○"
 
 type IssuesList struct {
 	components.ListBase
-	issues         []jira.Issue
-	allIssues      []jira.Issue
-	filter         string
-	tabs           []config.IssueTabConfig
-	tab            int
-	tabCache       map[int][]jira.Issue
-	userEmail      string
-	keyColWidth    int
-	fields         []string
-	theme          *theme.Theme
-	typeIcons      map[string]string
-	typeIconCols   int
-	statusIcons    map[string]string
-	statusIconCols int
-	jqlQuery       string
-	jqlTabIdx      int
+	issues          []jira.Issue
+	allIssues       []jira.Issue
+	filter          string
+	tabs            []config.IssueTabConfig
+	tab             int
+	tabCache        map[int][]jira.Issue
+	userEmail       string
+	keyColWidth     int
+	fields          []string
+	theme           *theme.Theme
+	typeIcons       map[string]string
+	typeIconCols    int
+	statusIcons     map[string]string
+	statusIconCols  int
+	jqlQuery        string
+	jqlTabIdx       int
+	hierarchyTabIdx int
+	hierarchyTitle  string
+	hierarchyStack  *navstack.NavStack
 }
 
 func NewIssuesList() *IssuesList {
-	return &IssuesList{theme: theme.Default, jqlTabIdx: -1}
+	return &IssuesList{theme: theme.Default, jqlTabIdx: -1, hierarchyTabIdx: -1}
 }
 
 func (m *IssuesList) SetFields(fields []string) { m.fields = fields }
@@ -123,6 +127,79 @@ func (m *IssuesList) JQLQuery() string {
 	return m.jqlQuery
 }
 
+// Appends and focuses a hierarchy tab. If one already exists, behaves
+// like ReplaceHierarchyTabContent and returns the existing index.
+func (m *IssuesList) AddHierarchyTab(title string, issues []jira.Issue) int {
+	if m.hierarchyTabIdx >= 0 {
+		m.ReplaceHierarchyTabContent(title, issues)
+		return m.hierarchyTabIdx
+	}
+	m.tabs = append(m.tabs, config.IssueTabConfig{Name: title, JQL: ""})
+	m.hierarchyTabIdx = len(m.tabs) - 1
+	m.hierarchyTitle = title
+	m.hierarchyStack = navstack.NewNavStack()
+	if m.tabCache == nil {
+		m.tabCache = make(map[int][]jira.Issue)
+	}
+	m.tabCache[m.hierarchyTabIdx] = issues
+	m.tab = m.hierarchyTabIdx
+	m.loadFromCache()
+	return m.hierarchyTabIdx
+}
+
+// Replaces the hierarchy tab's title and issue list while keeping the
+// tab index and stack stable. No-op if no hierarchy tab.
+func (m *IssuesList) ReplaceHierarchyTabContent(title string, issues []jira.Issue) {
+	if m.hierarchyTabIdx < 0 {
+		return
+	}
+	m.hierarchyTitle = title
+	m.tabs[m.hierarchyTabIdx] = config.IssueTabConfig{Name: title, JQL: ""}
+	if m.tabCache == nil {
+		m.tabCache = make(map[int][]jira.Issue)
+	}
+	m.tabCache[m.hierarchyTabIdx] = issues
+	if m.tab == m.hierarchyTabIdx {
+		m.loadFromCache()
+	}
+}
+
+// Removes the hierarchy tab, drops its stack, and switches to tab 0.
+// No-op if no hierarchy tab.
+func (m *IssuesList) RemoveHierarchyTab() {
+	if m.hierarchyTabIdx < 0 {
+		return
+	}
+	if m.tabCache != nil {
+		delete(m.tabCache, m.hierarchyTabIdx)
+	}
+	m.tabs = append(m.tabs[:m.hierarchyTabIdx], m.tabs[m.hierarchyTabIdx+1:]...)
+	m.hierarchyTabIdx = -1
+	m.hierarchyTitle = ""
+	m.hierarchyStack = nil
+	m.tab = 0
+	m.loadFromCache()
+}
+
+func (m *IssuesList) HasHierarchyTab() bool {
+	return m.hierarchyTabIdx >= 0
+}
+
+func (m *IssuesList) IsHierarchyTab() bool {
+	return m.hierarchyTabIdx >= 0 && m.tab == m.hierarchyTabIdx
+}
+
+// The current hierarchy tab title ("Children"/"Parent"/"Link").
+func (m *IssuesList) HierarchyTitle() string {
+	return m.hierarchyTitle
+}
+
+// The NavStack associated with the hierarchy tab, or nil if no
+// hierarchy tab exists.
+func (m *IssuesList) HierarchyStack() *navstack.NavStack {
+	return m.hierarchyStack
+}
+
 func (m *IssuesList) NextTab() {
 	if len(m.tabs) == 0 {
 		return
@@ -153,6 +230,8 @@ func (m *IssuesList) loadFromCache() {
 }
 
 func (m *IssuesList) GetTabIndex() int { return m.tab }
+
+func (m *IssuesList) CurrentIssues() []jira.Issue { return m.allIssues }
 
 // SetTabIndex switches to the given tab and loads from cache if available
 func (m *IssuesList) SetTabIndex(idx int) {
@@ -228,16 +307,26 @@ func (m *IssuesList) SetIssuesForTab(tab int, issues []jira.Issue) {
 	m.tabCache[tab] = issues
 }
 
-// InvalidateTabCache clears all cached tab data
+// InvalidateTabCache clears all cached tab data and removes transient tabs (JQL and Hierarchy).
 func (m *IssuesList) InvalidateTabCache() {
 	m.tabCache = nil
-	if m.jqlTabIdx >= 0 {
-		m.tabs = m.tabs[:m.jqlTabIdx]
-		m.jqlTabIdx = -1
-		m.jqlQuery = ""
-		if m.tab >= len(m.tabs) {
-			m.tab = 0
-		}
+	trimFrom := len(m.tabs)
+	if m.jqlTabIdx >= 0 && m.jqlTabIdx < trimFrom {
+		trimFrom = m.jqlTabIdx
+	}
+	if m.hierarchyTabIdx >= 0 && m.hierarchyTabIdx < trimFrom {
+		trimFrom = m.hierarchyTabIdx
+	}
+	if trimFrom < len(m.tabs) {
+		m.tabs = m.tabs[:trimFrom]
+	}
+	m.jqlTabIdx = -1
+	m.jqlQuery = ""
+	m.hierarchyTabIdx = -1
+	m.hierarchyTitle = ""
+	m.hierarchyStack = nil
+	if m.tab >= len(m.tabs) {
+		m.tab = 0
 	}
 }
 
@@ -485,11 +574,11 @@ func (m *IssuesList) renderIssueRow(issue jira.Issue, width int, selected bool) 
 			if currStatusIcon != "" {
 				parts = append(parts, padRight(currStatusIcon, m.statusIconCols))
 			} else {
-                if selected {
-                    parts = append(parts, padRight(statusEmojiPlain(issue.Status), m.statusIconCols))
-                } else {
-                    parts = append(parts, padRight(statusEmoji(issue.Status), m.statusIconCols))
-                }
+				if selected {
+					parts = append(parts, padRight(statusEmojiPlain(issue.Status), m.statusIconCols))
+				} else {
+					parts = append(parts, padRight(statusEmoji(issue.Status), m.statusIconCols))
+				}
 			}
 		case "priority":
 			name := ""

--- a/pkg/tui/views/issues_hierarchy_tab_test.go
+++ b/pkg/tui/views/issues_hierarchy_tab_test.go
@@ -1,0 +1,196 @@
+package views
+
+import (
+	"testing"
+
+	"github.com/textfuel/lazyjira/v2/pkg/config"
+	"github.com/textfuel/lazyjira/v2/pkg/jira"
+)
+
+func TestAddHierarchyTab_SetsTabAndFocus(t *testing.T) {
+	m := NewIssuesList()
+	m.SetTabs([]config.IssueTabConfig{{Name: "My", JQL: ""}})
+	issues := []jira.Issue{{Key: "CHILD-1"}}
+
+	idx := m.AddHierarchyTab("Child", issues)
+
+	if !m.HasHierarchyTab() {
+		t.Fatalf("HasHierarchyTab() = false, want true")
+	}
+	if !m.IsHierarchyTab() {
+		t.Fatalf("IsHierarchyTab() = false, want true after AddHierarchyTab")
+	}
+	if m.GetTabIndex() != idx {
+		t.Fatalf("GetTabIndex() = %d, want %d", m.GetTabIndex(), idx)
+	}
+	if got := m.HierarchyTitle(); got != "Child" {
+		t.Fatalf("HierarchyTitle() = %q, want %q", got, "Child")
+	}
+	if m.HierarchyStack() == nil {
+		t.Fatalf("HierarchyStack() = nil, want non-nil after AddHierarchyTab")
+	}
+}
+
+func TestAddHierarchyTab_AppendedAfterJQLTab(t *testing.T) {
+	m := NewIssuesList()
+	m.SetTabs([]config.IssueTabConfig{{Name: "My", JQL: ""}})
+	m.AddJQLTab("project = FOO")
+	jqlIdx := m.GetTabIndex()
+
+	hierarchyIdx := m.AddHierarchyTab("Child", []jira.Issue{{Key: "C-1"}})
+
+	if hierarchyIdx <= jqlIdx {
+		t.Fatalf("hierarchyIdx=%d must be greater than jqlIdx=%d (hierarchy after JQL)", hierarchyIdx, jqlIdx)
+	}
+	if !m.HasJQLTab() {
+		t.Fatalf("JQL-Tab must survive AddHierarchyTab")
+	}
+}
+
+func TestReplaceHierarchyTabContent_UpdatesTitleAndIssues(t *testing.T) {
+	m := NewIssuesList()
+	m.SetTabs([]config.IssueTabConfig{{Name: "My", JQL: ""}})
+	idx := m.AddHierarchyTab("Child", []jira.Issue{{Key: "C-1"}})
+
+	m.ReplaceHierarchyTabContent("Parent", []jira.Issue{{Key: "P-1"}})
+
+	if m.GetTabIndex() != idx {
+		t.Fatalf("GetTabIndex() = %d, want %d (stable across replace)", m.GetTabIndex(), idx)
+	}
+	if got := m.HierarchyTitle(); got != "Parent" {
+		t.Fatalf("HierarchyTitle() = %q, want Parent", got)
+	}
+	sel := m.SelectedIssue()
+	if sel == nil || sel.Key != "P-1" {
+		t.Fatalf("SelectedIssue() after replace = %+v, want P-1", sel)
+	}
+}
+
+func TestReplaceHierarchyTabContent_NoHierarchyTab_NoOp(t *testing.T) {
+	m := NewIssuesList()
+	m.SetTabs([]config.IssueTabConfig{{Name: "My", JQL: ""}})
+
+	m.ReplaceHierarchyTabContent("Parent", []jira.Issue{{Key: "P-1"}})
+
+	if m.HasHierarchyTab() {
+		t.Fatalf("HasHierarchyTab() = true, want false (no-op when no hierarchy tab)")
+	}
+}
+
+func TestRemoveHierarchyTab_RemovesTabAndStack(t *testing.T) {
+	m := NewIssuesList()
+	m.SetTabs([]config.IssueTabConfig{{Name: "My", JQL: ""}})
+	m.AddHierarchyTab("Child", []jira.Issue{{Key: "C-1"}})
+
+	m.RemoveHierarchyTab()
+
+	if m.HasHierarchyTab() {
+		t.Fatalf("HasHierarchyTab() = true, want false after RemoveHierarchyTab")
+	}
+	if m.HierarchyStack() != nil {
+		t.Fatalf("HierarchyStack() = non-nil, want nil after RemoveHierarchyTab")
+	}
+	if m.GetTabIndex() != 0 {
+		t.Fatalf("GetTabIndex() = %d, want 0 after RemoveHierarchyTab", m.GetTabIndex())
+	}
+}
+
+func TestRemoveHierarchyTab_NoHierarchyTab_NoOp(t *testing.T) {
+	m := NewIssuesList()
+	m.SetTabs([]config.IssueTabConfig{{Name: "My", JQL: ""}})
+
+	m.RemoveHierarchyTab()
+
+	if m.HasHierarchyTab() {
+		t.Fatalf("HasHierarchyTab() = true, want false")
+	}
+}
+
+func TestRemoveHierarchyTab_WithJQLTabPresent_JQLIdxStable(t *testing.T) {
+	m := NewIssuesList()
+	m.SetTabs([]config.IssueTabConfig{{Name: "My", JQL: ""}})
+	m.AddJQLTab("project = FOO")
+	jqlIdxBefore := len(m.tabs) - 1
+	m.AddHierarchyTab("Child", []jira.Issue{{Key: "C-1"}})
+
+	m.RemoveHierarchyTab()
+
+	if !m.HasJQLTab() {
+		t.Fatalf("JQL-Tab must survive RemoveHierarchyTab")
+	}
+	if got := len(m.tabs) - 1; got != jqlIdxBefore {
+		t.Fatalf("JQL-Tab index shifted after RemoveHierarchyTab: got %d, want %d", got, jqlIdxBefore)
+	}
+}
+
+func TestHierarchyTab_SurvivesJQLTabSwitch(t *testing.T) {
+	m := NewIssuesList()
+	m.SetTabs([]config.IssueTabConfig{{Name: "My", JQL: ""}})
+	m.AddJQLTab("project = FOO")
+	jqlIdx := m.GetTabIndex()
+	hierarchyIdx := m.AddHierarchyTab("Child", []jira.Issue{{Key: "C-1"}})
+	stackBefore := m.HierarchyStack()
+
+	m.SetTabIndex(jqlIdx)
+	m.SetTabIndex(hierarchyIdx)
+
+	if !m.HasHierarchyTab() {
+		t.Fatalf("hierarchy tab lost after JQL round-trip")
+	}
+	if !m.IsHierarchyTab() {
+		t.Fatalf("IsHierarchyTab() = false after switching back")
+	}
+	if m.HierarchyStack() != stackBefore {
+		t.Fatalf("HierarchyStack() identity changed after switch (want same pointer)")
+	}
+	if m.HierarchyTitle() != "Child" {
+		t.Fatalf("HierarchyTitle() = %q, want Child", m.HierarchyTitle())
+	}
+}
+
+func TestHierarchyTab_StackAccessibleAfterSwitch(t *testing.T) {
+	m := NewIssuesList()
+	m.SetTabs([]config.IssueTabConfig{{Name: "My", JQL: ""}})
+	m.AddJQLTab("project = FOO")
+	jqlIdx := m.GetTabIndex()
+	hierarchyIdx := m.AddHierarchyTab("Child", []jira.Issue{{Key: "C-1"}})
+
+	depthBefore := m.HierarchyStack().Depth()
+	m.SetTabIndex(jqlIdx)
+	m.SetTabIndex(hierarchyIdx)
+
+	if got := m.HierarchyStack().Depth(); got != depthBefore {
+		t.Fatalf("HierarchyStack Depth after switch = %d, want %d", got, depthBefore)
+	}
+}
+
+func TestInvalidateTabCache_RemovesHierarchyTab(t *testing.T) {
+	m := NewIssuesList()
+	m.SetTabs([]config.IssueTabConfig{{Name: "My", JQL: ""}})
+	m.AddHierarchyTab("Child", []jira.Issue{{Key: "C-1"}})
+
+	m.InvalidateTabCache()
+
+	if m.HasHierarchyTab() {
+		t.Fatalf("HasHierarchyTab() = true, want false after InvalidateTabCache")
+	}
+	if m.HierarchyStack() != nil {
+		t.Fatalf("HierarchyStack() = non-nil, want nil after InvalidateTabCache")
+	}
+}
+
+func TestInvalidateTabCache_WithBothTabs_RemovesBoth(t *testing.T) {
+	m := NewIssuesList()
+	m.SetTabs([]config.IssueTabConfig{{Name: "My", JQL: ""}})
+	m.AddJQLTab("project = FOO")
+	m.AddHierarchyTab("Child", []jira.Issue{{Key: "C-1"}})
+
+	m.InvalidateTabCache()
+
+	if m.HasHierarchyTab() {
+		t.Fatalf("hierarchy tab survived InvalidateTabCache")
+	}
+	if m.HasJQLTab() {
+		t.Fatalf("JQL-Tab survived InvalidateTabCache")
+	}
+}


### PR DESCRIPTION
Closes #47

Space opens an issue's children, Backspace opens its parent; each step pushes onto a stack and Esc pops back. The Sub and Lnk info-panel tabs offer the same walks for the previewed issue. Both walks share an ad-hoc tab next to the existing ones, like the JQL tab.

- Cloud children come from the parent-link query from #66 (same data the Sub tab shows); DC still reads `Issue.Subtasks`.
- Each step snapshots the left panel (issues, cursor, focused panel, info tab and cursor) so Esc returns to where the user was.
- Space on a leaf issue opens its detail. Backspace on an issue without a parent is a no-op.
- Parent and Cloud children fetches drop stale responses by epoch, matching the existing `previewEpoch` pattern.

#66 was only the enabler for this PR. I got sidetracked, while working on this and realized, that I would have to solve the parent-link problem first.