### PR TITLE
Add slugify template function for custom commands

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/charmbracelet/x/ansi v0.11.6
+	golang.org/x/text v0.3.8
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -31,5 +32,4 @@ require (
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	golang.org/x/sys v0.38.0 // indirect
-	golang.org/x/text v0.3.8 // indirect
 )

--- a/pkg/ascii/ascii.go
+++ b/pkg/ascii/ascii.go
@@ -1,0 +1,47 @@
+// Package ascii reduces Unicode strings to ASCII via transliteration
+// and NFD-based accent stripping.
+package ascii
+
+import (
+	"strings"
+
+	"golang.org/x/text/unicode/norm"
+)
+
+// transliterations expands letters that need multi-char ASCII output
+// (German ä->ae, ß->ss). Plain accents go through NFD in Convert.
+var transliterations = map[rune]string{
+	'ä': "ae",
+	'ö': "oe",
+	'ü': "ue",
+	'ß': "ss",
+}
+
+// Convert lowercases s and reduces it to ASCII. German umlauts and ß
+// expand (ä->ae, ß->ss); other accented letters decompose via NFD to
+// their base letter (é->e). Anything still non-ASCII is dropped. ASCII
+// punctuation is preserved - callers decide how to filter it.
+func Convert(s string) string {
+	s = strings.ToLower(s)
+
+	var pre strings.Builder
+	pre.Grow(len(s))
+	for _, r := range s {
+		if rep, ok := transliterations[r]; ok {
+			pre.WriteString(rep)
+		} else {
+			pre.WriteRune(r)
+		}
+	}
+	decomposed := norm.NFD.String(pre.String())
+
+	var out strings.Builder
+	out.Grow(len(decomposed))
+	for _, r := range decomposed {
+		if r >= 128 {
+			continue
+		}
+		out.WriteRune(r)
+	}
+	return out.String()
+}

--- a/pkg/ascii/ascii_test.go
+++ b/pkg/ascii/ascii_test.go
@@ -1,0 +1,27 @@
+package ascii
+
+import "testing"
+
+func TestConvert(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"", ""},
+		{"hello", "hello"},
+		{"HELLO", "hello"},
+		{"Größe", "groesse"},
+		{"über alles", "ueber alles"},
+		{"straße", "strasse"},
+		{"café", "cafe"},
+		{"naïve", "naive"},
+		{"jalapeño", "jalapeno"},
+		{"keeps punctuation: a/b.c_d", "keeps punctuation: a/b.c_d"},
+		// Contract: Convert only strips non-ASCII runes and combining marks.
+		// ASCII punctuation survives by design — callers decide which chars
+		// to filter further.
+		{"a_b<c>d|e$f%g`h", "a_b<c>d|e$f%g`h"},
+	}
+	for _, tc := range cases {
+		if got := Convert(tc.in); got != tc.want {
+			t.Errorf("Convert(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}

--- a/pkg/config/custom_commands.go
+++ b/pkg/config/custom_commands.go
@@ -5,6 +5,8 @@ import (
 	"slices"
 	"strings"
 	"text/template"
+
+	"github.com/textfuel/lazyjira/v2/pkg/ascii"
 )
 
 // Context identifies a UI state in which a custom command may fire.
@@ -64,8 +66,34 @@ func shellescape(s string) string {
 	return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'"
 }
 
+// slugify produces an ASCII slug: lowercase [a-z0-9], other runes
+// collapsed to '-'. Delegates ASCII normalization to ascii.Convert so
+// the transliteration rules (ä->ae, ß->ss, NFD accent strip) stay
+// shared with branch-name sanitization.
+func slugify(s string) string {
+	s = ascii.Convert(s)
+
+	var b strings.Builder
+	b.Grow(len(s))
+	prevDash := true // suppress leading dashes
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9':
+			b.WriteRune(r)
+			prevDash = false
+		default:
+			if !prevDash {
+				b.WriteByte('-')
+				prevDash = true
+			}
+		}
+	}
+	return strings.TrimRight(b.String(), "-")
+}
+
 var commandFuncMap = template.FuncMap{
 	"shellescape": shellescape,
+	"slugify":     slugify,
 }
 
 // ResolveCustomCommands validates the flat CustomCommands list and returns

--- a/pkg/config/custom_commands_test.go
+++ b/pkg/config/custom_commands_test.go
@@ -192,3 +192,57 @@ func TestResolveCustomCommands_ShellescapeFunc(t *testing.T) {
 		t.Errorf("output = %q, want %q", got, want)
 	}
 }
+
+func TestSlugify(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"", ""},
+		{"hello", "hello"},
+		{"Hello World", "hello-world"},
+		{"Fix Bug #42!", "fix-bug-42"},
+		{"  leading and trailing  ", "leading-and-trailing"},
+		{"multiple   spaces", "multiple-spaces"},
+		{"--already--dashed--", "already-dashed"},
+		{"snake_case_name", "snake-case-name"},
+		{"path/to/thing", "path-to-thing"},
+		{"!!!", ""},
+		{"123-foo", "123-foo"},
+		{"a\tb\nc", "a-b-c"},
+		{"Übung 1", "uebung-1"},
+		{"Größe", "groesse"},
+		{"über alles", "ueber-alles"},
+		{"straße", "strasse"},
+		{"café", "cafe"},
+		{"naïve", "naive"},
+		{"jalapeño piñata", "jalapeno-pinata"},
+	}
+	for _, tc := range cases {
+		if got := slugify(tc.in); got != tc.want {
+			t.Errorf("slugify(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestResolveCustomCommands_SlugifyFunc(t *testing.T) {
+	cfg := &Config{
+		CustomCommands: []CustomCommandConfig{
+			{Key: "b", Name: "Branch", Command: "git checkout -b {{.Summary | slugify}}"},
+		},
+	}
+	resolved, err := cfg.ResolveCustomCommands()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var buf bytes.Buffer
+	data := struct{ Summary string }{Summary: "Fix Login Bug #42!"}
+	if err := resolved[0].Template.Execute(&buf, data); err != nil {
+		t.Fatalf("template execute error: %v", err)
+	}
+
+	want := "git checkout -b fix-login-bug-42"
+	if got := buf.String(); got != want {
+		t.Errorf("output = %q, want %q", got, want)
+	}
+}

--- a/pkg/git/branchname.go
+++ b/pkg/git/branchname.go
@@ -5,7 +5,8 @@ import (
 	"regexp"
 	"strings"
 	"text/template"
-	"unicode"
+
+	"github.com/textfuel/lazyjira/v2/pkg/ascii"
 )
 
 // BranchTemplateData holds data available in branch name templates
@@ -18,8 +19,10 @@ type BranchTemplateData struct {
 	ParentKey  string
 }
 
-const defaultTemplate = "{{.Key}}-{{.Summary}}"
-const maxBranchLen = 60
+const (
+	defaultTemplate = "{{.Key}}-{{.Summary}}"
+	maxBranchLen    = 60
+)
 
 var (
 	issueKeyRe   = regexp.MustCompile(`(?i)([A-Z][A-Z0-9]+-\d+)`)
@@ -31,8 +34,10 @@ var (
 )
 
 // GenerateBranchName creates a branch name from issue data using the given template.
-// Pass an empty string for tmplStr to use the default template.
-func GenerateBranchName(data BranchTemplateData, tmplStr string, asciiOnly bool) string {
+// Pass an empty string for tmplStr to use the default template. ASCII
+// reduction is the caller's responsibility (per-field, before passing
+// data in); see pkg/tui/handlers_keys.go.
+func GenerateBranchName(data BranchTemplateData, tmplStr string) string {
 	if tmplStr == "" {
 		tmplStr = defaultTemplate
 	}
@@ -49,26 +54,16 @@ func GenerateBranchName(data BranchTemplateData, tmplStr string, asciiOnly bool)
 		_ = tmpl.Execute(&buf, data)
 	}
 
-	return Sanitize(buf.String(), asciiOnly)
+	return Sanitize(buf.String())
 }
 
-// Sanitize cleans a branch name to be a valid git ref
-func Sanitize(name string, asciiOnly bool) string {
+// Sanitize cleans a branch name to be a valid git ref.
+func Sanitize(name string) string {
 	name = strings.TrimLeft(name, "/")
 	name = strings.ReplaceAll(name, " ", "-")
 	name = invalidChars.ReplaceAllString(name, "")
 	name = strings.ReplaceAll(name, "..", ".")
 	name = atBrace.ReplaceAllString(name, "")
-
-	if asciiOnly {
-		var b strings.Builder
-		for _, r := range name {
-			if r < 128 {
-				b.WriteRune(r)
-			}
-		}
-		name = b.String()
-	}
 
 	name = multiHyphens.ReplaceAllString(name, "-")
 	name = multiDots.ReplaceAllString(name, ".")
@@ -85,7 +80,12 @@ func Sanitize(name string, asciiOnly bool) string {
 
 // SanitizeSummary converts an issue summary to a branch-name-friendly slug
 func SanitizeSummary(summary string, asciiOnly bool) string {
-	s := strings.ToLower(summary)
+	var s string
+	if asciiOnly {
+		s = ascii.Convert(summary)
+	} else {
+		s = strings.ToLower(summary)
+	}
 	s = strings.ReplaceAll(s, " ", "-")
 	s = invalidChars.ReplaceAllString(s, "")
 	s = strings.Map(func(r rune) rune {
@@ -94,16 +94,6 @@ func SanitizeSummary(summary string, asciiOnly bool) string {
 		}
 		return r
 	}, s)
-
-	if asciiOnly {
-		var b strings.Builder
-		for _, r := range s {
-			if r < 128 && (unicode.IsLetter(r) || unicode.IsDigit(r) || r == '-' || r == '.') {
-				b.WriteRune(r)
-			}
-		}
-		s = b.String()
-	}
 
 	s = multiHyphens.ReplaceAllString(s, "-")
 	s = strings.Trim(s, "-.")

--- a/pkg/git/branchname_test.go
+++ b/pkg/git/branchname_test.go
@@ -7,11 +7,10 @@ import (
 
 func TestGenerateBranchName(t *testing.T) {
 	tests := []struct {
-		name      string
-		data      BranchTemplateData
-		tmpl      string
-		asciiOnly bool
-		want      string
+		name string
+		data BranchTemplateData
+		tmpl string
+		want string
 	}{
 		{
 			name: "default template",
@@ -54,21 +53,23 @@ func TestGenerateBranchName(t *testing.T) {
 			want: "Story/PROJ-10/PROJ-42-add-feature",
 		},
 		{
-			name: "ascii only strips unicode from summary",
+			// GenerateBranchName does not transliterate by itself; ASCII
+			// reduction is a per-field caller responsibility. Non-ASCII
+			// in raw fields survives.
+			name: "non-ASCII in raw fields survives",
 			data: BranchTemplateData{
-				Key:       "PROJ-1",
-				ParentKey: "PROJ-2",
-				Summary:   "fix-\u00e4\u00f6\u00fc-bug",
+				Key:     "PROJ-1",
+				Type:    "L\u00f6sung",
+				Summary: "fix-bug",
 			},
-			tmpl:      "{{.ParentKey}}/{{.Key}}_{{.Summary}}",
-			asciiOnly: true,
-			want:      "PROJ-2/PROJ-1_fix-bug",
+			tmpl: "{{.Type}}/{{.Key}}-{{.Summary}}",
+			want: "L\u00f6sung/PROJ-1-fix-bug",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := GenerateBranchName(tt.data, tt.tmpl, tt.asciiOnly)
+			got := GenerateBranchName(tt.data, tt.tmpl)
 			if got != tt.want {
 				t.Errorf("GenerateBranchName() = %q, want %q", got, tt.want)
 			}
@@ -78,23 +79,22 @@ func TestGenerateBranchName(t *testing.T) {
 
 func TestSanitize(t *testing.T) {
 	tests := []struct {
-		name      string
-		input     string
-		asciiOnly bool
-		want      string
+		name  string
+		input string
+		want  string
 	}{
-		{"spaces to hyphens", "hello world", false, "hello-world"},
-		{"multiple hyphens", "a---b", false, "a-b"},
-		{"trailing dot", "branch.", false, "branch"},
-		{"trailing slash", "branch/", false, "branch"},
-		{"max length truncation", "a-" + strings.Repeat("b", 100), false, "a-" + strings.Repeat("b", 58)},
-		{"slash preserved", "parent/child", false, "parent/child"},
-		{"leading slash stripped", "/child", false, "child"},
+		{"spaces to hyphens", "hello world", "hello-world"},
+		{"multiple hyphens", "a---b", "a-b"},
+		{"trailing dot", "branch.", "branch"},
+		{"trailing slash", "branch/", "branch"},
+		{"max length truncation", "a-" + strings.Repeat("b", 100), "a-" + strings.Repeat("b", 58)},
+		{"slash preserved", "parent/child", "parent/child"},
+		{"leading slash stripped", "/child", "child"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := Sanitize(tt.input, tt.asciiOnly)
+			got := Sanitize(tt.input)
 			if got != tt.want {
 				t.Errorf("Sanitize(%q) = %q, want %q", tt.input, got, tt.want)
 			}
@@ -112,6 +112,10 @@ func TestSanitizeSummary(t *testing.T) {
 		{"basic", "Fix Login Bug", false, "fix-login-bug"},
 		{"special chars", "Add feature (v2) & test!", false, "add-feature-v2-test"},
 		{"ascii only", "Umlaut aeoeue", true, "umlaut-aeoeue"},
+		{"umlauts transliterated", "Größe der Straße", true, "groesse-der-strasse"},
+		{"accents stripped", "café piñata", true, "cafe-pinata"},
+		{"umlauts with droppable special chars", "Fehler in Größe (v2)", true, "fehler-in-groesse-v2"},
+		{"umlauts kept when not asciiOnly", "Größe", false, "größe"},
 	}
 
 	for _, tt := range tests {
@@ -123,3 +127,4 @@ func TestSanitizeSummary(t *testing.T) {
 		})
 	}
 }
+

--- a/pkg/tui/handlers_keys.go
+++ b/pkg/tui/handlers_keys.go
@@ -5,6 +5,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 
+	"github.com/textfuel/lazyjira/v2/pkg/ascii"
 	"github.com/textfuel/lazyjira/v2/pkg/git"
 	"github.com/textfuel/lazyjira/v2/pkg/tui/components"
 	"github.com/textfuel/lazyjira/v2/pkg/tui/views"
@@ -701,6 +702,9 @@ func (a *App) handleActionCreateBranch() (tea.Model, tea.Cmd) {
 	if sel.IssueType != nil {
 		typeName = sel.IssueType.Name
 	}
+	if a.cfg.Git.AsciiOnly {
+		typeName = ascii.Convert(typeName)
+	}
 	parentKey := ""
 	if sel.Parent != nil {
 		parentKey = sel.Parent.Key
@@ -720,7 +724,7 @@ func (a *App) handleActionCreateBranch() (tea.Model, tea.Cmd) {
 			break
 		}
 	}
-	name := git.GenerateBranchName(data, tmplStr, a.cfg.Git.AsciiOnly)
+	name := git.GenerateBranchName(data, tmplStr)
 	a.inputModal.Show("Create branch", name)
 	a.editContext = editCtx{kind: editBranch}
 	if result, err := git.SearchBranches(a.gitRepoPath, sel.Key); err == nil {


### PR DESCRIPTION
Closes #71

Registers a `slugify` filter on the customCommands template `FuncMap`, so
fields like `.Summary` can be turned into URL- and branch-safe
identifiers:

```yaml
customCommands:
  - command: "git switch -c wip/{{ .Key }}-{{ .Summary | slugify }}"
```

Output is lowercase ASCII with hyphens between word-ish runs. German
umlauts and `ß` are transliterated properly (`ä` -> `ae`, `ß` -> `ss`); accents
from other languages are stripped via NFD (`è` -> `e`).

The ASCII-normalization is factored out as `git.ToASCII` so it can be
shared with the existing branch-name path. As a side effect,
`SanitizeSummary(..., asciiOnly: true)` now transliterates umlauts
instead of dropping.