### PR TITLE
feat: enable task lists in ticket body

### DIFF
--- a/pkg/tui/views/adf.go
+++ b/pkg/tui/views/adf.go
@@ -141,6 +141,17 @@ func (r *adfRenderer) renderBlock(node any, indent int) {
 			r.renderListItem(item, indent, fmt.Sprintf("%d. ", i+1))
 		}
 
+	case adfTaskList:
+		for _, item := range content {
+			if itemMap, ok := item.(map[string]any); ok {
+				if t, _ := itemMap["type"].(string); t == adfTaskList {
+					r.renderBlock(item, indent+2)
+					continue
+				}
+			}
+			r.renderTaskItem(item, indent)
+		}
+
 	case adfCodeBlock:
 		lang := ""
 		if attrs, ok := block["attrs"].(map[string]any); ok {
@@ -224,6 +235,26 @@ func (r *adfRenderer) renderListItem(node any, indent int, marker string) {
 			r.renderBlock(child, indent+markerW)
 		}
 	}
+}
+
+func (r *adfRenderer) renderTaskItem(node any, indent int) {
+	item, ok := node.(map[string]any)
+	if !ok {
+		return
+	}
+	content, _ := item["content"].([]any)
+	done := false
+	if attrs, ok := item["attrs"].(map[string]any); ok {
+		state, _ := attrs["state"].(string)
+		done = state == "DONE"
+	}
+	text := r.collectInline(content)
+	marker := "[ ] "
+	if done {
+		marker = "[x] "
+		text = lipgloss.NewStyle().Strikethrough(true).Foreground(theme.ColorGray).Render(text)
+	}
+	r.appendWrapped(text, indent, marker)
 }
 
 func (r *adfRenderer) collectInline(content []any) string {

--- a/pkg/tui/views/adf_extra_test.go
+++ b/pkg/tui/views/adf_extra_test.go
@@ -119,6 +119,97 @@ func TestBuiltinRenderer_RenderListItem_NestedList(t *testing.T) {
 	}
 }
 
+type taskItemSpec struct {
+	text   string
+	done   bool
+	nested []taskItemSpec
+}
+
+func makeTaskListADF(items []taskItemSpec) map[string]any {
+	return map[string]any{
+		"type":    "doc",
+		"content": []any{taskListNode(items)},
+	}
+}
+
+func taskListNode(items []taskItemSpec) map[string]any {
+	content := make([]any, 0, len(items))
+	for _, it := range items {
+		state := "TODO"
+		if it.done {
+			state = "DONE"
+		}
+		content = append(content, map[string]any{
+			"type":    adfTaskItem,
+			"attrs":   map[string]any{"state": state},
+			"content": []any{map[string]any{"type": adfText, "text": it.text}},
+		})
+		if len(it.nested) > 0 {
+			content = append(content, taskListNode(it.nested))
+		}
+	}
+	return map[string]any{"type": adfTaskList, "content": content}
+}
+
+func TestBuiltinRenderer_RenderTaskList(t *testing.T) {
+	t.Parallel()
+	adf := makeTaskListADF([]taskItemSpec{
+		{text: "todo item", done: false},
+		{text: "done item", done: true},
+	})
+	lines := BuiltinRenderer{}.Render(adf, 80)
+	if len(lines) == 0 {
+		t.Fatal("expected non-empty output for task list")
+	}
+	joined := stripANSI(strings.Join(lines, "\n"))
+	if !strings.Contains(joined, "[ ] todo item") {
+		t.Errorf("task list output = %q, want '[ ] todo item'", joined)
+	}
+	if !strings.Contains(joined, "[x] done item") {
+		t.Errorf("task list output = %q, want '[x] done item'", joined)
+	}
+}
+
+func TestBuiltinRenderer_RenderTaskList_Nested(t *testing.T) {
+	t.Parallel()
+	adf := map[string]any{
+		"type": "doc",
+		"content": []any{
+			map[string]any{
+				"type": adfTaskList,
+				"content": []any{
+					map[string]any{
+						"type":    adfTaskItem,
+						"attrs":   map[string]any{"state": "TODO"},
+						"content": []any{map[string]any{"type": adfText, "text": "outer task"}},
+					},
+					map[string]any{
+						"type": adfTaskList,
+						"content": []any{
+							map[string]any{
+								"type":    adfTaskItem,
+								"attrs":   map[string]any{"state": "DONE"},
+								"content": []any{map[string]any{"type": adfText, "text": "nested task"}},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	lines := BuiltinRenderer{}.Render(adf, 80)
+	if len(lines) == 0 {
+		t.Fatal("expected non-empty output for nested task list")
+	}
+	joined := stripANSI(strings.Join(lines, "\n"))
+	if !strings.Contains(joined, "outer task") {
+		t.Errorf("nested task list output = %q, want 'outer task'", joined)
+	}
+	if !strings.Contains(joined, "nested task") {
+		t.Errorf("nested task list output = %q, want 'nested task'", joined)
+	}
+}
+
 func makeTableADF(rows [][]string) map[string]any {
 	tableRows := make([]any, 0, len(rows))
 	for i, row := range rows {

--- a/pkg/tui/views/adfmd.go
+++ b/pkg/tui/views/adfmd.go
@@ -1,6 +1,7 @@
 package views
 
 import (
+	"crypto/rand"
 	"encoding/json"
 	"fmt"
 	"regexp"
@@ -22,6 +23,8 @@ const (
 	adfHardBreak   = "hardBreak"
 	adfInlineCard  = "inlineCard"
 	adfListItem    = "listItem"
+	adfTaskList    = "taskList"
+	adfTaskItem    = "taskItem"
 )
 
 // ADFToMarkdown converts an ADF document to Markdown text
@@ -116,6 +119,13 @@ func blockToMarkdown(node any, indent int) string {
 	case "table":
 		return tableToMarkdown(content, indent)
 
+	case adfTaskList:
+		var items []string
+		for _, item := range content {
+			items = append(items, taskItemToMarkdown(item, indent))
+		}
+		return strings.Join(items, "\n")
+
 	default:
 		return opaqueMarker(block)
 	}
@@ -156,6 +166,25 @@ func listItemToMarkdown(node any, indent int, marker string) string {
 		}
 	}
 	return strings.Join(parts, "\n")
+}
+
+func taskItemToMarkdown(node any, indent int) string {
+	item, ok := node.(map[string]any)
+	if !ok {
+		return ""
+	}
+	if t, _ := item["type"].(string); t == adfTaskList {
+		return blockToMarkdown(item, indent+2)
+	}
+	content, _ := item["content"].([]any)
+	box := "[ ]"
+	if attrs, ok := item["attrs"].(map[string]any); ok {
+		if state, _ := attrs["state"].(string); state == "DONE" {
+			box = "[x]"
+		}
+	}
+	prefix := strings.Repeat(" ", indent)
+	return prefix + "- " + box + " " + inlineToMarkdown(content)
 }
 
 func inlineToMarkdown(content []any) string {
@@ -358,6 +387,11 @@ func markdownToADF(md string) any {
 			continue
 		}
 
+		if block, ok := tryParseTaskList(lines, &i, trimmed); ok {
+			blocks = append(blocks, block)
+			continue
+		}
+
 		if strings.HasPrefix(trimmed, "- ") {
 			blocks = append(blocks, parseList(lines, &i, "bullet"))
 			continue
@@ -475,6 +509,7 @@ var (
 	underlineRe   = regexp.MustCompile(`<u>(.+?)</u>`)
 	linkRe        = regexp.MustCompile(`\[([^\]]+)\]\(([^)]+)\)`)
 	mentionRe     = regexp.MustCompile(`\[@([^\]]+)\]\(accountid:([^)]+)\)`)
+	taskItemRe    = regexp.MustCompile(`^(\s*)- \[( |x|X)\] (.*)$`)
 )
 
 func parseInline(text string) []any {
@@ -587,6 +622,71 @@ func parseInlineSegment(text string) []any {
 	return result
 }
 
+func tryParseTaskList(lines []string, i *int, trimmed string) (any, bool) {
+	if !taskItemRe.MatchString(trimmed) {
+		return nil, false
+	}
+	return parseTaskList(lines, i), true
+}
+
+func parseTaskList(lines []string, idx *int) map[string]any {
+	var items []any
+	baseIndent := len(lines[*idx]) - len(strings.TrimLeft(lines[*idx], " "))
+
+	for *idx < len(lines) {
+		line := lines[*idx]
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			break
+		}
+		currentIndent := len(line) - len(strings.TrimLeft(line, " "))
+		if currentIndent != baseIndent {
+			break
+		}
+		m := taskItemRe.FindStringSubmatch(line)
+		if m == nil {
+			break
+		}
+
+		state := "TODO"
+		if strings.EqualFold(m[2], "x") {
+			state = "DONE"
+		}
+		content := parseInline(m[3])
+		if content == nil {
+			content = []any{}
+		}
+		*idx++
+		items = append(items, map[string]any{
+			"type":    adfTaskItem,
+			"attrs":   map[string]any{"state": state, "localId": newLocalID()},
+			"content": content,
+		})
+
+		if *idx < len(lines) {
+			nextLine := lines[*idx]
+			nextIndent := len(nextLine) - len(strings.TrimLeft(nextLine, " "))
+			if nextIndent > baseIndent && taskItemRe.MatchString(nextLine) {
+				items = append(items, parseTaskList(lines, idx))
+			}
+		}
+	}
+
+	return map[string]any{
+		"type":    adfTaskList,
+		"attrs":   map[string]any{"localId": newLocalID()},
+		"content": items,
+	}
+}
+
+func newLocalID() string {
+	b := make([]byte, 16)
+	_, _ = rand.Read(b)
+	b[6] = (b[6] & 0x0f) | 0x40
+	b[8] = (b[8] & 0x3f) | 0x80
+	return fmt.Sprintf("%x-%x-%x-%x-%x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:16])
+}
+
 func parseList(lines []string, idx *int, listType string) map[string]any {
 	adfType := "bulletList"
 	markerRe := regexp.MustCompile(`^(\s*)- (.*)$`)
@@ -609,6 +709,9 @@ func parseList(lines []string, idx *int, listType string) map[string]any {
 			break
 		}
 		if currentIndent > baseIndent {
+			break
+		}
+		if listType == "bullet" && len(items) > 0 && taskItemRe.MatchString(line) {
 			break
 		}
 

--- a/pkg/tui/views/adfmd_test.go
+++ b/pkg/tui/views/adfmd_test.go
@@ -79,6 +79,11 @@ func TestADFToMarkdown(t *testing.T) {
 			`{"type":"doc","content":[{"type":"table","content":[{"type":"tableRow","content":[{"type":"tableHeader","content":[{"type":"paragraph","content":[{"type":"text","text":"A"}]}]},{"type":"tableHeader","content":[{"type":"paragraph","content":[{"type":"text","text":"B"}]}]}]},{"type":"tableRow","content":[{"type":"tableCell","content":[{"type":"paragraph","content":[{"type":"text","text":"1"}]}]},{"type":"tableCell","content":[{"type":"paragraph","content":[{"type":"text","text":"2"}]}]}]}]}]}`,
 			"| A | B |\n| --- | --- |\n| 1 | 2 |",
 		},
+		{
+			"task list",
+			`{"type":"doc","content":[{"type":"taskList","content":[{"type":"taskItem","attrs":{"state":"TODO"},"content":[{"type":"text","text":"a"}]},{"type":"taskItem","attrs":{"state":"DONE"},"content":[{"type":"text","text":"b"}]}]}]}`,
+			"- [ ] a\n- [x] b",
+		},
 	}
 
 	for _, tt := range tests {
@@ -134,6 +139,7 @@ func TestMarkdownToADF_BlockTypes(t *testing.T) {
 		{"rule", "---", adfRule},
 		{"paragraph", "just text", adfParagraph},
 		{"table", "| A | B |\n| --- | --- |\n| 1 | 2 |", adfTable},
+		{"task list", "- [ ] item", adfTaskList},
 	}
 
 	for _, tt := range tests {
@@ -182,6 +188,7 @@ func TestMarkdownADFRoundTrip(t *testing.T) {
 		{"bullet list", "- a\n- b"},
 		{"ordered list", "1. a\n2. b"},
 		{"rule", "---"},
+		{"task list", "- [ ] a\n- [x] b"},
 	}
 
 	for _, tt := range tests {
@@ -204,4 +211,129 @@ func TestMarkdownToADF_OpaqueMarkerRestored(t *testing.T) {
 		t.Fatal("expected the opaque node to survive the round trip")
 	}
 	testkit.AssertEqual(t, "restored type", blockType(t, restored[0]), "panel")
+}
+
+func taskItemState(t *testing.T, block any) string {
+	t.Helper()
+	m, ok := block.(map[string]any)
+	if !ok {
+		t.Fatalf("block is not a map: %T", block)
+	}
+	attrs, ok := m["attrs"].(map[string]any)
+	if !ok {
+		t.Fatal("taskItem has no attrs")
+	}
+	state, _ := attrs["state"].(string)
+	return state
+}
+
+func TestMarkdownToADF_TaskItemState(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		md   string
+		want string
+	}{
+		{"unchecked", "- [ ] todo", "TODO"},
+		{"checked lowercase", "- [x] done", "DONE"},
+		{"checked uppercase", "- [X] done", "DONE"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			blocks := mdBlocks(t, tt.md)
+			taskList, ok := blocks[0].(map[string]any)
+			if !ok {
+				t.Fatal("first block is not a map")
+			}
+			items, ok := taskList["content"].([]any)
+			if !ok || len(items) == 0 {
+				t.Fatal("taskList has no items")
+			}
+			testkit.AssertEqual(t, "state", taskItemState(t, items[0]), tt.want)
+		})
+	}
+}
+
+func TestMarkdownToADF_TaskList_HasLocalID(t *testing.T) {
+	t.Parallel()
+
+	blocks := mdBlocks(t, "- [ ] a\n- [x] b")
+	taskList, ok := blocks[0].(map[string]any)
+	if !ok {
+		t.Fatal("first block is not a map")
+	}
+	listAttrs, ok := taskList["attrs"].(map[string]any)
+	if !ok {
+		t.Fatal("taskList has no attrs")
+	}
+	if id, _ := listAttrs["localId"].(string); id == "" {
+		t.Error("taskList missing localId")
+	}
+
+	items, ok := taskList["content"].([]any)
+	if !ok || len(items) != 2 {
+		t.Fatalf("expected 2 taskItems, got %d", len(items))
+	}
+	seen := make(map[string]bool)
+	for _, item := range items {
+		m, ok := item.(map[string]any)
+		if !ok {
+			t.Fatal("taskItem is not a map")
+		}
+		itemAttrs, ok := m["attrs"].(map[string]any)
+		if !ok {
+			t.Fatal("taskItem has no attrs")
+		}
+		id, _ := itemAttrs["localId"].(string)
+		if id == "" {
+			t.Error("taskItem missing localId")
+		}
+		if seen[id] {
+			t.Errorf("duplicate localId %q across taskItems", id)
+		}
+		seen[id] = true
+	}
+}
+
+func TestMarkdownToADF_TaskItem_EmptyTextIsEmptyArray(t *testing.T) {
+	t.Parallel()
+
+	blocks := mdBlocks(t, "- [ ] first\n- [ ] ")
+	items, ok := blocks[0].(map[string]any)["content"].([]any)
+	if !ok || len(items) != 2 {
+		t.Fatalf("expected 2 taskItems, got %d", len(items))
+	}
+	empty, ok := items[1].(map[string]any)
+	if !ok {
+		t.Fatal("second taskItem is not a map")
+	}
+	content, ok := empty["content"].([]any)
+	if !ok {
+		t.Fatalf("empty taskItem content = %#v (%T), want an empty []any", empty["content"], empty["content"])
+	}
+	testkit.AssertEqual(t, "content length", len(content), 0)
+}
+
+func TestMarkdownToADF_MalformedTaskLine_DoesNotCorruptSiblings(t *testing.T) {
+	t.Parallel()
+
+	blocks := mdBlocks(t, "- [ ] one\n- [x] two\n- []broken\n- [ ] four")
+	if len(blocks) != 3 {
+		t.Fatalf("expected 3 blocks (taskList, bulletList, taskList), got %d: %#v", len(blocks), blocks)
+	}
+	testkit.AssertEqual(t, "block 0 type", blockType(t, blocks[0]), adfTaskList)
+	testkit.AssertEqual(t, "block 1 type", blockType(t, blocks[1]), adfBulletList)
+	testkit.AssertEqual(t, "block 2 type", blockType(t, blocks[2]), adfTaskList)
+
+	leading, _ := blocks[0].(map[string]any)["content"].([]any)
+	if len(leading) != 2 {
+		t.Errorf("expected 2 items in leading taskList, got %d", len(leading))
+	}
+	trailing, _ := blocks[2].(map[string]any)["content"].([]any)
+	if len(trailing) != 1 {
+		t.Errorf("expected 1 item in trailing taskList, got %d", len(trailing))
+	}
 }


### PR DESCRIPTION
## What

Task lists in a ticket body are currently not rendered. Enable rendering and editing them in the body. The task list is rendered as the github flavoured `- [ ]` or `- [x]` checklist.

<img width="108" height="128" alt="image" src="https://github.com/user-attachments/assets/f19abf39-84d1-40e4-928a-2d45d050371b" />


## Why

Task lists like these didn't render:

<img width="156" height="187" alt="image" src="https://github.com/user-attachments/assets/f7e05071-f111-4b9f-8482-484ad8ca0d93" />


## How to test

Create a ticket with a task list, then try viewing and editing in lazyjira.

