### PR TITLE
Resolve @-mentions to Jira accounts on write

### DIFF
--- a/pkg/tui/app.go
+++ b/pkg/tui/app.go
@@ -158,7 +158,10 @@ type App struct {
 
 	editTempPath string
 	editContext  editCtx
-	converter    ADFConverter
+
+	// pendingMention holds a write deferred until the user cache is loaded.
+	pendingMention *pendingMention
+	converter      ADFConverter
 
 	onSelect    onSelectFunc
 	onChecklist onChecklistFunc
@@ -506,6 +509,8 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return a, nil
 	case usersLoadedMsg:
 		return a.handleUsersLoaded(msg)
+	case mentionUsersLoadedMsg:
+		return a.handleMentionUsersLoaded(msg)
 	case labelsLoadedMsg:
 		return a.handleLabelsLoaded(msg)
 	case componentsLoadedMsg:
@@ -873,7 +878,25 @@ func (a *App) applyEdit(mdContent string) tea.Cmd {
 	ctx := a.editContext
 	a.editContext = editCtx{}
 
-	var body any = mdContent
+	if a.isCloud && mentionsApply(ctx.kind) && hasMentionCandidate(mdContent) {
+		pk := projectKeyFromIssueKey(ctx.issueKey)
+		if pk == "" {
+			pk = a.projectKey
+		}
+		if users, ok := a.projectUsers(pk); ok {
+			return a.completeApplyEdit(pendingMention{content: mdContent, editContext: ctx, projectKey: pk}, users)
+		}
+		a.pendingMention = &pendingMention{content: mdContent, editContext: ctx, projectKey: pk}
+		return fetchUsersForMention(a.client, pk)
+	}
+	return a.convertAndSubmit(ctx, mdContent)
+}
+
+// convertAndSubmit converts mdContent to ADF on cloud (no mention resolution)
+// and submits the edit. Used for non-cloud edits and cloud edits without any
+// @-mention to resolve.
+func (a *App) convertAndSubmit(ctx editCtx, mdContent string) tea.Cmd {
+	body := any(mdContent)
 	if a.isCloud {
 		adf, err := a.converter.FromMarkdown(mdContent, ctx.converterState)
 		if err != nil {
@@ -882,18 +905,24 @@ func (a *App) applyEdit(mdContent string) tea.Cmd {
 		}
 		body = adf
 	}
+	return a.submitEdit(ctx, body, mdContent)
+}
 
+// submitEdit dispatches a converted edit to the right write command. body is the
+// payload sent to the API (ADF on cloud, markdown otherwise); md is the raw
+// markdown used for optimistic local updates.
+func (a *App) submitEdit(ctx editCtx, body any, md string) tea.Cmd {
 	switch ctx.kind { //nolint:exhaustive
 	case editDesc:
-		a.optimisticFieldUpdate(ctx.issueKey, fldDescription, mdContent)
+		a.optimisticFieldUpdate(ctx.issueKey, fldDescription, md)
 		return updateIssueField(a.client, ctx.issueKey, fldDescription, body)
 	case editCommentNew:
 		return addComment(a.client, ctx.issueKey, body)
 	case editCommentMod:
 		return updateComment(a.client, ctx.issueKey, ctx.commentID, body)
 	case editFieldText:
-		a.optimisticFieldUpdate(ctx.issueKey, ctx.fieldID, mdContent)
-		return updateIssueField(a.client, ctx.issueKey, ctx.fieldID, mdContent)
+		a.optimisticFieldUpdate(ctx.issueKey, ctx.fieldID, md)
+		return updateIssueField(a.client, ctx.issueKey, ctx.fieldID, md)
 	}
 	return nil
 }

--- a/pkg/tui/handlers_modal.go
+++ b/pkg/tui/handlers_modal.go
@@ -84,7 +84,17 @@ func (a *App) handleEditorFinished(msg editorFinishedMsg) (tea.Model, tea.Cmd) {
 		}
 		content = strings.TrimSpace(content)
 		if changed && content != "" {
-			var val any = content
+			if a.isCloud && hasMentionCandidate(content) {
+				pm := pendingMention{content: content, createDesc: true, fieldIndex: idx, convState: convState, projectKey: a.projectKey}
+				users, ok := a.projectUsers(a.projectKey)
+				if !ok {
+					a.pendingMention = &pm
+					return a, tea.Batch(append(cmds, fetchUsersForMention(a.client, a.projectKey))...)
+				}
+				cmds = append(cmds, a.completeCreateDesc(pm, users))
+				return a, tea.Batch(cmds...)
+			}
+			val := any(content)
 			if a.isCloud {
 				adf, convErr := a.converter.FromMarkdown(content, convState)
 				if convErr != nil {

--- a/pkg/tui/mention_resolve.go
+++ b/pkg/tui/mention_resolve.go
@@ -1,0 +1,111 @@
+package tui
+
+import (
+	"regexp"
+	"slices"
+	"strconv"
+	"strings"
+
+	"github.com/textfuel/lazyjira/v2/pkg/ascii"
+	"github.com/textfuel/lazyjira/v2/pkg/jira"
+)
+
+// mentionScanRe captures a leading boundary (start of string, or a single
+// non-word, non-backslash char) in group 1 and the raw @-token in group 2.
+// The boundary keeps emails (me@host) and escaped (\@) positions from matching.
+var mentionScanRe = regexp.MustCompile(`(^|[^\p{L}\p{N}_\\])@([\p{L}\p{N}_]+)`)
+
+// maskPatterns are blanked out (in order) before scanning so @-tokens inside
+// fenced blocks, inline code or already-resolved mentions are never touched.
+var maskPatterns = []*regexp.Regexp{
+	regexp.MustCompile("(?s)```.*?```"),
+	regexp.MustCompile("(?s)~~~.*?~~~"),
+	regexp.MustCompile("`[^`]*`"),
+	regexp.MustCompile(`\[@[^\]]*\]\(accountid:[^)]*\)`),
+}
+
+// normalizeToWords lowercases s, transliterates it to ASCII (German ae/oe/ue/ss
+// plus NFD accent stripping), turns '_' into spaces and splits on whitespace.
+// Each resulting word has leading and trailing ASCII punctuation (",.") trimmed;
+// empty words are dropped.
+func normalizeToWords(s string) []string {
+	s = strings.ReplaceAll(s, "_", " ")
+	s = ascii.Convert(s)
+	fields := strings.Fields(s)
+	words := make([]string, 0, len(fields))
+	for _, f := range fields {
+		if f = strings.Trim(f, ",."); f != "" {
+			words = append(words, f)
+		}
+	}
+	return words
+}
+
+// matchUsers returns every user whose DisplayName matches the token words.
+// A single-word token matches when the word is one of the DisplayName words.
+// A multi-word token matches only when the words equal the full DisplayName
+// word sequence.
+func matchUsers(tokenWords []string, users []jira.User) []jira.User {
+	var matched []jira.User
+	for _, u := range users {
+		uw := normalizeToWords(u.DisplayName)
+		var ok bool
+		if len(tokenWords) == 1 {
+			ok = slices.Contains(uw, tokenWords[0])
+		} else {
+			ok = slices.Equal(tokenWords, uw)
+		}
+		if ok {
+			matched = append(matched, u)
+		}
+	}
+	return matched
+}
+
+// hasMentionCandidate reports whether md contains at least one @-token that the
+// scanner could replace, letting callers skip the (possibly async) mention
+// machinery for ordinary text. May return true for tokens that ultimately stay
+// literal (e.g. inside code spans); resolveMentions then leaves them untouched.
+func hasMentionCandidate(md string) bool {
+	return mentionScanRe.MatchString(md)
+}
+
+// resolveMentions replaces every unambiguous @-token in md with an ADF mention
+// link [@DisplayName](accountid:ID). Tokens that match zero or multiple users
+// stay literal, as do tokens inside masked spans (see maskPatterns).
+func resolveMentions(md string, users []jira.User) string {
+	masked, spans := maskSpans(md)
+	masked = mentionScanRe.ReplaceAllStringFunc(masked, func(m string) string {
+		sub := mentionScanRe.FindStringSubmatch(m)
+		prefix, rawToken := sub[1], sub[2]
+		matches := matchUsers(normalizeToWords(rawToken), users)
+		if len(matches) != 1 {
+			return m
+		}
+		u := matches[0]
+		return prefix + "[@" + u.DisplayName + "](accountid:" + u.AccountID + ")"
+	})
+	return restoreSpans(masked, spans)
+}
+
+// maskSpans replaces each protected span with a NUL-delimited placeholder and
+// returns the masked string plus the original spans, indexed by placeholder.
+func maskSpans(md string) (string, []string) {
+	var spans []string
+	for _, re := range maskPatterns {
+		md = re.ReplaceAllStringFunc(md, func(m string) string {
+			placeholder := "\x00" + strconv.Itoa(len(spans)) + "\x00"
+			spans = append(spans, m)
+			return placeholder
+		})
+	}
+	return md, spans
+}
+
+// restoreSpans reverses maskSpans, putting every original span back in place.
+func restoreSpans(md string, spans []string) string {
+	for i, s := range spans {
+		md = strings.ReplaceAll(md, "\x00"+strconv.Itoa(i)+"\x00", s)
+	}
+	return md
+}

--- a/pkg/tui/mention_resolve_test.go
+++ b/pkg/tui/mention_resolve_test.go
@@ -1,0 +1,105 @@
+package tui
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/textfuel/lazyjira/v2/pkg/jira"
+)
+
+func TestNormalizeToWords(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		in   string
+		want []string
+	}{
+		{"two words", "Jane Doe", []string{"jane", "doe"}},
+		{"umlaut", "Müller", []string{"mueller"}},
+		{"accent", "José", []string{"jose"}},
+		{"sharp-s and umlaut", "Größe", []string{"groesse"}},
+		{"comma trimmed", "Doe, Jane", []string{"doe", "jane"}},
+		{"underscore to space", "jane_doe", []string{"jane", "doe"}},
+		{"empty", "", nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := normalizeToWords(tc.in)
+			if !slices.Equal(got, tc.want) {
+				t.Errorf("normalizeToWords(%q) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestMatchUsers(t *testing.T) {
+	t.Parallel()
+	users := []jira.User{
+		{DisplayName: "Jane Doe", AccountID: "a1"},
+		{DisplayName: "John Doe", AccountID: "a2"},
+		{DisplayName: "Jürgen Müller", AccountID: "a3"},
+	}
+	cases := []struct {
+		name  string
+		token []string
+		want  []string // matched account IDs, in user order
+	}{
+		{"single unique", []string{"jane"}, []string{"a1"}},
+		{"single ambiguous", []string{"doe"}, []string{"a1", "a2"}},
+		{"multi-word exact", []string{"jane", "doe"}, []string{"a1"}},
+		{"transliterated", []string{"mueller"}, []string{"a3"}},
+		{"no match", []string{"jose"}, nil},
+		{"multi-word no prefix", []string{"jane", "d"}, nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := matchUsers(tc.token, users)
+			ids := make([]string, 0, len(got))
+			for _, u := range got {
+				ids = append(ids, u.AccountID)
+			}
+			if !slices.Equal(ids, tc.want) {
+				t.Errorf("matchUsers(%v) ids = %v, want %v", tc.token, ids, tc.want)
+			}
+		})
+	}
+}
+
+func TestResolveMentions(t *testing.T) {
+	t.Parallel()
+	users := []jira.User{
+		{DisplayName: "Jane Doe", AccountID: "a1"},
+		{DisplayName: "John Doe", AccountID: "a2"},
+		{DisplayName: "Jürgen Müller", AccountID: "a3"},
+		{DisplayName: "Solo One", AccountID: "s1"},
+	}
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"underscore token", "hi @Solo_One!", "hi [@Solo One](accountid:s1)!"},
+		{"transliterated token", "ping @mueller", "ping [@Jürgen Müller](accountid:a3)"},
+		{"umlaut token", "ping @Müller", "ping [@Jürgen Müller](accountid:a3)"},
+		{"ambiguous unchanged", "@doe", "@doe"},
+		{"no match unchanged", "@nobody", "@nobody"},
+		{"email unchanged", "mail me@solo.com", "mail me@solo.com"},
+		{"handle unchanged", "git@host", "git@host"},
+		{"escaped unchanged", "\\@solo", "\\@solo"},
+		{"inline code unchanged", "`@solo`", "`@solo`"},
+		{"fenced unchanged", "```\n@solo\n```", "```\n@solo\n```"},
+		{"already resolved unchanged", "[@Solo One](accountid:s1)", "[@Solo One](accountid:s1)"},
+		{"multiple replaced", "@mueller and @Solo_One", "[@Jürgen Müller](accountid:a3) and [@Solo One](accountid:s1)"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := resolveMentions(tc.in, users)
+			if got != tc.want {
+				t.Errorf("resolveMentions(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/tui/mention_write.go
+++ b/pkg/tui/mention_write.go
@@ -1,0 +1,96 @@
+package tui
+
+import (
+	"context"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/textfuel/lazyjira/v2/pkg/jira"
+)
+
+// pendingMention holds a write that was deferred because the user cache was
+// cold. Once the users arrive it is completed via the createDesc or applyEdit
+// path.
+type pendingMention struct {
+	content     string
+	createDesc  bool    // true: create-form description field; false: applyEdit
+	fieldIndex  int     // createDesc only
+	convState   any     // createDesc only (applyEdit uses editContext.converterState)
+	editContext editCtx // applyEdit only
+	projectKey  string  // project whose users resolve this mention
+}
+
+// mentionUsersLoadedMsg carries the users fetched for a deferred mention write.
+type mentionUsersLoadedMsg struct{ users []jira.User }
+
+// mentionsApply reports whether an edit kind is rendered as ADF, where a
+// resolved @-mention becomes a real mention. Plain-text custom fields
+// (editFieldText) are written as-is without ADF conversion, so resolving there
+// would store the link syntax as literal text; they are excluded.
+func mentionsApply(kind editKind) bool {
+	switch kind {
+	case editDesc, editCommentNew, editCommentMod:
+		return true
+	default:
+		return false
+	}
+}
+
+// projectUsers returns the cached assignable users for the given project key
+// and whether the cache holds an entry for it.
+func (a *App) projectUsers(projectKey string) ([]jira.User, bool) {
+	u, ok := a.usersCache[projectKey]
+	return u, ok
+}
+
+// fetchUsersForMention loads the project users for a deferred write. Unlike
+// fetchUsers it never emits errorMsg: on failure it returns an empty list so
+// the pending write still completes (mentions fall back to literal text).
+func fetchUsersForMention(client jira.ClientInterface, projectKey string) tea.Cmd {
+	return func() tea.Msg {
+		users, _ := client.GetUsers(context.Background(), projectKey)
+		return mentionUsersLoadedMsg{users: users}
+	}
+}
+
+// handleMentionUsersLoaded caches the freshly loaded users and resumes the
+// deferred write.
+func (a *App) handleMentionUsersLoaded(msg mentionUsersLoadedMsg) (tea.Model, tea.Cmd) {
+	pm := a.pendingMention
+	a.pendingMention = nil
+	if pm == nil {
+		return a, nil
+	}
+	if pm.projectKey != "" && len(msg.users) > 0 {
+		a.usersCache[pm.projectKey] = msg.users
+	}
+	if pm.createDesc {
+		return a, a.completeCreateDesc(*pm, msg.users)
+	}
+	return a, a.completeApplyEdit(*pm, msg.users)
+}
+
+// completeCreateDesc resolves mentions with the now-available users, converts
+// to ADF and writes the create-form description field.
+func (a *App) completeCreateDesc(pm pendingMention, users []jira.User) tea.Cmd {
+	content := resolveMentions(pm.content, users)
+	adf, err := a.converter.FromMarkdown(content, pm.convState)
+	if err != nil {
+		a.statusPanel.SetError("convert description: " + err.Error())
+		return nil
+	}
+	a.createForm.SetFieldValue(pm.fieldIndex, adf, content)
+	return nil
+}
+
+// completeApplyEdit resolves mentions with the now-available users, converts to
+// ADF and submits the edit.
+func (a *App) completeApplyEdit(pm pendingMention, users []jira.User) tea.Cmd {
+	md := resolveMentions(pm.content, users)
+	adf, err := a.converter.FromMarkdown(md, pm.editContext.converterState)
+	if err != nil {
+		a.statusPanel.SetError("convert markdown: " + err.Error())
+		return nil
+	}
+	return a.submitEdit(pm.editContext, adf, md)
+}

--- a/pkg/tui/mention_write_test.go
+++ b/pkg/tui/mention_write_test.go
@@ -1,0 +1,305 @@
+package tui
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/textfuel/lazyjira/v2/pkg/jira"
+	"github.com/textfuel/lazyjira/v2/pkg/jira/jiratest"
+	"github.com/textfuel/lazyjira/v2/pkg/tui/components"
+)
+
+// identityConverter passes markdown straight through so tests can assert on the
+// resolved markdown that reaches the write call, independent of ADF shape.
+type identityConverter struct{}
+
+func (identityConverter) ToMarkdown(adf any) (string, any, error) {
+	s, _ := adf.(string)
+	return s, nil, nil
+}
+
+func (identityConverter) FromMarkdown(md string, _ any) (any, error) {
+	return md, nil
+}
+
+func soloUser() jira.User { return jira.User{DisplayName: "Solo One", AccountID: "s1"} }
+
+func TestMentionColdPath_Comment(t *testing.T) {
+	t.Parallel()
+	fake := &jiratest.FakeClient{
+		GetUsersFunc: func(_ context.Context, _ string) ([]jira.User, error) {
+			return []jira.User{soloUser()}, nil
+		},
+		AddCommentFunc: func(_ context.Context, _ string, _ any) (*jira.Comment, error) {
+			return &jira.Comment{}, nil
+		},
+	}
+	app := newAppWithFake(t, fake)
+	app.converter = identityConverter{}
+	app.isCloud = true
+	app.projectKey = testProject
+	app.editContext = editCtx{kind: editCommentNew, issueKey: testKey}
+
+	cmd := app.applyEdit("ping @Solo_One")
+	if cmd == nil {
+		t.Fatal("applyEdit returned nil cmd on cold cache")
+	}
+	if app.pendingMention == nil {
+		t.Fatal("pendingMention not set on cold path")
+	}
+	if len(fake.AddCommentCalls) != 0 {
+		t.Fatal("AddComment must not run before users are loaded")
+	}
+
+	msg := cmd()
+	loaded, ok := msg.(mentionUsersLoadedMsg)
+	if !ok {
+		t.Fatalf("expected mentionUsersLoadedMsg, got %T", msg)
+	}
+	_, follow := app.handleMentionUsersLoaded(loaded)
+	if follow == nil {
+		t.Fatal("handleMentionUsersLoaded returned nil cmd")
+	}
+	follow()
+
+	if len(fake.AddCommentCalls) != 1 {
+		t.Fatalf("AddComment called %d times, want 1", len(fake.AddCommentCalls))
+	}
+	body, _ := fake.AddCommentCalls[0].Body.(string)
+	if !strings.Contains(body, "accountid:s1") {
+		t.Errorf("comment body = %q, want it to contain accountid:s1", body)
+	}
+	if app.pendingMention != nil {
+		t.Error("pendingMention should be cleared after completion")
+	}
+}
+
+func TestMentionWarmPath_Comment(t *testing.T) {
+	t.Parallel()
+	fake := &jiratest.FakeClient{
+		T: t,
+		AddCommentFunc: func(_ context.Context, _ string, _ any) (*jira.Comment, error) {
+			return &jira.Comment{}, nil
+		},
+	}
+	app := newAppWithFake(t, fake)
+	app.converter = identityConverter{}
+	app.isCloud = true
+	app.projectKey = testProject
+	app.usersCache[testProject] = []jira.User{soloUser()}
+	app.editContext = editCtx{kind: editCommentNew, issueKey: testKey}
+
+	cmd := app.applyEdit("ping @Solo_One")
+	if cmd == nil {
+		t.Fatal("applyEdit returned nil cmd")
+	}
+	if app.pendingMention != nil {
+		t.Error("warm cache must not defer the write")
+	}
+
+	msg := cmd()
+	if _, ok := msg.(mentionUsersLoadedMsg); ok {
+		t.Fatal("warm path must not emit mentionUsersLoadedMsg")
+	}
+	if len(fake.AddCommentCalls) != 1 {
+		t.Fatalf("AddComment called %d times, want 1", len(fake.AddCommentCalls))
+	}
+	body, _ := fake.AddCommentCalls[0].Body.(string)
+	if !strings.Contains(body, "accountid:s1") {
+		t.Errorf("comment body = %q, want it to contain accountid:s1", body)
+	}
+}
+
+func TestMentionSkippedForPlainTextField(t *testing.T) {
+	t.Parallel()
+	fake := &jiratest.FakeClient{
+		T: t,
+		UpdateIssueFunc: func(_ context.Context, _ string, _ map[string]any) error {
+			return nil
+		},
+	}
+	app := newAppWithFake(t, fake)
+	app.converter = identityConverter{}
+	app.isCloud = true
+	app.projectKey = testProject
+	app.usersCache[testProject] = []jira.User{soloUser()} // warm: would resolve if attempted
+	app.editContext = editCtx{kind: editFieldText, issueKey: testKey, fieldID: "customfield_10010"}
+
+	cmd := app.applyEdit("ping @Solo_One")
+	if cmd == nil {
+		t.Fatal("applyEdit returned nil cmd")
+	}
+	if app.pendingMention != nil {
+		t.Error("plain-text field must not defer for mentions")
+	}
+	cmd()
+
+	if len(fake.UpdateIssueCalls) != 1 {
+		t.Fatalf("UpdateIssue called %d times, want 1", len(fake.UpdateIssueCalls))
+	}
+	got, _ := fake.UpdateIssueCalls[0].Fields["customfield_10010"].(string)
+	if got != "ping @Solo_One" {
+		t.Errorf("field value = %q, want %q", got, "ping @Solo_One")
+	}
+	if strings.Contains(got, "accountid") {
+		t.Errorf("plain-text field must not get a resolved mention: %q", got)
+	}
+}
+
+func TestMentionColdPath_CreateDesc(t *testing.T) {
+	t.Parallel()
+	app := newAppWithFake(t, &jiratest.FakeClient{T: t})
+	app.converter = identityConverter{}
+	app.isCloud = true
+	app.projectKey = testProject
+	app.createForm = formWithFields([]components.CreateFormField{
+		{FieldID: "summary"},
+		{FieldID: "description"},
+	})
+	app.editContext = editCtx{kind: editCreateDesc, fieldIndex: 1}
+	path := writeTempFile(t, "see @Solo_One")
+
+	if _, cmd := app.handleEditorFinished(editorFinishedMsg{original: "old", tempPath: path}); cmd == nil {
+		t.Fatal("editor finish on cold cache should return a fetch cmd")
+	}
+	if app.pendingMention == nil || !app.pendingMention.createDesc {
+		t.Fatal("create-desc cold path must defer via pendingMention")
+	}
+
+	app.handleMentionUsersLoaded(mentionUsersLoadedMsg{users: []jira.User{soloUser()}})
+
+	got, _ := app.createForm.FieldAt(1).Value.(string)
+	if !strings.Contains(got, "accountid:s1") {
+		t.Errorf("description value = %q, want it to contain accountid:s1", got)
+	}
+}
+
+func TestMentionWarmPath_CrossProject(t *testing.T) {
+	t.Parallel()
+	fake := &jiratest.FakeClient{
+		T: t,
+		AddCommentFunc: func(_ context.Context, _ string, _ any) (*jira.Comment, error) {
+			return &jira.Comment{}, nil
+		},
+	}
+	app := newAppWithFake(t, fake)
+	app.converter = identityConverter{}
+	app.isCloud = true
+	app.projectKey = testProject // board project differs from the edited issue
+	app.usersCache["OTHER"] = []jira.User{soloUser()}
+	app.editContext = editCtx{kind: editCommentNew, issueKey: "OTHER-7"}
+
+	cmd := app.applyEdit("ping @Solo_One")
+	if cmd == nil {
+		t.Fatal("applyEdit returned nil cmd")
+	}
+	if app.pendingMention != nil {
+		t.Error("warm cross-project cache must not defer the write")
+	}
+
+	msg := cmd()
+	if _, ok := msg.(mentionUsersLoadedMsg); ok {
+		t.Fatal("warm path must not emit mentionUsersLoadedMsg")
+	}
+	if len(fake.AddCommentCalls) != 1 {
+		t.Fatalf("AddComment called %d times, want 1", len(fake.AddCommentCalls))
+	}
+	body, _ := fake.AddCommentCalls[0].Body.(string)
+	if !strings.Contains(body, "accountid:s1") {
+		t.Errorf("comment body = %q, want accountid:s1 from the issue's project users", body)
+	}
+}
+
+func TestMentionColdPath_CrossProject(t *testing.T) {
+	t.Parallel()
+	fake := &jiratest.FakeClient{
+		GetUsersFunc: func(_ context.Context, _ string) ([]jira.User, error) {
+			return []jira.User{soloUser()}, nil
+		},
+		AddCommentFunc: func(_ context.Context, _ string, _ any) (*jira.Comment, error) {
+			return &jira.Comment{}, nil
+		},
+	}
+	app := newAppWithFake(t, fake)
+	app.converter = identityConverter{}
+	app.isCloud = true
+	app.projectKey = testProject
+	app.editContext = editCtx{kind: editCommentNew, issueKey: "OTHER-7"}
+
+	cmd := app.applyEdit("ping @Solo_One")
+	if cmd == nil {
+		t.Fatal("applyEdit returned nil cmd on cold cache")
+	}
+
+	msg := cmd()
+	loaded, ok := msg.(mentionUsersLoadedMsg)
+	if !ok {
+		t.Fatalf("expected mentionUsersLoadedMsg, got %T", msg)
+	}
+	if len(fake.GetUsersCalls) != 1 || fake.GetUsersCalls[0].ProjectKey != "OTHER" {
+		t.Fatalf("GetUsers should be called once for OTHER, got %+v", fake.GetUsersCalls)
+	}
+
+	_, follow := app.handleMentionUsersLoaded(loaded)
+	if follow == nil {
+		t.Fatal("handleMentionUsersLoaded returned nil cmd")
+	}
+	follow()
+
+	if _, ok := app.usersCache["OTHER"]; !ok {
+		t.Error("loaded users should be cached under the issue's project key OTHER")
+	}
+	if len(fake.AddCommentCalls) != 1 {
+		t.Fatalf("AddComment called %d times, want 1", len(fake.AddCommentCalls))
+	}
+	body, _ := fake.AddCommentCalls[0].Body.(string)
+	if !strings.Contains(body, "accountid:s1") {
+		t.Errorf("comment body = %q, want accountid:s1", body)
+	}
+}
+
+func TestMentionColdPath_GetUsersError(t *testing.T) {
+	t.Parallel()
+	fake := &jiratest.FakeClient{
+		T: t,
+		GetUsersFunc: func(_ context.Context, _ string) ([]jira.User, error) {
+			return nil, errors.New("boom")
+		},
+		AddCommentFunc: func(_ context.Context, _ string, _ any) (*jira.Comment, error) {
+			return &jira.Comment{}, nil
+		},
+	}
+	app := newAppWithFake(t, fake)
+	app.converter = identityConverter{}
+	app.isCloud = true
+	app.projectKey = testProject
+	app.editContext = editCtx{kind: editCommentNew, issueKey: testKey}
+
+	cmd := app.applyEdit("ping @Solo_One")
+	msg := cmd()
+	loaded, ok := msg.(mentionUsersLoadedMsg)
+	if !ok {
+		t.Fatalf("expected mentionUsersLoadedMsg even on fetch error, got %T", msg)
+	}
+	if len(loaded.users) != 0 {
+		t.Fatalf("expected empty user list on error, got %d", len(loaded.users))
+	}
+	_, follow := app.handleMentionUsersLoaded(loaded)
+	if follow == nil {
+		t.Fatal("write must still proceed after a fetch error")
+	}
+	follow()
+
+	if len(fake.AddCommentCalls) != 1 {
+		t.Fatalf("AddComment called %d times, want 1", len(fake.AddCommentCalls))
+	}
+	body, _ := fake.AddCommentCalls[0].Body.(string)
+	if !strings.Contains(body, "@Solo_One") {
+		t.Errorf("comment body = %q, want the literal @Solo_One on fetch error", body)
+	}
+	if strings.Contains(body, "accountid") {
+		t.Errorf("comment body = %q, must not resolve when users could not be fetched", body)
+	}
+}


### PR DESCRIPTION
`@Name` in a comment or description is now converted to a real Jira mention on submit, when exactly one loaded user matches the name. Ambiguous or unknown names stay as literal text, so a wrong guess never silently mentions the wrong person. Cloud only; Data Center writes are untouched and keep the literal `@Name`.

Matching normalizes both sides through the existing `pkg/ascii.Convert`: case-folded, diacritics and umlauts folded (`Müller` matches `mueller`), and `_` treated as a space so `@Jane_Doe` resolves. `@mueller` matches a user's first or last name; `@Jane_Doe` must match the full name. Code spans, fenced blocks, escaped `\@`, and already-resolved mentions are masked out before the scan, so none of those get rewritten.

A comment or description with no `@` is written exactly as before. The resolver is a self-contained function (`mention_resolve.go`) that rewrites the markdown before ADF conversion, so it doesn't touch the converter itself.

Lookup uses the edited issue's own project, so editing an issue from another project (JQL tab) resolves against that project's users, not the active board's. When that project's user list isn't cached yet, the write defers one update tick to fetch it via a command and then continues; no network call happens inside `Update`. A failed fetch falls back to literal text rather than dropping the write.

One follow-up: there's no picker for ambiguous names yet, so two or more matches stay literal.
