### PR TITLE
feat: show issue summary on detail page

### DIFF
--- a/pkg/tui/views/detail.go
+++ b/pkg/tui/views/detail.go
@@ -268,13 +268,17 @@ func (d *DetailView) ClickItem(relY int) tea.Cmd {
 	if !d.IsListTab() || d.issue == nil {
 		return nil
 	}
-	// relY=0 is title bar, relY=1+ is content. Find which block the click falls in.
+	// relY=0 is title bar, relY=1+ is the summary header then content. Find which block the click falls in.
 	// We need to map content line to block index.
-	// Simple approach: the clicked line (accounting for scroll) maps to a block.
-	clickedLine := d.scrollY + relY - 1 // -1 for title border
-	if clickedLine < 0 {
+	// Simple approach: the clicked line (accounting for scroll and the pinned
+	// summary header) maps to a block.
+	contentWidth, _ := components.PanelDimensions(d.width, d.height)
+	headerLen := len(d.summaryHeaderLines(contentWidth))
+	clickedLine := relY - 1 // -1 for title border
+	if clickedLine < headerLen {
 		return nil
 	}
+	clickedLine += d.scrollY - headerLen
 
 	// Walk blocks to find which one contains the clicked line.
 	blockWidth := max(d.width-2, 10) - 1 // -1 for list bar prefix
@@ -477,6 +481,8 @@ func (d *DetailView) View() string {
 	}
 
 	title := d.buildTitle(contentWidth)
+	header := d.summaryHeaderLines(contentWidth)
+	visible = max(visible-len(header), 1)
 
 	var contentLines []string
 	if count := d.listTabItemCount(); count > 0 {
@@ -492,6 +498,7 @@ func (d *DetailView) View() string {
 
 	totalLines := len(contentLines)
 	contentLines = d.clampAndSliceScroll(contentLines, visible)
+	contentLines = append(header, contentLines...)
 
 	body := strings.Join(contentLines, "\n")
 
@@ -634,6 +641,19 @@ func (d *DetailView) buildTitle(maxWidth int) string {
 
 	sep := sepStyle.Render(" - ")
 	return prefix + sep + strings.Join(tabParts, sep)
+}
+
+// summaryHeaderLines renders the full issue summary as a wrapped header shown above the tab content.
+func (d *DetailView) summaryHeaderLines(width int) []string {
+	if d.issue == nil || d.issue.Summary == "" {
+		return nil
+	}
+	wrapped := wrapText(d.issue.Summary, width-1)
+	lines := make([]string, 0, len(wrapped)+1)
+	for _, l := range wrapped {
+		lines = append(lines, " "+d.theme.Title.Render(l))
+	}
+	return append(lines, "")
 }
 
 func (d *DetailView) renderDescription(width int) []string {

--- a/pkg/tui/views/detail_view_test.go
+++ b/pkg/tui/views/detail_view_test.go
@@ -345,6 +345,26 @@ func TestDetailView_ClickItem_NegativeLineNoop(t *testing.T) {
 	}
 }
 
+func TestDetailView_ClickItem_AccountsForSummaryHeader(t *testing.T) {
+	t.Parallel()
+	detail := makeFocusedDetail()
+	detail.SetIssue(&jira.Issue{
+		Key:      testKey,
+		Summary:  "Short summary",
+		Comments: []jira.Comment{{Body: "first"}, {Body: "second"}},
+	})
+	detail.SetActiveTab(TabComments)
+
+	contentWidth, _ := components.PanelDimensions(detail.width, detail.height)
+	header := detail.summaryHeaderLines(contentWidth)
+	if len(header) == 0 {
+		t.Fatal("expected a non-empty summary header")
+	}
+
+	detail.ClickItem(1 + len(header))
+	testkit.AssertEqual(t, "cursor selects first block accounting for header offset", detail.listCursor, 0)
+}
+
 func TestDetailView_IsListTab_FalseForDetails(t *testing.T) {
 	t.Parallel()
 	detail := NewDetailView(BuiltinRenderer{})
@@ -624,11 +644,32 @@ func TestDetailView_View_DescriptionBodyShown(t *testing.T) {
 	}
 }
 
+func TestDetailView_View_ShowsFullSummaryWrapped(t *testing.T) {
+	t.Parallel()
+	detail := makeFocusedDetail()
+	longSummary := "This is a deliberately long issue summary that will not fit on a single narrow terminal row"
+	detail.SetIssue(&jira.Issue{
+		Key:         testKey,
+		Summary:     longSummary,
+		Description: "body text",
+	})
+	output := stripANSI(detail.View())
+	for _, word := range strings.Fields(longSummary) {
+		if !strings.Contains(output, word) {
+			t.Errorf("detail view missing summary word %q; view = %q", word, output)
+		}
+	}
+	if strings.Contains(output, "…") {
+		t.Errorf("summary should wrap, not truncate with ellipsis; view = %q", output)
+	}
+}
+
 func TestDetailView_View_CommentsTab_ShowsAuthor(t *testing.T) {
 	t.Parallel()
 	detail := makeFocusedDetail()
 	detail.SetIssue(&jira.Issue{
-		Key: testKey,
+		Key:     testKey,
+		Summary: "Visible even on the comments tab",
 		Comments: []jira.Comment{
 			{
 				Author: &jira.User{DisplayName: "Bob"},
@@ -643,6 +684,9 @@ func TestDetailView_View_CommentsTab_ShowsAuthor(t *testing.T) {
 	}
 	if !strings.Contains(output, "great idea") {
 		t.Errorf("comments view = %q, want to contain comment body", output)
+	}
+	if !strings.Contains(output, "Visible even on the comments tab") {
+		t.Errorf("comments view = %q, want summary header present on non-Body tab", output)
 	}
 }
 


### PR DESCRIPTION
## What

Add the full summary to the
    details panel [0] so it's always trivially readable.

<img width="748" height="87" alt="image" src="https://github.com/user-attachments/assets/ebc7bcb9-c282-4bfc-b487-4008ba1d099f" />



## Why

 The issue summary is only shown on the board/mine [2] panel, which can
    easily become trimmed. In this case the only way to view the summary is
    to call edit on the summary in panel [2]. 

## How to test

<!-- Steps to verify the change works -->

