### PR TITLE
fix: set projectID when projectKey is configured

### DIFF
--- a/pkg/tui/handlers_data.go
+++ b/pkg/tui/handlers_data.go
@@ -378,6 +378,11 @@ func (a *App) handleProjectsLoaded(msg projectsLoadedMsg) (tea.Model, tea.Cmd) {
 		a.resolveBoardID()
 		return a, a.fetchActiveTab()
 	}
+	if a.projectID == "" {
+		if id, ok := a.resolveProjectID(a.projectKey); ok {
+			a.projectID = id
+		}
+	}
 	return a, nil
 }
 

--- a/pkg/tui/handlers_data_more_test.go
+++ b/pkg/tui/handlers_data_more_test.go
@@ -438,6 +438,31 @@ func TestHandleProjectsLoaded(t *testing.T) {
 			t.Error("expected nil cmd when project key already set")
 		}
 	})
+
+	t.Run("config-preset key resolves ID from loaded list", func(t *testing.T) {
+		t.Parallel()
+		app := newAppWithFake(t, &jiratest.FakeClient{T: t})
+		app.demoMode = true
+		app.projectKey = testProject // simulates projects: config seeding the key with no ID
+
+		_, cmd := app.handleProjectsLoaded(projectsLoadedMsg{projects: []jira.Project{{Key: testProject, ID: "10005"}}})
+
+		testkit.AssertEqual(t, "projectID", app.projectID, "10005")
+		if cmd != nil {
+			t.Error("expected nil cmd when project key already set")
+		}
+	})
+
+	t.Run("config-preset key with no match leaves ID empty", func(t *testing.T) {
+		t.Parallel()
+		app := newAppWithFake(t, &jiratest.FakeClient{T: t})
+		app.demoMode = true
+		app.projectKey = testProject
+
+		_, _ = app.handleProjectsLoaded(projectsLoadedMsg{projects: []jira.Project{{Key: "OPS", ID: "2"}}})
+
+		testkit.AssertEqual(t, "projectID", app.projectID, "")
+	})
 }
 
 func TestPrefetchChildrenDetails(t *testing.T) {


### PR DESCRIPTION
When a projectKey is configured in config, creating a new issue will fail, because the projectID is not set, yet the jira API requires it. Make sure the projectID is set even in this case.



