### PR TITLE
Create subtasks under the selected issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ Press `?` inside the app for all keybindings.
 - [x] Configurable navigation keys
 - [x] Searchable keybindings help popup
 - [x] Scroll detail panel without switching focus
-- [ ] Create subtasks from TUI
+- [x] Create subtasks from TUI
 - [ ] Link issues (add/remove issue links)
 - [ ] CLI mode (non-interactive commands for scripting and automation)
 - [ ] Robust issue type changer (handle subtask/parent unlinking, field validation)

--- a/docs/Keybindings.md
+++ b/docs/Keybindings.md
@@ -33,6 +33,7 @@ Detail scroll keys (`J`/`K`/`ctrl+f`/`ctrl+b`) can be remapped via `keybinding.d
 | `a` | Change assignee |
 | `n` | Create new issue (issues list) or new comment (comments tab) |
 | `ctrl+n` | Duplicate issue |
+| `S` | Create a subtask under the selected issue (issues list or the info panel's Sub tab). Parent and project are taken from the selection; not available when the selection is itself a subtask or an epic. |
 | `c` | View comments |
 | `o` | Open in browser |
 | `u` | Pick URL from description |

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -155,16 +155,17 @@ type UniversalKeys struct {
 }
 
 type IssueKeys struct {
-	Select       string `yaml:"select"`
-	Open         string `yaml:"open"`
-	FocusRight   string `yaml:"focusRight"`
-	Transition   string `yaml:"transition"`
-	Browser      string `yaml:"browser"`
-	URLPicker    string `yaml:"urlPicker"`
-	CopyURL      string `yaml:"copyURL"`
-	CloseJQLTab  string `yaml:"closeJQLTab"`
-	CreateBranch string `yaml:"createBranch"`
-	CreateIssue  string `yaml:"createIssue"`
+	Select        string `yaml:"select"`
+	Open          string `yaml:"open"`
+	FocusRight    string `yaml:"focusRight"`
+	Transition    string `yaml:"transition"`
+	Browser       string `yaml:"browser"`
+	URLPicker     string `yaml:"urlPicker"`
+	CopyURL       string `yaml:"copyURL"`
+	CloseJQLTab   string `yaml:"closeJQLTab"`
+	CreateBranch  string `yaml:"createBranch"`
+	CreateIssue   string `yaml:"createIssue"`
+	CreateSubtask string `yaml:"createSubtask"`
 }
 
 type ProjectKeys struct {

--- a/pkg/jira/client.go
+++ b/pkg/jira/client.go
@@ -252,7 +252,7 @@ func (c *Client) doWithBase(ctx context.Context, baseURL, method, path string, b
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		c.log("  BODY: %s\n", string(respBody))
-		return fmt.Errorf("request %s %s returned status %d: %s", method, path, resp.StatusCode, string(respBody))
+		return newAPIError(method, path, resp.StatusCode, string(respBody))
 	}
 
 	if result != nil && len(respBody) > 0 {

--- a/pkg/jira/errors.go
+++ b/pkg/jira/errors.go
@@ -1,0 +1,60 @@
+package jira
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+)
+
+// APIError is a non-2xx response from the Jira REST API. It keeps the raw body
+// for the unchanged Error() string while exposing the parsed, user-facing
+// messages from the error envelope via Messages.
+type APIError struct {
+	Method   string
+	Path     string
+	Status   int
+	Body     string
+	Messages []string
+}
+
+func (e *APIError) Error() string {
+	return fmt.Sprintf("request %s %s returned status %d: %s",
+		e.Method, e.Path, e.Status, e.Body)
+}
+
+func newAPIError(method, path string, status int, body string) *APIError {
+	return &APIError{
+		Method:   method,
+		Path:     path,
+		Status:   status,
+		Body:     body,
+		Messages: parseErrorMessages(body),
+	}
+}
+
+// parseErrorMessages extracts the human-readable messages from a Jira REST
+// error envelope ({"errorMessages": [...], "errors": {...}}). Field errors are
+// appended in key order for determinism. Returns nil when the body is not such
+// an envelope.
+func parseErrorMessages(body string) []string {
+	var envelope struct {
+		ErrorMessages []string          `json:"errorMessages"`
+		Errors        map[string]string `json:"errors"`
+	}
+	if err := json.Unmarshal([]byte(body), &envelope); err != nil {
+		return nil
+	}
+
+	messages := envelope.ErrorMessages
+
+	keys := make([]string, 0, len(envelope.Errors))
+	for k := range envelope.Errors {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		messages = append(messages, envelope.Errors[k])
+	}
+
+	return messages
+}

--- a/pkg/jira/errors_test.go
+++ b/pkg/jira/errors_test.go
@@ -1,0 +1,72 @@
+package jira
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/textfuel/lazyjira/v2/pkg/internal/testkit"
+)
+
+func TestParseErrorMessages_ErrorMessagesArray(t *testing.T) {
+	t.Parallel()
+
+	body := `{"errorMessages":["You cannot create issues in this project."],"errors":{}}`
+	got := parseErrorMessages(body)
+
+	want := []string{"You cannot create issues in this project."}
+	if len(got) != len(want) || got[0] != want[0] {
+		t.Errorf("parseErrorMessages(%q) = %v, want %v", body, got, want)
+	}
+}
+
+func TestParseErrorMessages_FieldErrorsMap(t *testing.T) {
+	t.Parallel()
+
+	body := `{"errorMessages":[],"errors":{"parent":"Issue does not exist or you do not have permission to see it."}}`
+	got := parseErrorMessages(body)
+
+	want := []string{"Issue does not exist or you do not have permission to see it."}
+	if len(got) != len(want) || got[0] != want[0] {
+		t.Errorf("parseErrorMessages(%q) = %v, want %v", body, got, want)
+	}
+}
+
+func TestParseErrorMessages_NonEnvelopeReturnsNil(t *testing.T) {
+	t.Parallel()
+
+	if got := parseErrorMessages("plain text, not json"); got != nil {
+		t.Errorf("parseErrorMessages(non-json) = %v, want nil", got)
+	}
+}
+
+func TestClient_HTTPError_ExposesAPIErrorWithMessages(t *testing.T) {
+	t.Parallel()
+
+	body := `{"errorMessages":["You cannot create issues in this project."]}`
+	client, _ := newRecordingClient(t, cloudOpts(),
+		testkit.StubResponse{Status: http.StatusNotFound, Body: body})
+
+	_, err := client.GetCreateMeta(t.Context(), errorTestProjectKey, "10001")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("error %v is not unwrappable to *APIError", err)
+	}
+	if len(apiErr.Messages) != 1 ||
+		apiErr.Messages[0] != "You cannot create issues in this project." {
+		t.Errorf("apiErr.Messages = %v", apiErr.Messages)
+	}
+
+	// Backward compatibility: the Error() string keeps status and wrapper.
+	if !strings.Contains(err.Error(), "status 404") {
+		t.Errorf("Error() %q missing 'status 404'", err.Error())
+	}
+	if !strings.Contains(err.Error(), "get create meta") {
+		t.Errorf("Error() %q missing wrapper prefix", err.Error())
+	}
+}

--- a/pkg/tui/app.go
+++ b/pkg/tui/app.go
@@ -79,6 +79,7 @@ type createCtx struct {
 	projectID     string
 	issueTypeID   string
 	issueTypeName string
+	parentKey     string
 	duplicateFrom *jira.Issue
 }
 
@@ -521,6 +522,8 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		a.createForm.Resume()
 		a.createForm.SetError(msg.err.Error())
 		return a, nil
+	case createPreFormErrorMsg:
+		return a.handleCreatePreFormError(msg)
 	case issueUpdatedMsg:
 		return a.handleIssueUpdated(msg)
 	case commentAddedMsg:

--- a/pkg/tui/app_update_routing_test.go
+++ b/pkg/tui/app_update_routing_test.go
@@ -344,6 +344,26 @@ func TestUpdate_RoutesCreateAndEditMessages(t *testing.T) {
 			msg:  createErrorMsg{err: errors.New("boom")},
 		},
 		{
+			name: "pre-form create error aborts to status",
+			setup: func(app *App, _ *jiratest.FakeClient) {
+				app.createCtx = createCtx{projectKey: "DSOTEST", parentKey: testKey}
+				app.createForm.SetLoading(true)
+			},
+			msg: createPreFormErrorMsg{err: &jira.APIError{
+				Status:   404,
+				Messages: []string{"You cannot create issues in this project."},
+			}},
+			assert: func(t *testing.T, app *App) {
+				t.Helper()
+				if app.createForm.IsVisible() {
+					t.Error("form should be hidden after a pre-form error")
+				}
+				if app.statusPanel.ErrorMessage() == "" {
+					t.Error("status panel should carry the pre-form error")
+				}
+			},
+		},
+		{
 			name:    "issue updated refetches detail",
 			setup:   func(app *App, fake *jiratest.FakeClient) { stubFullIssueFetch(fake, &jira.Issue{Key: testKey}) },
 			msg:     issueUpdatedMsg{issueKey: testKey, field: "summary"},

--- a/pkg/tui/commands.go
+++ b/pkg/tui/commands.go
@@ -243,6 +243,11 @@ type createMetaLoadedMsg struct{ fields []jira.CreateMetaField }
 type issueCreatedMsg struct{ issue *jira.Issue }
 type createErrorMsg struct{ err error }
 
+// createPreFormErrorMsg is a create failure that happens before the form is
+// populated (issue-type metadata load). Unlike createErrorMsg it aborts the
+// flow instead of resuming an empty form.
+type createPreFormErrorMsg struct{ err error }
+
 type customFieldOptionsMsg struct {
 	issueKey      string
 	fieldID       string
@@ -303,7 +308,7 @@ func fetchCreateMeta(client jira.ClientInterface, projectKey, issueTypeID string
 	return func() tea.Msg {
 		fields, err := client.GetCreateMeta(context.Background(), projectKey, issueTypeID)
 		if err != nil {
-			return createErrorMsg{err: err}
+			return createPreFormErrorMsg{err: err}
 		}
 		return createMetaLoadedMsg{fields: fields}
 	}

--- a/pkg/tui/commands_fetch_test.go
+++ b/pkg/tui/commands_fetch_test.go
@@ -222,14 +222,14 @@ func TestFetchCreateMeta(t *testing.T) {
 		}
 	})
 
-	t.Run("error returns createErrorMsg", func(t *testing.T) {
+	t.Run("error returns createPreFormErrorMsg", func(t *testing.T) {
 		t.Parallel()
 		fake := newFakeClient(t)
 		fake.GetCreateMetaFunc = func(_ context.Context, _, _ string) ([]jira.CreateMetaField, error) {
 			return nil, errors.New("x")
 		}
-		if _, ok := fetchCreateMeta(fake, testProject, "10001")().(createErrorMsg); !ok {
-			t.Error("want createErrorMsg")
+		if _, ok := fetchCreateMeta(fake, testProject, "10001")().(createPreFormErrorMsg); !ok {
+			t.Error("want createPreFormErrorMsg")
 		}
 	})
 }

--- a/pkg/tui/components/createform.go
+++ b/pkg/tui/components/createform.go
@@ -672,13 +672,17 @@ func (f *CreateForm) submitForm() (tea.Cmd, bool) {
 		}
 	}
 	if hasErrors {
-		count := 0
+		var names []string
 		for _, fld := range f.allFields {
 			if fld.HasError {
-				count++
+				name := fld.Name
+				if name == "" {
+					name = fld.FieldID
+				}
+				names = append(names, name)
 			}
 		}
-		f.errorMsg = fmt.Sprintf("%d required field(s) empty", count)
+		f.errorMsg = "Required field(s) empty: " + strings.Join(names, ", ")
 		return nil, true
 	}
 

--- a/pkg/tui/components/createform_test.go
+++ b/pkg/tui/components/createform_test.go
@@ -720,6 +720,26 @@ func TestCreateForm_RenderWithError(t *testing.T) {
 	}
 }
 
+func TestCreateForm_SubmitNamesEmptyRequiredFields(t *testing.T) {
+	t.Parallel()
+	form := NewCreateForm(nil)
+	form.SetSize(120, 40)
+	form.ShowForm([]CreateFormField{
+		{FieldID: "summary", Name: "Summary", Type: CFFieldSingleText, Required: true, DisplayValue: "filled"},
+		{FieldID: "priority", Name: "Priority", Type: CFFieldSingleSelect, Required: true},
+		{FieldID: "components", Name: "Components", Type: CFFieldMultiSelect, Required: true},
+	}, testIssueType, testProjectKey)
+
+	cmd, _ := form.submitForm()
+
+	if cmd != nil {
+		t.Fatal("expected no submit cmd while required fields are empty")
+	}
+	if !strings.Contains(form.errorMsg, "Priority") || !strings.Contains(form.errorMsg, "Components") {
+		t.Errorf("error should name the empty required fields, got %q", form.errorMsg)
+	}
+}
+
 func TestCreateForm_InterceptMouseWheelScrolls(t *testing.T) {
 	t.Parallel()
 	form := NewCreateForm(nil)

--- a/pkg/tui/createerror.go
+++ b/pkg/tui/createerror.go
@@ -1,0 +1,37 @@
+package tui
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"unicode"
+
+	"github.com/textfuel/lazyjira/v2/pkg/jira"
+)
+
+// formatCreateError turns a create-flow failure into a user-facing message,
+// surfacing Jira's own errorMessages without the internal request wrapper. It
+// falls back to the raw error when the failure is not a Jira API error.
+func formatCreateError(err error, projectKey string, subtask bool) string {
+	var apiErr *jira.APIError
+	if !errors.As(err, &apiErr) || len(apiErr.Messages) == 0 {
+		return err.Error()
+	}
+
+	noun := "issue"
+	if subtask {
+		noun = "subtask"
+	}
+
+	detail := lowerFirst(strings.TrimRight(strings.Join(apiErr.Messages, "; "), "."))
+	return fmt.Sprintf("Cannot create %s in %s: %s", noun, projectKey, detail)
+}
+
+func lowerFirst(s string) string {
+	if s == "" {
+		return s
+	}
+	r := []rune(s)
+	r[0] = unicode.ToLower(r[0])
+	return string(r)
+}

--- a/pkg/tui/createerror_test.go
+++ b/pkg/tui/createerror_test.go
@@ -1,0 +1,76 @@
+package tui
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/textfuel/lazyjira/v2/pkg/jira"
+)
+
+func TestFormatCreateError_SubtaskWithAPIMessages(t *testing.T) {
+	t.Parallel()
+
+	err := &jira.APIError{
+		Method:   "GET",
+		Path:     "/issue/createmeta/DSOTEST/issuetypes/10054",
+		Status:   404,
+		Body:     `{"errorMessages":["You cannot create issues in this project."]}`,
+		Messages: []string{"You cannot create issues in this project."},
+	}
+
+	got := formatCreateError(err, "DSOTEST", true)
+	want := "Cannot create subtask in DSOTEST: you cannot create issues in this project"
+	if got != want {
+		t.Errorf("formatCreateError() = %q, want %q", got, want)
+	}
+}
+
+func TestFormatCreateError_IssueNoun(t *testing.T) {
+	t.Parallel()
+
+	err := &jira.APIError{Status: 404, Messages: []string{"Boom happened."}}
+
+	got := formatCreateError(err, "PLAT", false)
+	want := "Cannot create issue in PLAT: boom happened"
+	if got != want {
+		t.Errorf("formatCreateError() = %q, want %q", got, want)
+	}
+}
+
+func TestFormatCreateError_NonAPIErrorFallsBackToRaw(t *testing.T) {
+	t.Parallel()
+
+	err := errors.New("connection refused")
+
+	got := formatCreateError(err, "PLAT", true)
+	if got != "connection refused" {
+		t.Errorf("formatCreateError() = %q, want raw error", got)
+	}
+}
+
+func TestHandleCreatePreFormError_AbortsWithoutEmptyForm(t *testing.T) {
+	t.Parallel()
+	app := focusApp(t)
+	app.createCtx = createCtx{projectKey: "DSOTEST", parentKey: testKey}
+	app.createForm.SetLoading(true) // form is visible-loading before createmeta resolves
+	if !app.createForm.IsVisible() {
+		t.Fatal("precondition: loading form should be visible")
+	}
+
+	apiErr := &jira.APIError{
+		Status:   404,
+		Messages: []string{"You cannot create issues in this project."},
+	}
+	_, _ = app.handleCreatePreFormError(createPreFormErrorMsg{err: apiErr})
+
+	if app.createForm.IsVisible() {
+		t.Error("pre-form error must hide the form, not resume an empty one")
+	}
+	if app.createCtx.parentKey != "" {
+		t.Errorf("createCtx should be cleared, got %+v", app.createCtx)
+	}
+	want := "Cannot create subtask in DSOTEST: you cannot create issues in this project"
+	if got := app.statusPanel.ErrorMessage(); got != want {
+		t.Errorf("status error = %q, want %q", got, want)
+	}
+}

--- a/pkg/tui/handlers_data.go
+++ b/pkg/tui/handlers_data.go
@@ -757,6 +757,17 @@ func (a *App) metaToFormField(mf jira.CreateMetaField) components.CreateFormFiel
 		SchemaItems:   mf.Schema.Items,
 	}
 
+	// Default the reporter to the current user, matching Jira's own behaviour
+	// (reporter = creator). The user can still change or clear it.
+	if mf.Schema.System == "reporter" && a.currentUser != nil {
+		key := fldName
+		if a.isCloud {
+			key = fldAccountID
+		}
+		ff.Value = map[string]string{key: a.currentUser.AccountID}
+		ff.DisplayValue = a.currentUser.DisplayName
+	}
+
 	if !mf.Required && ff.DisplayValue == "" && ft != components.CFFieldMultiText {
 		ff.DisplayValue = "None"
 	}

--- a/pkg/tui/handlers_data.go
+++ b/pkg/tui/handlers_data.go
@@ -329,9 +329,10 @@ func (a *App) handleComponentsLoaded(msg componentsLoadedMsg) (tea.Model, tea.Cm
 func (a *App) handleIssueTypesLoaded(msg issueTypesLoadedMsg) (tea.Model, tea.Cmd) {
 	if a.createCtx.intent {
 		a.createCtx.intent = false
+		subtaskOnly := a.createCtx.parentKey != ""
 		items := make([]components.ModalItem, 0, len(msg.issueTypes))
 		for _, t := range msg.issueTypes {
-			if !t.Subtask {
+			if t.Subtask == subtaskOnly {
 				items = append(items, components.ModalItem{ID: t.ID, Label: t.Name})
 			}
 		}
@@ -340,7 +341,11 @@ func (a *App) handleIssueTypesLoaded(msg issueTypesLoadedMsg) (tea.Model, tea.Cm
 				return components.CreateFormTypeSelectedMsg{TypeID: item.ID, TypeName: item.Label}
 			}
 		}
-		a.modal.Show("Select issue type", items)
+		title := "Select issue type"
+		if subtaskOnly {
+			title = "Select subtask type"
+		}
+		a.modal.Show(title, items)
 		return a, nil
 	}
 	items := make([]components.ModalItem, 0, len(msg.issueTypes))
@@ -453,6 +458,19 @@ func (a *App) handleCreateFormTypeSelected(msg components.CreateFormTypeSelected
 	a.createForm.SetLoading(true)
 	*a.logFlag = true
 	return a, fetchCreateMeta(a.client, a.createCtx.projectKey, msg.TypeID)
+}
+
+// handleCreatePreFormError aborts a create flow that failed before the form was
+// populated. The form is hidden (never resumed empty) and the failure is shown
+// as a readable status message carrying Jira's own wording.
+func (a *App) handleCreatePreFormError(msg createPreFormErrorMsg) (tea.Model, tea.Cmd) {
+	subtask := a.createCtx.parentKey != ""
+	text := formatCreateError(msg.err, a.createCtx.projectKey, subtask)
+	a.createForm.Hide()
+	a.createCtx = createCtx{}
+	a.statusPanel.SetError(text)
+	a.modal.ShowError("Error", []components.ModalItem{{Label: text}})
+	return a, nil
 }
 
 // handleCreateMetaLoaded builds form fields from metadata

--- a/pkg/tui/handlers_data_more_test.go
+++ b/pkg/tui/handlers_data_more_test.go
@@ -272,6 +272,72 @@ func TestMetaToFormField_OptionalGetsNonePlaceholder(t *testing.T) {
 	testkit.AssertEqual(t, "placeholder", field.DisplayValue, "None")
 }
 
+func TestMetaToFormField_PrefillsReporterWithCurrentUser_Cloud(t *testing.T) {
+	t.Parallel()
+	app := newAppWithFake(t, &jiratest.FakeClient{T: t})
+	app.isCloud = true
+	app.currentUser = &jira.User{AccountID: "acc-1", DisplayName: "Alice"}
+
+	field := app.metaToFormField(jira.CreateMetaField{
+		FieldID: "reporter", Name: "Reporter", Required: true,
+		Schema: jira.CreateMetaSchema{Type: schemaUser, System: "reporter"},
+	})
+
+	testkit.AssertEqual(t, "display", field.DisplayValue, "Alice")
+	v, ok := field.Value.(map[string]string)
+	if !ok || v[fldAccountID] != "acc-1" {
+		t.Errorf("reporter Value = %v, want {accountId: acc-1}", field.Value)
+	}
+}
+
+func TestMetaToFormField_PrefillsReporter_ServerUsesNameKey(t *testing.T) {
+	t.Parallel()
+	app := newAppWithFake(t, &jiratest.FakeClient{T: t})
+	app.isCloud = false
+	app.currentUser = &jira.User{AccountID: "bob", DisplayName: "Bob"}
+
+	field := app.metaToFormField(jira.CreateMetaField{
+		FieldID: "reporter", Name: "Reporter",
+		Schema: jira.CreateMetaSchema{Type: schemaUser, System: "reporter"},
+	})
+
+	v, ok := field.Value.(map[string]string)
+	if !ok || v[fldName] != "bob" {
+		t.Errorf("reporter Value = %v, want {name: bob}", field.Value)
+	}
+}
+
+func TestMetaToFormField_ReporterEmptyWithoutCurrentUser(t *testing.T) {
+	t.Parallel()
+	app := newAppWithFake(t, &jiratest.FakeClient{T: t})
+	app.currentUser = nil
+
+	field := app.metaToFormField(jira.CreateMetaField{
+		FieldID: "reporter", Name: "Reporter",
+		Schema: jira.CreateMetaSchema{Type: schemaUser, System: "reporter"},
+	})
+
+	if field.Value != nil {
+		t.Errorf("reporter should stay empty without a current user, got %v", field.Value)
+	}
+}
+
+func TestMetaToFormField_AssigneeNotPrefilled(t *testing.T) {
+	t.Parallel()
+	app := newAppWithFake(t, &jiratest.FakeClient{T: t})
+	app.isCloud = true
+	app.currentUser = &jira.User{AccountID: "acc-1", DisplayName: "Alice"}
+
+	field := app.metaToFormField(jira.CreateMetaField{
+		FieldID: fldAssignee, Name: "Assignee",
+		Schema: jira.CreateMetaSchema{Type: schemaUser, System: fldAssignee},
+	})
+
+	if field.Value != nil {
+		t.Errorf("assignee must not be auto-prefilled, got %v", field.Value)
+	}
+}
+
 func TestApplyDuplicatePrefill(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/tui/handlers_keys.go
+++ b/pkg/tui/handlers_keys.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/textfuel/lazyjira/v2/pkg/ascii"
 	"github.com/textfuel/lazyjira/v2/pkg/git"
+	"github.com/textfuel/lazyjira/v2/pkg/jira"
 	"github.com/textfuel/lazyjira/v2/pkg/tui/components"
 	"github.com/textfuel/lazyjira/v2/pkg/tui/views"
 )
@@ -419,6 +420,13 @@ func (a *App) handleIssueAction(action Action) (tea.Model, tea.Cmd, bool) {
 		m, cmd := a.startCreateIssue()
 		return m, cmd, true
 
+	case ActCreateSubtask:
+		if a.canCreateSubtask() {
+			m, cmd := a.startCreateSubtask()
+			return m, cmd, true
+		}
+		return a, nil, true
+
 	case ActNew:
 		if a.side == sideLeft && a.leftFocus == focusIssues && a.projectKey != "" {
 			m, cmd := a.startCreateIssue()
@@ -483,6 +491,86 @@ func (a *App) startDuplicateIssue() (tea.Model, tea.Cmd) {
 	}
 	*a.logFlag = true
 	return a, fetchIssueTypes(a.client, a.projectID)
+}
+
+// canCreateSubtask reports whether a subtask can be created for the parent under
+// the cursor on the active surface (issues list or info-panel Sub tab). Subtasks
+// and epics (hierarchyLevel > 0) are excluded; an unknown issue type is allowed
+// and validated by the API. The board project is irrelevant: the subtask follows
+// its parent's project.
+func (a *App) canCreateSubtask() bool {
+	parent := a.currentSubtaskParent()
+	if parent == nil {
+		return false
+	}
+	if parent.IssueType != nil && (parent.IssueType.Subtask || parent.IssueType.HierarchyLevel > 0) {
+		return false
+	}
+	return true
+}
+
+// currentSubtaskParent resolves the parent issue under the cursor for the active
+// surface: the selected issue when the issues list is focused, or the selected
+// Sub-tab child when the info panel is focused. Returns nil when no valid parent
+// is selectable. Gate and startCreateSubtask share it so they never diverge.
+func (a *App) currentSubtaskParent() *jira.Issue {
+	if a.side != sideLeft {
+		return nil
+	}
+	switch a.leftFocus {
+	case focusIssues:
+		return a.currentIssue()
+	case focusInfo:
+		return a.infoPanel.SelectedSubtaskIssue()
+	default:
+		return nil
+	}
+}
+
+func (a *App) startCreateSubtask() (tea.Model, tea.Cmd) {
+	parent := a.currentSubtaskParent()
+	if parent == nil {
+		return a, nil
+	}
+
+	// A subtask lives in its parent's project, which may differ from the board
+	// (cross-project JQL tab). Derive it from the parent, not the board.
+	projectKey := projectKeyFromIssueKey(parent.Key)
+	projectID, ok := a.resolveProjectID(projectKey)
+	if !ok {
+		a.statusPanel.SetError("Cannot create subtask in " + projectKey + ": project not found")
+		return a, nil
+	}
+
+	a.createCtx = createCtx{
+		intent:     true,
+		projectKey: projectKey,
+		projectID:  projectID,
+		parentKey:  parent.Key,
+	}
+	*a.logFlag = true
+	return a, fetchIssueTypes(a.client, projectID)
+}
+
+// projectKeyFromIssueKey returns the project key prefix of an issue key
+// ("PROJ" from "PROJ-123"). Jira project keys contain no hyphen, so the key is
+// everything before the last hyphen.
+func projectKeyFromIssueKey(issueKey string) string {
+	if i := strings.LastIndex(issueKey, "-"); i > 0 {
+		return issueKey[:i]
+	}
+	return issueKey
+}
+
+// resolveProjectID maps a project key to its numeric ID via the loaded project
+// list. The cloud issue-type endpoint requires the ID, not the key.
+func (a *App) resolveProjectID(projectKey string) (string, bool) {
+	for _, p := range a.projectList.AllProjects() {
+		if p.Key == projectKey {
+			return p.ID, true
+		}
+	}
+	return "", false
 }
 
 func (a *App) startCreateIssue() (tea.Model, tea.Cmd) {

--- a/pkg/tui/handlers_modal.go
+++ b/pkg/tui/handlers_modal.go
@@ -396,6 +396,9 @@ func (a *App) handleCreateFormUserChecklist(field *components.CreateFormField, i
 func (a *App) handleCreateFormSubmit(msg components.CreateFormSubmitMsg) (tea.Model, tea.Cmd) {
 	msg.Fields["project"] = map[string]string{"key": a.createCtx.projectKey}
 	msg.Fields["issuetype"] = map[string]string{"id": a.createCtx.issueTypeID}
+	if a.createCtx.parentKey != "" {
+		msg.Fields["parent"] = map[string]string{"key": a.createCtx.parentKey}
+	}
 	a.createForm.SetLoading(true)
 	*a.logFlag = true
 	return a, createIssue(a.client, msg.Fields)

--- a/pkg/tui/handlers_subtask_test.go
+++ b/pkg/tui/handlers_subtask_test.go
@@ -1,0 +1,304 @@
+package tui
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/textfuel/lazyjira/v2/pkg/jira"
+	"github.com/textfuel/lazyjira/v2/pkg/jira/jiratest"
+	"github.com/textfuel/lazyjira/v2/pkg/tui/components"
+	"github.com/textfuel/lazyjira/v2/pkg/tui/views"
+)
+
+func TestCanCreateSubtask(t *testing.T) {
+	t.Parallel()
+
+	standard := &jira.IssueType{ID: "1", Name: "Story", HierarchyLevel: 0}
+	subtask := &jira.IssueType{ID: "2", Name: "Sub-task", Subtask: true}
+	epic := &jira.IssueType{ID: "3", Name: "Epic", HierarchyLevel: 1}
+
+	cases := []struct {
+		name  string
+		setup func(*App)
+		want  bool
+	}{
+		{"standard issue", func(a *App) {
+			a.issuesList.SetIssues([]jira.Issue{{Key: testKey, IssueType: standard}})
+		}, true},
+		{"unknown type allowed", func(a *App) {
+			a.issuesList.SetIssues([]jira.Issue{{Key: testKey}})
+		}, true},
+		{"subtask excluded", func(a *App) {
+			a.issuesList.SetIssues([]jira.Issue{{Key: testKey, IssueType: subtask}})
+		}, false},
+		{"epic excluded", func(a *App) {
+			a.issuesList.SetIssues([]jira.Issue{{Key: testKey, IssueType: epic}})
+		}, false},
+		{"board project irrelevant", func(a *App) {
+			// C4: the gate no longer depends on the board project; the parent
+			// carries its own project.
+			a.projectKey = ""
+			a.issuesList.SetIssues([]jira.Issue{{Key: testKey, IssueType: standard}})
+		}, true},
+		{"no selection", func(a *App) {}, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			app := focusApp(t)
+			app.side = sideLeft
+			app.leftFocus = focusIssues
+			app.projectKey = testProject
+			tc.setup(app)
+
+			if got := app.canCreateSubtask(); got != tc.want {
+				t.Errorf("canCreateSubtask() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCanCreateSubtask_WrongContext(t *testing.T) {
+	t.Parallel()
+	app := focusApp(t)
+	app.side = sideRight
+	app.leftFocus = focusIssues
+	app.projectKey = testProject
+	app.issuesList.SetIssues([]jira.Issue{{Key: testKey}})
+
+	if app.canCreateSubtask() {
+		t.Error("canCreateSubtask should be false when issues panel is not focused")
+	}
+}
+
+func TestStartCreateSubtask(t *testing.T) {
+	t.Parallel()
+	app := focusApp(t)
+	app.projectKey = testProject
+	app.projectID = "10000"
+	app.projectList.SetProjects([]jira.Project{{Key: testProject, ID: "10000"}})
+	app.issuesList.SetIssues([]jira.Issue{{Key: testKey}})
+
+	_, cmd := app.startCreateSubtask()
+
+	if cmd == nil {
+		t.Fatal("expected issue-types fetch command")
+	}
+	if app.createCtx.parentKey != testKey {
+		t.Errorf("parentKey = %q, want %q", app.createCtx.parentKey, testKey)
+	}
+	if !app.createCtx.intent {
+		t.Error("intent should be set")
+	}
+}
+
+func TestStartCreateSubtask_RequiresSelection(t *testing.T) {
+	t.Parallel()
+	app := focusApp(t)
+	app.projectKey = testProject
+
+	if _, cmd := app.startCreateSubtask(); cmd != nil {
+		t.Error("expected nil cmd without a selected parent issue")
+	}
+}
+
+func TestProjectKeyFromIssueKey(t *testing.T) {
+	t.Parallel()
+	cases := map[string]string{
+		"PLAT-1":      "PLAT",
+		"DSOTEST-123": "DSOTEST",
+		"X-1":         "X",
+		"NODASH":      "NODASH",
+	}
+	for in, want := range cases {
+		if got := projectKeyFromIssueKey(in); got != want {
+			t.Errorf("projectKeyFromIssueKey(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestStartCreateSubtask_ProjectFromParent(t *testing.T) {
+	t.Parallel()
+	app := focusApp(t)
+	// Board sits on PLAT, but the selected parent lives in DSOTEST (cross-project
+	// JQL tab). The subtask must target the parent's project, not the board's.
+	app.projectKey = "PLAT"
+	app.projectID = "10000"
+	app.projectList.SetProjects([]jira.Project{
+		{Key: "PLAT", ID: "10000"},
+		{Key: "DSOTEST", ID: "20000"},
+	})
+	app.issuesList.SetIssues([]jira.Issue{{Key: "DSOTEST-5"}})
+
+	_, cmd := app.startCreateSubtask()
+
+	if cmd == nil {
+		t.Fatal("expected issue-types fetch command")
+	}
+	if app.createCtx.projectKey != "DSOTEST" {
+		t.Errorf("projectKey = %q, want DSOTEST (parent's project)", app.createCtx.projectKey)
+	}
+	if app.createCtx.projectID != "20000" {
+		t.Errorf("projectID = %q, want 20000 (resolved from parent project)", app.createCtx.projectID)
+	}
+	if app.createCtx.parentKey != "DSOTEST-5" {
+		t.Errorf("parentKey = %q, want DSOTEST-5", app.createCtx.parentKey)
+	}
+}
+
+func TestStartCreateSubtask_UnresolvableProjectAborts(t *testing.T) {
+	t.Parallel()
+	app := focusApp(t)
+	app.projectKey = "PLAT"
+	app.projectList.SetProjects([]jira.Project{{Key: "PLAT", ID: "10000"}})
+	app.issuesList.SetIssues([]jira.Issue{{Key: "OTHER-9"}}) // OTHER not in project list
+
+	_, cmd := app.startCreateSubtask()
+
+	if cmd != nil {
+		t.Error("expected abort (nil cmd) when the parent project cannot be resolved")
+	}
+	if app.statusPanel.ErrorMessage() == "" {
+		t.Error("expected a status error on unresolvable parent project")
+	}
+	if app.createCtx.intent {
+		t.Error("createCtx should not be armed on abort")
+	}
+}
+
+func TestCanCreateSubtask_SubTabSurface(t *testing.T) {
+	t.Parallel()
+
+	standard := &jira.IssueType{ID: "1", Name: "Story", HierarchyLevel: 0}
+	subtask := &jira.IssueType{ID: "2", Name: "Sub-task", Subtask: true}
+
+	cases := []struct {
+		name  string
+		setup func(*App)
+		want  bool
+	}{
+		{"epic child is a valid parent", func(a *App) {
+			a.infoPanel.SetIssue(&jira.Issue{Key: "EPIC-1",
+				Subtasks: []jira.Issue{{Key: "STORY-2", IssueType: standard}}})
+			a.infoPanel.SetActiveTab(views.InfoTabSubtasks)
+		}, true},
+		{"subtask child excluded", func(a *App) {
+			a.infoPanel.SetIssue(&jira.Issue{Key: "EPIC-1",
+				Subtasks: []jira.Issue{{Key: "SUB-2", IssueType: subtask}}})
+			a.infoPanel.SetActiveTab(views.InfoTabSubtasks)
+		}, false},
+		{"unknown child type allowed", func(a *App) {
+			a.infoPanel.SetIssue(&jira.Issue{Key: "EPIC-1",
+				Subtasks: []jira.Issue{{Key: "X-2"}}})
+			a.infoPanel.SetActiveTab(views.InfoTabSubtasks)
+		}, true},
+		{"non-subtask tab excluded", func(a *App) {
+			a.infoPanel.SetIssue(&jira.Issue{Key: "EPIC-1",
+				Subtasks: []jira.Issue{{Key: "STORY-2", IssueType: standard}}})
+			a.infoPanel.SetActiveTab(views.InfoTabLinks)
+		}, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			app := focusApp(t)
+			app.side = sideLeft
+			app.leftFocus = focusInfo
+			tc.setup(app)
+
+			if got := app.canCreateSubtask(); got != tc.want {
+				t.Errorf("canCreateSubtask() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestStartCreateSubtask_FromSubTab(t *testing.T) {
+	t.Parallel()
+	app := focusApp(t)
+	app.side = sideLeft
+	app.leftFocus = focusInfo
+	app.projectList.SetProjects([]jira.Project{{Key: "DSOTEST", ID: "20000"}})
+	app.infoPanel.SetIssue(&jira.Issue{Key: "EPIC-1",
+		Subtasks: []jira.Issue{{Key: "DSOTEST-7"}}})
+	app.infoPanel.SetActiveTab(views.InfoTabSubtasks)
+
+	_, cmd := app.startCreateSubtask()
+
+	if cmd == nil {
+		t.Fatal("expected issue-types fetch command")
+	}
+	if app.createCtx.parentKey != "DSOTEST-7" {
+		t.Errorf("parentKey = %q, want DSOTEST-7 (selected sub-tab child)", app.createCtx.parentKey)
+	}
+	if app.createCtx.projectKey != "DSOTEST" {
+		t.Errorf("projectKey = %q, want DSOTEST", app.createCtx.projectKey)
+	}
+}
+
+func TestHandleIssueTypesLoaded_SubtaskFilter(t *testing.T) {
+	t.Parallel()
+	app := focusApp(t)
+	app.modal.SetSize(120, 40)
+	app.createCtx = createCtx{intent: true, parentKey: testKey}
+
+	_, _ = app.handleIssueTypesLoaded(issueTypesLoadedMsg{issueTypes: []jira.IssueType{
+		{ID: "1", Name: "Story"},
+		{ID: "2", Name: "Sub-task", Subtask: true},
+	}})
+
+	view := app.modal.View()
+	if !strings.Contains(view, "Sub-task") {
+		t.Errorf("subtask type should be offered, view:\n%s", view)
+	}
+	if strings.Contains(view, "Story") {
+		t.Errorf("standard type should be filtered out, view:\n%s", view)
+	}
+	if !strings.Contains(view, "Select subtask type") {
+		t.Errorf("title should mark subtask selection, view:\n%s", view)
+	}
+}
+
+func TestHandleIssueTypesLoaded_NonSubtaskFilter(t *testing.T) {
+	t.Parallel()
+	app := focusApp(t)
+	app.modal.SetSize(120, 40)
+	app.createCtx = createCtx{intent: true}
+
+	_, _ = app.handleIssueTypesLoaded(issueTypesLoadedMsg{issueTypes: []jira.IssueType{
+		{ID: "1", Name: "Story"},
+		{ID: "2", Name: "Sub-task", Subtask: true},
+	}})
+
+	view := app.modal.View()
+	if !strings.Contains(view, "Story") {
+		t.Errorf("standard type should be offered, view:\n%s", view)
+	}
+	if strings.Contains(view, "Sub-task") {
+		t.Errorf("subtask type should be filtered out without a parent, view:\n%s", view)
+	}
+	if !strings.Contains(view, "Select issue type") {
+		t.Errorf("title should mark plain issue selection, view:\n%s", view)
+	}
+}
+
+func TestHandleCreateFormSubmit_InjectsParent(t *testing.T) {
+	t.Parallel()
+	fake := &jiratest.FakeClient{T: t}
+	fake.CreateIssueFunc = func(context.Context, map[string]any) (*jira.Issue, error) {
+		return &jira.Issue{Key: "PLAT-99"}, nil
+	}
+	app := newAppWithFake(t, fake)
+	app.createCtx = createCtx{projectKey: testProject, issueTypeID: "10001", parentKey: testKey}
+
+	fields := map[string]any{"summary": "hi"}
+	_, _ = app.handleCreateFormSubmit(components.CreateFormSubmitMsg{Fields: fields})
+
+	parent, ok := fields["parent"].(map[string]string)
+	if !ok || parent["key"] != testKey {
+		t.Errorf("parent field not injected: %v", fields["parent"])
+	}
+}

--- a/pkg/tui/keybindings.go
+++ b/pkg/tui/keybindings.go
@@ -224,6 +224,9 @@ func (a *App) helpBarItems() []components.HelpItem {
 			components.HelpItem{Key: km.Keys(ActNew), Description: "create"},
 			components.HelpItem{Key: km.Keys(ActJQLSearch), Description: "JQL search"},
 		)
+		if a.canCreateSubtask() {
+			items = append(items, components.HelpItem{Key: km.Keys(ActCreateSubtask), Description: "subtask"})
+		}
 		items = append(items, a.customCommandHelpItems(config.CtxIssues)...)
 		items = append(items, components.HelpItem{Key: km.Keys(ActHelp), Description: "help"})
 		return items

--- a/pkg/tui/keymap.go
+++ b/pkg/tui/keymap.go
@@ -43,6 +43,7 @@ const (
 	ActCloseJQLTab    Action = "closeJQLTab"
 	ActCreateBranch   Action = "createBranch"
 	ActCreateIssue    Action = "createIssue"
+	ActCreateSubtask  Action = "createSubtask"
 	ActDuplicateIssue Action = "duplicateIssue"
 	ActShowParent     Action = "showParent"
 
@@ -96,6 +97,7 @@ func DefaultKeymap() Keymap {
 		ActCloseJQLTab:    {"x"},
 		ActCreateBranch:   {"b"},
 		ActDuplicateIssue: {"ctrl+n"},
+		ActCreateSubtask:  {"S"},
 		ActShowParent:     {"backspace"},
 
 		ActNavDown:     {"j", "down", "ctrl+j"},
@@ -147,6 +149,7 @@ func KeymapFromConfig(kcfg config.KeybindingConfig) Keymap {
 	set(ActCloseJQLTab, kcfg.Issues.CloseJQLTab)
 	set(ActCreateBranch, kcfg.Issues.CreateBranch)
 	set(ActCreateIssue, kcfg.Issues.CreateIssue)
+	set(ActCreateSubtask, kcfg.Issues.CreateSubtask)
 	// Detail
 	set(ActFocusLeft, kcfg.Detail.FocusLeft)
 	set(ActInfoTab, kcfg.Detail.InfoTab)


### PR DESCRIPTION
A subtask can now be created under the selected issue, from the task list and from the info panel's Sub tab. The type picker is limited to subtask types; the normal create path is unchanged. The shortcut is configurable like the other issue actions (`keybinding.issues.createSubtask`, default `S`).

The action is offered only where a subtask is valid. Subtasks and epics (`hierarchyLevel > 0`) are excluded. The check is best-effort, though. The items in the Sub tab often carry no type, and on DC `hierarchyLevel` is frequently 0, so those cases fall through to Jira's validation on submit.

The project is resolved from the parent key against the loaded project list (Cloud needs the ID for the issue-type endpoint); if it isn't loaded, the flow aborts with a status message.

Three changes that ride along:

- Create errors split into pre-form and submit stages: a failed issue-type fetch now aborts with a readable message (carrying Jira's `errorMessages`) instead of an empty form with a raw error under it. Submit errors still stay inline, and normal create gets the same split.
- The reporter field defaults to the current user, like Jira's own create. Still editable or clearable.
- The "required field(s) empty" message names the fields instead of counting them.