### PR TITLE
refactor(nix): remove pkgs from package attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,24 @@ Or add to your flake inputs:
 inputs.lazyjira.url = "github:textfuel/lazyjira";
 ```
 
+Or import the package
+
+```nix
+let
+  version = "...";
+  src =
+    fetchFromGitHub {
+      owner = "textfuel";
+      repo = "lazyjira";
+      tag = "v${version}";
+      hash = "...";
+    };
+
+  buildGoApplication = import (lazyjiraSrc + "/nix/build-go-application.nix") system;
+in
+callPackage ./nix/package.nix {inherit buildGoApplication version;}
+```
+
 #### deb (Debian, Ubuntu)
 
 Download `.deb` from [Releases](https://github.com/textfuel/lazyjira/releases):

--- a/nix/build-go-application.nix
+++ b/nix/build-go-application.nix
@@ -1,0 +1,27 @@
+system:
+let
+  inherit (builtins) fromJSON readFile;
+  inherit ((fromJSON (readFile ../flake.lock)).nodes) nixpkgs gomod2nix;
+  fetchLocked =
+    node:
+    let
+      inherit (node.locked)
+        owner
+        repo
+        rev
+        narHash
+        ;
+    in
+    fetchTarball {
+      url = "https://github.com/${owner}/${repo}/archive/${rev}.tar.gz";
+      sha256 = narHash;
+    };
+
+  pkgs = import (fetchLocked nixpkgs) {
+    inherit system;
+    overlays = [
+      (import "${fetchLocked gomod2nix}/overlay.nix")
+    ];
+  };
+in
+pkgs.buildGoApplication

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,35 +1,9 @@
 {
-  pkgs ? (
-    let
-      inherit (builtins) fromJSON readFile;
-      inherit ((fromJSON (readFile ../flake.lock)).nodes) nixpkgs gomod2nix;
-      fetchLocked =
-        node:
-        let
-          inherit (node.locked)
-            owner
-            repo
-            rev
-            narHash
-            ;
-        in
-
-        fetchTarball {
-          url = "https://github.com/${owner}/${repo}/archive/${rev}.tar.gz";
-          sha256 = narHash;
-
-        };
-    in
-    import (fetchLocked nixpkgs) {
-      overlays = [
-        (import "${fetchLocked gomod2nix}/overlay.nix")
-      ];
-    }
-  ),
-  buildGoApplication ? pkgs.buildGoApplication,
+  lib,
+  buildGoApplication,
   version ? (
     if builtins.pathExists ../.git then
-      builtins.substring 0 7 (pkgs.lib.commitIdFromGitRepo ../.git)
+      builtins.substring 0 7 (lib.commitIdFromGitRepo ../.git)
     else
       "dev"
   ),
@@ -46,7 +20,7 @@ buildGoApplication {
     "-X main.version=${version}"
   ];
   subPackages = [ "cmd/lazyjira" ];
-  meta = with pkgs.lib; {
+  meta = with lib; {
     description = "Terminal UI for Jira";
     homepage = "https://github.com/textfuel/lazyjira";
     license = licenses.mit;


### PR DESCRIPTION
## What

Fixing my own mess :eyes: from #96
Fixes the `nixpkgs` manual import which lacks the `system`. This also allows cross compilation of lazyjira.

## Why

When importing `nix/package.nix` from a flake without providing `pkgs`, the default `nixpkgs` import fails because neither `builtins.currentSystem` nor `args.system` are defined. `currentSystem` isn't defined in flake because its impure and well `system` can't be provided. `import nixpkgs` underneath imports `default.nix` which then imports `pkgs/top-level.nix` which requires `system` =>
https://github.com/NixOS/nixpkgs/blob/32d52cc4732270b1ea959901a7634c4adfec86ee/pkgs/top-level/impure.nix#L13-L18

This PR allows the `system` provided by the caller. `system` is optional if `pkgs` is provided since not necessary in this scenario.

## How to test

`nix/packages.nix` need to be imported without `builtins.currentSystem` nor `pkgs`.

For instance from a flake where `lazyjira` is imported via npins
```
  lazyjira = import (npins.sources.lazyjira.outPath + "/nix/package.nix") { system = "x86_64-linux"; };
```
