### PR TITLE
Nix: Add support for non flake user

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -11,6 +11,8 @@ on:
       - gomod2nix.toml
       - flake.nix
       - flake.lock
+      - nix/package.nix
+      - nix/shell.nix
 
 permissions:
   contents: read

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Added
+
+- Nix: Create a standalone `lazyjira` package and shell for non flake user.
+
 ## [2.19.0] - 2026-06-22
 
 ### Added

--- a/flake.nix
+++ b/flake.nix
@@ -8,36 +8,28 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
   };
-  outputs = { self, nixpkgs, flake-utils, gomod2nix }:
-    flake-utils.lib.eachDefaultSystem (system:
+  outputs =
+    {
+      nixpkgs,
+      flake-utils,
+      gomod2nix,
+      self,
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
       let
-        pkgs = nixpkgs.legacyPackages.${system};
-        buildGoApplication = gomod2nix.legacyPackages.${system}.buildGoApplication;
-      in {
+        pkgs = nixpkgs.legacyPackages.${system}.extend gomod2nix.overlays.default;
+        inherit (pkgs) callPackage;
+      in
+      {
         packages = rec {
-          lazyjira = buildGoApplication {
-            pname = "lazyjira";
+          lazyjira = callPackage ./nix/package.nix {
             version = self.shortRev or self.dirtyShortRev or "dev";
-            src = self;
-            modules = ./gomod2nix.toml;
-            ldflags = [ "-s" "-w" "-X main.version=${self.shortRev or "dev"}" ];
-            subPackages = [ "cmd/lazyjira" ];
-            meta = with pkgs.lib; {
-              description = "Terminal UI for Jira";
-              homepage = "https://github.com/textfuel/lazyjira";
-              license = licenses.mit;
-              mainProgram = "lazyjira";
-            };
           };
           default = lazyjira;
         };
 
-        devShells.default = pkgs.mkShell {
-          buildInputs = [
-            pkgs.go
-            gomod2nix.packages.${system}.default
-          ];
-        };
+        devShells.default = pkgs.callPackage ./nix/shell.nix { };
       }
     );
 }

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,0 +1,55 @@
+{
+  pkgs ? (
+    let
+      inherit (builtins) fromJSON readFile;
+      inherit ((fromJSON (readFile ../flake.lock)).nodes) nixpkgs gomod2nix;
+      fetchLocked =
+        node:
+        let
+          inherit (node.locked)
+            owner
+            repo
+            rev
+            narHash
+            ;
+        in
+
+        fetchTarball {
+          url = "https://github.com/${owner}/${repo}/archive/${rev}.tar.gz";
+          sha256 = narHash;
+
+        };
+    in
+    import (fetchLocked nixpkgs) {
+      overlays = [
+        (import "${fetchLocked gomod2nix}/overlay.nix")
+      ];
+    }
+  ),
+  buildGoApplication ? pkgs.buildGoApplication,
+  version ? (
+    if builtins.pathExists ../.git then
+      builtins.substring 0 7 (pkgs.lib.commitIdFromGitRepo ../.git)
+    else
+      "dev"
+  ),
+}:
+buildGoApplication {
+  inherit version;
+
+  pname = "lazyjira";
+  src = ./..;
+  modules = ../gomod2nix.toml;
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.version=${version}"
+  ];
+  subPackages = [ "cmd/lazyjira" ];
+  meta = with pkgs.lib; {
+    description = "Terminal UI for Jira";
+    homepage = "https://github.com/textfuel/lazyjira";
+    license = licenses.mit;
+    mainProgram = "lazyjira";
+  };
+}

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -1,0 +1,12 @@
+{
+  mkShell,
+  go,
+  gomod2nix,
+}:
+mkShell {
+  name = "lazyjira-dev";
+  packages = [
+    go
+    gomod2nix
+  ];
+}


### PR DESCRIPTION
## What

This commit doesn't change anything for flake's users, however, for non flake's users, it adds a flake free package and shell.

The implementation is highly inspired on [release-go](https://github.com/tcurdt/release-go/blob/a10866366d0c2d736ffc011e466f708f3f676897/default.nix#L1-L13).

## Why

I need to add `lazyjira` to my nix config which doesn't use flake. Until now, I've been manually adding `lazyjira` to my path via
```
nix shell github:textfuel/lazyjira#.packages.x86-64-linux.lazyjira
```
but this is not very convenient. I'd like to add it to my config, therefore a non flake package would be nice.

## How to test

The newly added package can be build directly from the `nix repl`
```bash
nix-repl> :b (import ./nix/packages.nix {})

This derivation produced the following outputs:
  out -> /nix/store/c1kl4ky97qx79swr0zx6hqixg9cj5f9n-lazyjira-2.17.0
```

---

- The `version` attribute now uses nix functions directly to remove the dependency on flake. This drops the `self.dirtyShortRev or "dev"` value. Hopefully this isn't an issue?

- I don't known which nix formatter was used before, I suspect mine wasn't the right one given the diff, please let me know I will change this accordingly.

