### PR TITLE
Support configurable icons for issue priorities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Added
+
+- Custom icons for issue priorities in the list view. Configure via `gui.priorityIcons` map in config.yml. Plain text works too.
+
 ## [2.13.0] - 2026-05-05
 
 ### Added

--- a/docs/Config.md
+++ b/docs/Config.md
@@ -59,6 +59,12 @@ gui:
         To do: "📋"
         On hold: "⏸️"
         Future: "🔜"
+    priorityIcons:
+        Highest: "⇈"
+        High: "↑"
+        Medium: "→"
+        Low: "↓"
+        Lowest: "⇊"
 
 keybinding:
     universal:
@@ -211,6 +217,18 @@ gui:
         To do: "📋"
         On hold: "⏸️"
         Future: "🔜"
+```
+
+`priorityIcons` will have issue `priority` names replaced by the emojis you set. Mappings are case-sensitive, and support not only emojis but also plaintext. Unmapped priorities fall back to the plain priority name. Enable the field `priority` under `issueListFields` to profit from this option.
+
+```
+gui:
+    priorityIcons:
+        Highest: "⇈"
+        High: "↑"
+        Medium: "→"
+        Low: "↓"
+        Lowest: "⇊"
 ```
 
 ### Issue list fields

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -190,6 +190,7 @@ type GUIConfig struct {
 	SelectCreatedIssue   *bool             `yaml:"selectCreatedIssue"`
 	TypeIcons            map[string]string `yaml:"typeIcons"`
 	StatusIcons          map[string]string `yaml:"statusIcons"`
+	PriorityIcons        map[string]string `yaml:"priorityIcons"`
 }
 
 // ShouldPrefillFromTab returns true when the creation form should prefill from tab JQL

--- a/pkg/tui/app.go
+++ b/pkg/tui/app.go
@@ -253,6 +253,9 @@ func NewAppWithAuth(cfg *config.Config, client jira.ClientInterface, authMethod 
 	if len(cfg.GUI.StatusIcons) > 0 {
 		issuesList.SetStatusIcons(cfg.GUI.StatusIcons)
 	}
+	if len(cfg.GUI.PriorityIcons) > 0 {
+		issuesList.SetPriorityIcons(cfg.GUI.PriorityIcons)
+	}
 	issuesList.SetTabs(cfg.IssueTabs)
 	issuesList.SetFocused(true)
 	issuesList.SetUserEmail(cfg.Jira.Email)

--- a/pkg/tui/views/issues.go
+++ b/pkg/tui/views/issues.go
@@ -28,25 +28,27 @@ const statusOpen = "○"
 
 type IssuesList struct {
 	components.ListBase
-	issues          []jira.Issue
-	allIssues       []jira.Issue
-	filter          string
-	tabs            []config.IssueTabConfig
-	tab             int
-	tabCache        map[int][]jira.Issue
-	userEmail       string
-	keyColWidth     int
-	fields          []string
-	theme           *theme.Theme
-	typeIcons       map[string]string
-	typeIconCols    int
-	statusIcons     map[string]string
-	statusIconCols  int
-	jqlQuery        string
-	jqlTabIdx       int
-	hierarchyTabIdx int
-	hierarchyTitle  string
-	hierarchyStack  *navstack.NavStack
+	issues           []jira.Issue
+	allIssues        []jira.Issue
+	filter           string
+	tabs             []config.IssueTabConfig
+	tab              int
+	tabCache         map[int][]jira.Issue
+	userEmail        string
+	keyColWidth      int
+	fields           []string
+	theme            *theme.Theme
+	typeIcons        map[string]string
+	typeIconCols     int
+	statusIcons      map[string]string
+	statusIconCols   int
+	priorityIcons    map[string]string
+	priorityIconCols int
+	jqlQuery         string
+	jqlTabIdx        int
+	hierarchyTabIdx  int
+	hierarchyTitle   string
+	hierarchyStack   *navstack.NavStack
 }
 
 func NewIssuesList() *IssuesList {
@@ -73,6 +75,16 @@ func (m *IssuesList) SetStatusIcons(icons map[string]string) {
 		}
 	}
 	m.statusIconCols = max
+}
+func (m *IssuesList) SetPriorityIcons(icons map[string]string) {
+	m.priorityIcons = icons
+	max := 0
+	for _, icon := range icons {
+		if w := lipgloss.Width(icon); w > max {
+			max = w
+		}
+	}
+	m.priorityIconCols = max
 }
 func (m *IssuesList) SetTabs(tabs []config.IssueTabConfig) { m.tabs = tabs }
 func (m *IssuesList) SetUserEmail(email string)            { m.userEmail = email }
@@ -535,6 +547,7 @@ func (m *IssuesList) renderIssueRow(issue jira.Issue, width int, selected bool) 
 
 	currTypeIcon := typeIcon(m.typeIcons, issue.IssueType)
 	currStatusIcon := statusIcon(m.statusIcons, issue.Status)
+	currPriorityIcon := priorityIcon(m.priorityIcons, issue.Priority)
 
 	fixedWidth := 1
 	if len(fields) > 1 {
@@ -547,7 +560,11 @@ func (m *IssuesList) renderIssueRow(issue jira.Issue, width int, selected bool) 
 		case fieldStatus:
 			fixedWidth += max(1, m.statusIconCols)
 		case "priority":
-			fixedWidth += 8
+			if currPriorityIcon != "" {
+				fixedWidth += m.priorityIconCols
+			} else {
+				fixedWidth += 8
+			}
 		case "assignee":
 			fixedWidth += 12
 		case "type":
@@ -581,11 +598,15 @@ func (m *IssuesList) renderIssueRow(issue jira.Issue, width int, selected bool) 
 				}
 			}
 		case "priority":
-			name := ""
-			if issue.Priority != nil {
-				name = issue.Priority.Name
+			if currPriorityIcon != "" {
+				parts = append(parts, padRight(currPriorityIcon, m.priorityIconCols))
+			} else {
+				name := ""
+				if issue.Priority != nil {
+					name = issue.Priority.Name
+				}
+				parts = append(parts, padRight(components.TruncateEnd(name, 8), 8))
 			}
-			parts = append(parts, padRight(components.TruncateEnd(name, 8), 8))
 		case "assignee":
 			name := ""
 			if issue.Assignee != nil {
@@ -662,6 +683,18 @@ func statusIcon(icons map[string]string, status *jira.Status) string {
 		return ""
 	}
 	icon, ok := icons[status.Name]
+	if !ok || icon == "" {
+		return ""
+	}
+	return icon
+}
+
+// priorityIcon returns the configured icon for the given priority, or empty string if none.
+func priorityIcon(icons map[string]string, priority *jira.Priority) string {
+	if priority == nil {
+		return ""
+	}
+	icon, ok := icons[priority.Name]
 	if !ok || icon == "" {
 		return ""
 	}


### PR DESCRIPTION
Adds `gui.priorityIcons`, mirroring `typeIcons` (#38) and `statusIcons`
(#64). Unmapped priorities keep their plain name.