### PR TITLE
Add managed JQL tabs created from the TUI

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -372,6 +372,48 @@ issueTabs:
 
 Resolution order: per-tab `maxResults` → global `maxResults` → built-in default (50). Values `<= 0` are treated as unset. Note that the Jira server may enforce its own upper bound and silently return fewer issues than requested.
 
+## Managed tabs (`saved_tabs.yml`)
+
+Tabs created from inside the TUI are stored in a separate file, `saved_tabs.yml`, in the same config directory as `config.yml` (so `~/.config/lazyjira/saved_tabs.yml` on Linux, and honoring `LAZYJIRA_CONFIG_DIR` / `XDG_CONFIG_HOME`). This keeps `config.yml` untouched: lazyjira never rewrites it, so your hand-edited comments and formatting are safe.
+
+There are two sources of tabs:
+
+| Source | File | Edited via | Templates |
+|--------|------|------------|-----------|
+| Config tabs | `config.yml` `issueTabs` | hand-edited (read-only from the TUI) | yes (`{{.ProjectKey}}`) |
+| Managed tabs | `saved_tabs.yml` | created, deleted, reordered in the TUI | no (concrete JQL) |
+
+You normally do not edit `saved_tabs.yml` by hand. It is written by the Save, Delete, Promote, and Reorder actions (see [Keybindings](Keybindings.md#issues)). The format is an ordered list, and the list order is the tab order shown in the bar:
+
+```yaml
+tabs:
+  - name: "My Bugs"
+    jql: "project = ABC AND type = Bug AND statusCategory != Done"
+    project: "ABC"      # bind to one project; empty = global (shown under every project)
+    maxResults: 50      # optional, same meaning as on issueTabs
+```
+
+| Field | Description |
+|-------|-------------|
+| `name` | Tab label. |
+| `jql` | Concrete JQL (no template expansion). |
+| `project` | Project key the tab belongs to. Empty means global: the tab appears under every project. |
+| `maxResults` | Optional per-tab page size, same resolution as for `issueTabs`. |
+
+### Tab order
+
+For the active project the bar is assembled in this order:
+
+1. Managed tabs whose `project` matches the current project or is empty (global), in `saved_tabs.yml` order.
+2. Config tabs from `issueTabs`, except those shadowed by a managed tab (see below).
+3. Transient tabs (ad-hoc JQL search, hierarchy view) created at runtime.
+
+### Shadow, promote, un-promote
+
+A managed tab and a config tab can share a name. When they do, the managed tab **shadows** the config one: the config tab is hidden while a same-named managed tab exists. Matching is by name.
+
+This is what the Promote action uses. Promoting a config tab copies it (name, JQL, `maxResults`) into `saved_tabs.yml`, bound to the current project. The config original is then shadowed, but `config.yml` is never modified, so promote is non-destructive and reversible. Deleting the managed copy **un-promotes** it: the config tab reappears unchanged.
+
 ## Keybindings
 
 All keybindings are remappable. See [Keybindings](Keybindings.md) for the full list of defaults.
@@ -607,5 +649,6 @@ Available in every scope:
 | File | Description |
 |------|-------------|
 | `config.yml` | Main configuration |
+| `saved_tabs.yml` | Managed tabs created from inside the TUI |
 | `auth.json` | Credentials, created automatically with restricted permissions |
 | `jql_history.txt` | JQL search history, up to 50 entries |

--- a/docs/Keybindings.md
+++ b/docs/Keybindings.md
@@ -41,6 +41,27 @@ Detail scroll keys (`J`/`K`/`ctrl+f`/`ctrl+b`) can be remapped via `keybinding.d
 | `b` | Create branch from issue |
 | `s` | JQL search |
 | `x` | Close JQL tab |
+| `M` | Manage the active tab (see below) |
+| `D` | Delete the active managed tab (asks for confirmation) |
+| `<` / `>` | Move the active managed tab left / right within the managed section |
+
+### Managed tabs
+
+The `M` key is context-sensitive and is how you turn queries into lasting, named tabs (stored in `saved_tabs.yml`, see [Config](Config.md#managed-tabs-saved_tabsyml)):
+
+- On a transient JQL tab (created with `s`): **Save** it as a managed tab. You are prompted for a name, and the tab is bound to the current project.
+- On a config tab (from `issueTabs`): **Promote** a copy into the store. The name is pre-filled. The config original is then shadowed by the managed copy; `config.yml` is left untouched.
+
+`D` deletes the active managed tab after a confirmation. If a same-named config tab was shadowed, it reappears (un-promote). `<` and `>` reorder the active managed tab. All three are no-ops on tabs they do not apply to (for example `D` does nothing on a config tab). `x` still only closes a transient JQL tab.
+
+These keys are remappable under `keybinding.issues` in `config.yml`:
+
+| Action | Config key | Default |
+|--------|-----------|---------|
+| Manage (save / promote) | `manageTab` | `M` |
+| Delete managed tab | `deleteManagedTab` | `D` |
+| Reorder left | `reorderTabLeft` | `<` |
+| Reorder right | `reorderTabRight` | `>` |
 
 ## Help popup
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -166,6 +166,11 @@ type IssueKeys struct {
 	CreateBranch  string `yaml:"createBranch"`
 	CreateIssue   string `yaml:"createIssue"`
 	CreateSubtask string `yaml:"createSubtask"`
+
+	ManageTab        string `yaml:"manageTab"`
+	DeleteManagedTab string `yaml:"deleteManagedTab"`
+	ReorderTabLeft   string `yaml:"reorderTabLeft"`
+	ReorderTabRight  string `yaml:"reorderTabRight"`
 }
 
 type ProjectKeys struct {

--- a/pkg/config/savedtabs.go
+++ b/pkg/config/savedtabs.go
@@ -1,0 +1,54 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+)
+
+const savedTabsFile = "saved_tabs.yml"
+
+// ManagedTab is a TUI-managed issue tab persisted in saved_tabs.yml. Unlike
+// IssueTabConfig (hand-edited templates in config.yml), a managed tab holds a
+// concrete JQL query bound to a project (empty Project means global).
+type ManagedTab struct {
+	Name       string `yaml:"name"`
+	JQL        string `yaml:"jql"`
+	Project    string `yaml:"project"`
+	MaxResults *int   `yaml:"maxResults"`
+}
+
+type savedTabsFileFormat struct {
+	Tabs []ManagedTab `yaml:"tabs"`
+}
+
+// LoadSavedTabs reads managed tabs from ConfigDir()/saved_tabs.yml.
+// Returns nil on a missing or unreadable file, mirroring LoadJQLHistory.
+func LoadSavedTabs() []ManagedTab {
+	path := filepath.Join(ConfigDir(), savedTabsFile)
+	data, err := os.ReadFile(path) //nolint:gosec
+	if err != nil {
+		return nil
+	}
+	var f savedTabsFileFormat
+	if err := yaml.Unmarshal(data, &f); err != nil {
+		return nil
+	}
+	return f.Tabs
+}
+
+// SaveSavedTabs writes managed tabs to ConfigDir()/saved_tabs.yml. It marshals
+// only the managed-tabs store, never config.yml, so the hand-edited config is
+// left untouched.
+func SaveSavedTabs(tabs []ManagedTab) error {
+	dir := ConfigDir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	data, err := yaml.Marshal(savedTabsFileFormat{Tabs: tabs})
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(dir, savedTabsFile), data, 0o644)
+}

--- a/pkg/config/savedtabs_test.go
+++ b/pkg/config/savedtabs_test.go
@@ -1,0 +1,67 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadSavedTabs_missingFile_returnsNil(t *testing.T) {
+	t.Setenv("LAZYJIRA_CONFIG_DIR", t.TempDir())
+
+	if got := LoadSavedTabs(); got != nil {
+		t.Errorf("LoadSavedTabs() = %v, want nil for missing file", got)
+	}
+}
+
+func TestSaveThenLoad_roundtrip(t *testing.T) {
+	t.Setenv("LAZYJIRA_CONFIG_DIR", t.TempDir())
+
+	limit := 25
+	want := []ManagedTab{
+		{Name: "Bugs", JQL: "type = Bug", Project: "ABC", MaxResults: &limit},
+		{Name: "Global", JQL: "assignee = currentUser()", Project: ""},
+	}
+
+	if err := SaveSavedTabs(want); err != nil {
+		t.Fatalf("SaveSavedTabs() error = %v", err)
+	}
+
+	got := LoadSavedTabs()
+	if len(got) != len(want) {
+		t.Fatalf("loaded %d tabs, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i].Name != want[i].Name || got[i].JQL != want[i].JQL || got[i].Project != want[i].Project {
+			t.Errorf("tab %d = %+v, want %+v", i, got[i], want[i])
+		}
+	}
+	if got[0].MaxResults == nil || *got[0].MaxResults != limit {
+		t.Errorf("tab 0 MaxResults = %v, want %d", got[0].MaxResults, limit)
+	}
+	if got[1].MaxResults != nil {
+		t.Errorf("tab 1 MaxResults = %v, want nil", got[1].MaxResults)
+	}
+}
+
+func TestSaveSavedTabs_doesNotTouchConfigYml(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("LAZYJIRA_CONFIG_DIR", dir)
+
+	sentinel := []byte("# hand-tuned config\njira:\n  url: https://example.atlassian.net\n")
+	if err := os.WriteFile(filepath.Join(dir, "config.yml"), sentinel, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := SaveSavedTabs([]ManagedTab{{Name: "X", JQL: "project = X"}}); err != nil {
+		t.Fatalf("SaveSavedTabs() error = %v", err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(dir, "config.yml")) //nolint:gosec
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != string(sentinel) {
+		t.Errorf("config.yml was modified:\ngot:  %q\nwant: %q", got, sentinel)
+	}
+}

--- a/pkg/tui/app.go
+++ b/pkg/tui/app.go
@@ -77,6 +77,9 @@ type editCtx struct {
 	// returnToJQLModal marks the save-tab prompt opened via Ctrl+S from the JQL
 	// search modal: cancelling reopens the search with tabJQL instead of dropping it.
 	returnToJQLModal bool
+	// prevEditingManagedTab restores the managed-tab-edit context on that reopen,
+	// so the reopened search behaves and labels itself as it did before Ctrl+S.
+	prevEditingManagedTab int
 }
 
 type createCtx struct {

--- a/pkg/tui/app.go
+++ b/pkg/tui/app.go
@@ -62,6 +62,7 @@ const (
 	editBranch
 	editCreateField
 	editCreateDesc
+	editTabName
 )
 
 type editCtx struct {
@@ -71,6 +72,8 @@ type editCtx struct {
 	fieldID        string
 	fieldIndex     int
 	converterState any
+	tabJQL         string // captured at prompt time; source for editTabName confirm
+	tabMaxResults  *int   // promote carries the config tab's page size; nil for save
 }
 
 type createCtx struct {
@@ -89,6 +92,7 @@ type onChecklistFunc func([]components.ModalItem) tea.Cmd
 type issuesLoadedMsg struct {
 	issues []jira.Issue
 	tab    int
+	epoch  int
 }
 type issueDetailLoadedMsg struct{ issue *jira.Issue }
 
@@ -212,6 +216,14 @@ type App struct {
 
 	customCmds []config.ResolvedCustomCommand
 
+	// savedTabs is the source of truth for the managed-tab store. Mutations
+	// persist to saved_tabs.yml and re-sync issuesList via SetSavedTabs.
+	savedTabs []config.ManagedTab
+
+	// editingManagedTab is the store index whose query an open JQL modal will
+	// overwrite on submit, or -1 when the modal performs a fresh search.
+	editingManagedTab int
+
 	panelSideW     int
 	panelStatusH   int
 	panelIssuesH   int
@@ -274,6 +286,12 @@ func NewAppWithAuth(cfg *config.Config, client jira.ClientInterface, authMethod 
 		issuesList.SetPriorityIcons(cfg.GUI.PriorityIcons)
 	}
 	issuesList.SetTabs(cfg.IssueTabs)
+	savedTabs := config.LoadSavedTabs()
+	issuesList.SetSavedTabs(savedTabs)
+	// Assemble for the initial project so the list's project filter matches
+	// a.projectKey from the start; otherwise managed tabs stay hidden (and
+	// fail to shadow their config namesakes) until the first project switch.
+	issuesList.RebuildTabs(projectKey)
 	issuesList.SetFocused(true)
 	issuesList.SetUserEmail(cfg.Jira.Email)
 	infoPanel := views.NewInfoPanel()
@@ -327,34 +345,36 @@ func NewAppWithAuth(cfg *config.Config, client jira.ClientInterface, authMethod 
 	}
 
 	app := &App{
-		cfg:             cfg,
-		client:          client,
-		keymap:          KeymapFromConfig(cfg.Keybinding),
-		splashInfo:      splash,
-		statusPanel:     statusPanel,
-		issuesList:      issuesList,
-		infoPanel:       infoPanel,
-		projectList:     projectList,
-		detailView:      detailView,
-		logPanel:        logPanel,
-		helpBar:         helpBar,
-		searchBar:       searchBar,
-		modal:           modal,
-		jqlModal:        jqlModal,
-		diffView:        diffView,
-		inputModal:      inputModal,
-		createForm:      createForm,
-		side:            sideLeft,
-		leftFocus:       focusIssues,
-		projectKey:      projectKey,
-		isCloud:         cfg.Jira.IsCloud(),
-		demoMode:        authMethod == AuthDemo,
-		logFlag:         logFlag,
-		usersCache:      make(map[string][]jira.User),
-		issueCache:      make(map[string]*jira.Issue),
-		childrenCache:   make(map[string][]jira.Issue),
-		createMetaCache: make(map[string][]jira.CreateMetaField),
-		converter:       BuiltinConverter{},
+		cfg:               cfg,
+		client:            client,
+		keymap:            KeymapFromConfig(cfg.Keybinding),
+		splashInfo:        splash,
+		statusPanel:       statusPanel,
+		issuesList:        issuesList,
+		infoPanel:         infoPanel,
+		projectList:       projectList,
+		detailView:        detailView,
+		logPanel:          logPanel,
+		helpBar:           helpBar,
+		searchBar:         searchBar,
+		modal:             modal,
+		jqlModal:          jqlModal,
+		diffView:          diffView,
+		inputModal:        inputModal,
+		createForm:        createForm,
+		savedTabs:         savedTabs,
+		editingManagedTab: -1,
+		side:              sideLeft,
+		leftFocus:         focusIssues,
+		projectKey:        projectKey,
+		isCloud:           cfg.Jira.IsCloud(),
+		demoMode:          authMethod == AuthDemo,
+		logFlag:           logFlag,
+		usersCache:        make(map[string][]jira.User),
+		issueCache:        make(map[string]*jira.Issue),
+		childrenCache:     make(map[string][]jira.Issue),
+		createMetaCache:   make(map[string][]jira.CreateMetaField),
+		converter:         BuiltinConverter{},
 	}
 	// cfg.Converter is validated at config-load time; "" and "builtin"
 	// both fall through to the BuiltinConverter set above.
@@ -574,11 +594,14 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case components.JQLSubmitMsg:
 		return a.handleJQLSubmit(msg)
+	case components.JQLSaveTabMsg:
+		return a.handleJQLSaveTab(msg)
 	case jqlSearchResultMsg:
 		return a.handleJQLSearchResult(msg)
 	case jqlSearchErrorMsg:
 		return a.handleJQLSearchError(msg)
 	case components.JQLCancelMsg:
+		a.editingManagedTab = -1
 		return a, nil
 	case components.JQLInputChangedMsg:
 		return a.handleJQLInputChanged(msg)
@@ -1154,7 +1177,7 @@ func (a *App) fetchActiveTab() tea.Cmd {
 		}
 		tabIdx := a.issuesList.GetTabIndex()
 		*a.logFlag = true
-		return fetchIssuesByJQL(a.client, jql, tabIdx, a.cfg.ResolveGlobalMaxResults())
+		return fetchIssuesByJQL(a.client, jql, tabIdx, a.cfg.ResolveGlobalMaxResults(), a.issuesList.TabEpoch())
 	}
 	if a.projectKey == "" {
 		return nil
@@ -1166,7 +1189,7 @@ func (a *App) fetchActiveTab() tea.Cmd {
 	tabIdx := a.issuesList.GetTabIndex()
 	jql := resolveTabJQL(tab, a.projectKey, a.cfg.Jira.Email)
 	*a.logFlag = true
-	return fetchIssuesByJQL(a.client, jql, tabIdx, a.cfg.ResolveMaxResults(tab))
+	return fetchIssuesByJQL(a.client, jql, tabIdx, a.cfg.ResolveMaxResults(tab), a.issuesList.TabEpoch())
 }
 
 func (a *App) updateFocusState() {

--- a/pkg/tui/app.go
+++ b/pkg/tui/app.go
@@ -74,6 +74,9 @@ type editCtx struct {
 	converterState any
 	tabJQL         string // captured at prompt time; source for editTabName confirm
 	tabMaxResults  *int   // promote carries the config tab's page size; nil for save
+	// returnToJQLModal marks the save-tab prompt opened via Ctrl+S from the JQL
+	// search modal: cancelling reopens the search with tabJQL instead of dropping it.
+	returnToJQLModal bool
 }
 
 type createCtx struct {

--- a/pkg/tui/commands.go
+++ b/pkg/tui/commands.go
@@ -53,13 +53,13 @@ func gitCheckoutTracking(repoPath, remoteBranch string) tea.Cmd {
 	}
 }
 
-func fetchIssuesByJQL(client jira.ClientInterface, jql string, tab, maxResults int) tea.Cmd {
+func fetchIssuesByJQL(client jira.ClientInterface, jql string, tab, maxResults, epoch int) tea.Cmd {
 	return func() tea.Msg {
 		result, err := client.SearchIssues(context.Background(), jql, 0, maxResults)
 		if err != nil {
 			return errorMsg{err: err}
 		}
-		return issuesLoadedMsg{issues: result.Issues, tab: tab}
+		return issuesLoadedMsg{issues: result.Issues, tab: tab, epoch: epoch}
 	}
 }
 

--- a/pkg/tui/commands_fetch_test.go
+++ b/pkg/tui/commands_fetch_test.go
@@ -33,7 +33,7 @@ func TestFetchIssuesByJQL(t *testing.T) {
 			return &jira.SearchResult{Issues: []jira.Issue{{Key: testKey}}}, nil
 		}
 
-		msg := fetchIssuesByJQL(fake, "project = PLAT", 2, 50)()
+		msg := fetchIssuesByJQL(fake, "project = PLAT", 2, 50, 7)()
 
 		loaded, ok := msg.(issuesLoadedMsg)
 		if !ok {
@@ -41,6 +41,9 @@ func TestFetchIssuesByJQL(t *testing.T) {
 		}
 		if loaded.tab != 2 || len(loaded.issues) != 1 {
 			t.Errorf("loaded = %+v, want tab=2 with one issue", loaded)
+		}
+		if loaded.epoch != 7 {
+			t.Errorf("loaded.epoch = %d, want 7 (captured at fetch time)", loaded.epoch)
 		}
 	})
 
@@ -50,7 +53,7 @@ func TestFetchIssuesByJQL(t *testing.T) {
 		fake.SearchIssuesFunc = func(_ context.Context, _ string, _, _ int) (*jira.SearchResult, error) {
 			return nil, errors.New("boom")
 		}
-		assertErrorMsg(t, fetchIssuesByJQL(fake, "x", 0, 10)())
+		assertErrorMsg(t, fetchIssuesByJQL(fake, "x", 0, 10, 0)())
 	})
 }
 

--- a/pkg/tui/components/help.go
+++ b/pkg/tui/components/help.go
@@ -37,6 +37,11 @@ func (h *HelpBar) SetStatusMsg(msg string) {
 	h.statusMsg = msg
 }
 
+// StatusMsg returns the current transient message.
+func (h *HelpBar) StatusMsg() string {
+	return h.statusMsg
+}
+
 // SetWidth updates the help bar width.
 func (h *HelpBar) SetWidth(w int) {
 	h.width = w

--- a/pkg/tui/components/jqlmodal.go
+++ b/pkg/tui/components/jqlmodal.go
@@ -13,6 +13,9 @@ import (
 // JQLSubmitMsg is sent when the user submits a JQL query
 type JQLSubmitMsg struct{ Query string }
 
+// JQLSaveTabMsg is sent when the user saves the current query as a managed tab
+type JQLSaveTabMsg struct{ Query string }
+
 // JQLCancelMsg is sent when the user cancels the JQL modal
 type JQLCancelMsg struct{}
 
@@ -162,6 +165,13 @@ func (m *JQLModal) handleKey(msg tea.KeyMsg) (JQLModal, tea.Cmd) {
 		}
 		m.focusInput = !m.focusInput
 		return *m, nil
+
+	case tea.KeyCtrlS:
+		q := m.input.Value()
+		if strings.TrimSpace(q) == "" {
+			return *m, nil
+		}
+		return *m, func() tea.Msg { return JQLSaveTabMsg{Query: q} }
 
 	case tea.KeyEnter:
 		return m.handleEnter()

--- a/pkg/tui/components/jqlmodal_test.go
+++ b/pkg/tui/components/jqlmodal_test.go
@@ -255,6 +255,31 @@ func TestJQLModal_TabInsertsSuggestionWhenOnlyOne(t *testing.T) {
 	}
 }
 
+func TestJQLModal_ctrlS_emitsSaveMsg(t *testing.T) {
+	t.Parallel()
+	m := NewJQLModal()
+	m.SetSize(80, 24)
+	m.Show(testQueryText, nil)
+	m, cmd := m.Update(tea.KeyMsg{Type: tea.KeyCtrlS})
+	if cmd == nil {
+		t.Fatal("expected save command")
+	}
+	msg, ok := cmd().(JQLSaveTabMsg)
+	if !ok {
+		t.Fatalf("expected JQLSaveTabMsg, got %T", cmd())
+	}
+	testkit.AssertEqual(t, "save query", msg.Query, testQueryText)
+}
+
+func TestJQLModal_ctrlS_emptyInputNoop(t *testing.T) {
+	t.Parallel()
+	m := NewJQLModal()
+	m.SetSize(80, 24)
+	m.Show("", nil)
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyCtrlS})
+	testkit.AssertEqual(t, "no command when empty", cmd == nil, true)
+}
+
 func TestJQLModal_ListNavWithJK(t *testing.T) {
 	t.Parallel()
 	m := NewJQLModal()

--- a/pkg/tui/custom_commands_test.go
+++ b/pkg/tui/custom_commands_test.go
@@ -18,6 +18,8 @@ func newTestApp() *App {
 		detailView:  views.NewDetailView(views.BuiltinRenderer{}),
 		side:        sideLeft,
 		leftFocus:   focusIssues,
+
+		editingManagedTab: -1,
 	}
 }
 

--- a/pkg/tui/handlers.go
+++ b/pkg/tui/handlers.go
@@ -80,18 +80,27 @@ func (a *App) handleAutoFetch() (tea.Model, tea.Cmd) {
 	return a, tea.Batch(cmds...)
 }
 
+// setActiveProject is the single mutator for the current project. Every project
+// change must go through it: it keeps a.projectKey and the issue list's tab
+// filter (issuesList.RebuildTabs) in sync. They used to drift when a caller set
+// a.projectKey directly, leaving managed tabs hidden and unable to shadow their
+// config namesakes. Invariant: never assign a.projectKey outside this method.
+func (a *App) setActiveProject(key, id string) {
+	a.projectKey = key
+	a.projectID = id
+	a.statusPanel.SetProject(key)
+	a.projectList.SetActiveKey(key)
+	a.issuesList.RebuildTabs(key)
+	a.resolveBoardID()
+}
+
 func (a *App) selectProject(p *jira.Project) tea.Cmd {
-	a.projectKey = p.Key
-	a.projectID = p.ID
-	a.statusPanel.SetProject(p.Key)
-	a.projectList.SetActiveKey(p.Key)
-	a.issuesList.InvalidateTabCache()
+	a.setActiveProject(p.Key, p.ID)
 	a.issueCache = make(map[string]*jira.Issue)
 	a.childrenCache = make(map[string][]jira.Issue)
 	a.createMetaCache = make(map[string][]jira.CreateMetaField)
 	a.invalidateInFlight()
 	a.infoPanel.SetIssue(nil)
-	a.resolveBoardID()
 	if !a.demoMode {
 		go saveLastProject(p.Key)
 	}

--- a/pkg/tui/handlers_data.go
+++ b/pkg/tui/handlers_data.go
@@ -16,6 +16,9 @@ import (
 
 // handleIssuesLoaded processes newly fetched issues
 func (a *App) handleIssuesLoaded(msg issuesLoadedMsg) (tea.Model, tea.Cmd) {
+	if msg.epoch != a.issuesList.TabEpoch() {
+		return a, nil // stale: tabs were reassembled after this fetch was issued
+	}
 	a.statusPanel.SetError("")
 	*a.logFlag = false
 	a.statusPanel.SetOnline(true)
@@ -53,8 +56,8 @@ func (a *App) handleIssuesLoaded(msg issuesLoadedMsg) (tea.Model, tea.Cmd) {
 		case a.issuesList.SelectByKey(detectedKey):
 			cmds = append(cmds, fetchIssueDetail(a.client, detectedKey))
 			a.gitDetectedKey = ""
-		case a.issuesList.GetTabIndex() != 0:
-			a.issuesList.SetTabIndex(0)
+		case a.issuesList.GetTabIndex() != a.issuesList.HomeTabIndex():
+			a.issuesList.SetTabIndex(a.issuesList.HomeTabIndex())
 			cmds = append(cmds, a.fetchActiveTab())
 		default:
 			a.gitDetectedKey = ""
@@ -371,11 +374,7 @@ func (a *App) handleProjectsLoaded(msg projectsLoadedMsg) (tea.Model, tea.Cmd) {
 	}
 	a.projectList.SetProjects(projects)
 	if a.projectKey == "" && len(projects) > 0 {
-		a.projectKey = projects[0].Key
-		a.projectID = projects[0].ID
-		a.statusPanel.SetProject(a.projectKey)
-		a.projectList.SetActiveKey(a.projectKey)
-		a.resolveBoardID()
+		a.setActiveProject(projects[0].Key, projects[0].ID)
 		return a, a.fetchActiveTab()
 	}
 	return a, nil

--- a/pkg/tui/handlers_jql.go
+++ b/pkg/tui/handlers_jql.go
@@ -3,6 +3,7 @@ package tui
 import (
 	tea "github.com/charmbracelet/bubbletea"
 
+	"github.com/textfuel/lazyjira/v2/pkg/config"
 	"github.com/textfuel/lazyjira/v2/pkg/tui/components"
 )
 
@@ -13,15 +14,38 @@ func (a *App) handleJQLSubmit(msg components.JQLSubmitMsg) (tea.Model, tea.Cmd) 
 	return a, fetchJQLSearch(a.client, msg.Query, a.cfg.ResolveGlobalMaxResults())
 }
 
-// handleJQLSearchResult processes JQL search results.
+// handleJQLSaveTab hides the JQL modal and opens the name prompt to persist the
+// current query as a new managed tab, reusing the editTabName confirm path.
+func (a *App) handleJQLSaveTab(msg components.JQLSaveTabMsg) (tea.Model, tea.Cmd) {
+	a.jqlModal.Hide()
+	a.editingManagedTab = -1
+	a.inputModal.Show("Save tab", "")
+	a.editContext = editCtx{kind: editTabName, tabJQL: msg.Query}
+	return a, nil
+}
+
+// handleJQLSearchResult processes JQL search results. When the search was an
+// in-place edit of a managed tab (editingManagedTab set), it overwrites that
+// store entry's query instead of opening a transient JQL tab.
 func (a *App) handleJQLSearchResult(msg jqlSearchResultMsg) (tea.Model, tea.Cmd) {
 	*a.logFlag = false
 	a.jqlModal.Hide()
-	a.issuesList.AddJQLTab(msg.jql)
-	a.issuesList.SetIssues(msg.issues)
 	history := LoadJQLHistory()
 	history = AddToHistory(history, msg.jql)
 	_ = SaveJQLHistory(history)
+	if idx := a.editingManagedTab; idx >= 0 && idx < len(a.savedTabs) {
+		a.savedTabs[idx].JQL = msg.jql
+		if err := config.SaveSavedTabs(a.savedTabs); err != nil {
+			a.helpBar.SetStatusMsg("save tabs: " + err.Error())
+		}
+		a.issuesList.SetSavedTabs(a.savedTabs)
+		a.jumpToManagedTab(a.savedTabs[idx].Name)
+		a.issuesList.SetIssues(msg.issues)
+		a.editingManagedTab = -1
+	} else {
+		a.issuesList.AddJQLTab(msg.jql)
+		a.issuesList.SetIssues(msg.issues)
+	}
 	a.side = sideLeft
 	a.leftFocus = focusIssues
 	a.updateFocusState()

--- a/pkg/tui/handlers_jql.go
+++ b/pkg/tui/handlers_jql.go
@@ -20,7 +20,7 @@ func (a *App) handleJQLSaveTab(msg components.JQLSaveTabMsg) (tea.Model, tea.Cmd
 	a.jqlModal.Hide()
 	a.editingManagedTab = -1
 	a.inputModal.Show("Save tab", "")
-	a.editContext = editCtx{kind: editTabName, tabJQL: msg.Query}
+	a.editContext = editCtx{kind: editTabName, tabJQL: msg.Query, returnToJQLModal: true}
 	return a, nil
 }
 

--- a/pkg/tui/handlers_jql.go
+++ b/pkg/tui/handlers_jql.go
@@ -17,10 +17,11 @@ func (a *App) handleJQLSubmit(msg components.JQLSubmitMsg) (tea.Model, tea.Cmd) 
 // handleJQLSaveTab hides the JQL modal and opens the name prompt to persist the
 // current query as a new managed tab, reusing the editTabName confirm path.
 func (a *App) handleJQLSaveTab(msg components.JQLSaveTabMsg) (tea.Model, tea.Cmd) {
+	prev := a.editingManagedTab
 	a.jqlModal.Hide()
 	a.editingManagedTab = -1
 	a.inputModal.Show("Save tab", "")
-	a.editContext = editCtx{kind: editTabName, tabJQL: msg.Query, returnToJQLModal: true}
+	a.editContext = editCtx{kind: editTabName, tabJQL: msg.Query, returnToJQLModal: true, prevEditingManagedTab: prev}
 	return a, nil
 }
 

--- a/pkg/tui/handlers_keys.go
+++ b/pkg/tui/handlers_keys.go
@@ -357,11 +357,37 @@ func (a *App) handleTabAction(action Action) (tea.Model, tea.Cmd, bool) {
 		}
 		return a, nil, true
 
+	case ActManageTab:
+		m, cmd := a.startManageTab()
+		return m, cmd, true
+
+	case ActDeleteManagedTab:
+		m, cmd := a.startDeleteManagedTab()
+		return m, cmd, true
+
+	case ActReorderTabLeft:
+		if a.side == sideLeft && a.leftFocus == focusIssues {
+			return a, a.reorderManagedTab(-1), true
+		}
+		return a, nil, true
+
+	case ActReorderTabRight:
+		if a.side == sideLeft && a.leftFocus == focusIssues {
+			return a, a.reorderManagedTab(1), true
+		}
+		return a, nil, true
+
 	case ActJQLSearch:
 		history := LoadJQLHistory()
 		prefill := ""
-		if a.projectKey != "" {
-			prefill = "project = " + a.projectKey + " AND "
+		if a.issuesList.IsManagedTab() {
+			prefill = normalizeJQL(a.issuesList.ActiveTab().JQL)
+			a.editingManagedTab = a.issuesList.ActiveManagedStoreIdx()
+		} else {
+			if a.projectKey != "" {
+				prefill = "project = " + a.projectKey + " AND "
+			}
+			a.editingManagedTab = -1
 		}
 		a.jqlModal.Show(prefill, history)
 		var cmds []tea.Cmd
@@ -666,7 +692,7 @@ func (a *App) navigateToLinkedIssue() (tea.Model, tea.Cmd) {
 		}
 	} else if cached, ok := a.issueCache[key]; ok {
 		a.issuesList.InjectIssue(*cached)
-		a.issuesList.SetTabIndex(0)
+		a.issuesList.SetTabIndex(a.issuesList.HomeTabIndex())
 	}
 	a.issuesList.SelectByKey(key)
 	a.leftFocus = focusIssues

--- a/pkg/tui/handlers_managedtab_edit_test.go
+++ b/pkg/tui/handlers_managedtab_edit_test.go
@@ -140,6 +140,33 @@ func TestJQLSaveTab_fromModal_savesManagedTab(t *testing.T) {
 	}
 }
 
+func TestJQLSaveTab_escReopensSearchWithQuery(t *testing.T) {
+	t.Setenv("LAZYJIRA_CONFIG_DIR", t.TempDir())
+	app := newAppWithFake(t, &jiratest.FakeClient{T: t})
+	app.demoMode = true
+	app.projectKey = testProjectABC
+	app.issuesList.SetTabs([]config.IssueTabConfig{{Name: "All", JQL: "x"}})
+	app.jqlModal.SetSize(80, 24)
+	query := "project = X AND status = Open"
+	app.jqlModal.Show(query, nil)
+
+	app.Update(components.JQLSaveTabMsg{Query: query}) // Ctrl+S opens the name prompt
+	if app.jqlModal.IsVisible() {
+		t.Fatal("JQL modal should hide while the name prompt is open")
+	}
+
+	app.handleInputCancelled() // Esc on the name prompt
+	if !app.jqlModal.IsVisible() {
+		t.Fatal("Esc on the save-tab prompt must reopen the JQL search")
+	}
+	if got := app.jqlModal.InputValue(); got != query {
+		t.Fatalf("reopened search must keep the query, got %q", got)
+	}
+	if len(config.LoadSavedTabs()) != 0 {
+		t.Error("cancelling save must not persist a tab")
+	}
+}
+
 func TestHelpBar_jqlModal_hasSaveTabHint(t *testing.T) {
 	t.Parallel()
 	app := appForKeybindings(t)

--- a/pkg/tui/handlers_managedtab_edit_test.go
+++ b/pkg/tui/handlers_managedtab_edit_test.go
@@ -167,6 +167,53 @@ func TestJQLSaveTab_escReopensSearchWithQuery(t *testing.T) {
 	}
 }
 
+func TestJQLSaveTab_escRestoresManagedEditContext(t *testing.T) {
+	t.Setenv("LAZYJIRA_CONFIG_DIR", t.TempDir())
+	app := newAppWithFake(t, &jiratest.FakeClient{T: t})
+	app.jqlModal.SetSize(80, 24)
+	app.editingManagedTab = 2 // as if editing the managed tab at store index 2
+	app.jqlModal.Show("project = X", nil)
+
+	app.Update(components.JQLSaveTabMsg{Query: "project = X"})
+	if app.editingManagedTab != -1 {
+		t.Fatalf("save-tab prompt should clear editingManagedTab, got %d", app.editingManagedTab)
+	}
+	app.handleInputCancelled()
+	if app.editingManagedTab != 2 {
+		t.Fatalf("esc must restore the managed-edit context, got %d", app.editingManagedTab)
+	}
+}
+
+func TestHelpBar_jqlModal_labelsByContext(t *testing.T) {
+	t.Parallel()
+	find := func(items []components.HelpItem, key string) string {
+		for _, it := range items {
+			if it.Key == key {
+				return it.Description
+			}
+		}
+		return ""
+	}
+	app := appForKeybindings(t)
+	app.jqlModal.Show("", nil)
+
+	app.editingManagedTab = -1
+	if got := find(app.helpBarItems(), "enter"); got != "search" {
+		t.Errorf("plain: enter label = %q, want search", got)
+	}
+	if got := find(app.helpBarItems(), "ctrl+s"); got != "save tab" {
+		t.Errorf("plain: ctrl+s label = %q, want save tab", got)
+	}
+
+	app.editingManagedTab = 0
+	if got := find(app.helpBarItems(), "enter"); got != "update tab" {
+		t.Errorf("managed: enter label = %q, want update tab", got)
+	}
+	if got := find(app.helpBarItems(), "ctrl+s"); got != "save as new tab" {
+		t.Errorf("managed: ctrl+s label = %q, want save as new tab", got)
+	}
+}
+
 func TestHelpBar_jqlModal_hasSaveTabHint(t *testing.T) {
 	t.Parallel()
 	app := appForKeybindings(t)

--- a/pkg/tui/handlers_managedtab_edit_test.go
+++ b/pkg/tui/handlers_managedtab_edit_test.go
@@ -1,0 +1,157 @@
+package tui
+
+import (
+	"testing"
+
+	"github.com/textfuel/lazyjira/v2/pkg/config"
+	"github.com/textfuel/lazyjira/v2/pkg/jira"
+	"github.com/textfuel/lazyjira/v2/pkg/jira/jiratest"
+	"github.com/textfuel/lazyjira/v2/pkg/tui/components"
+)
+
+// newManagedTabApp builds an app focused on a managed tab in project ABC.
+func newManagedTabApp(t *testing.T, jql string) *App {
+	t.Helper()
+	app := newAppWithFake(t, &jiratest.FakeClient{T: t})
+	app.demoMode = true
+	app.keymap = DefaultKeymap()
+	app.projectKey = testProjectABC
+	app.issuesList.SetTabs([]config.IssueTabConfig{{Name: "All", JQL: "x"}})
+	app.savedTabs = []config.ManagedTab{{Name: testManagedName, JQL: jql, Project: testProjectABC}}
+	app.issuesList.SetSavedTabs(app.savedTabs)
+	app.issuesList.RebuildTabs(testProjectABC)
+	app.issuesList.SetTabIndex(0) // managed Bugs
+	return app
+}
+
+func TestEditManagedTab_updatesQueryInPlace(t *testing.T) {
+	t.Setenv("LAZYJIRA_CONFIG_DIR", t.TempDir())
+	app := newManagedTabApp(t, "old query")
+
+	if _, _, ok := app.handleTabAction(ActJQLSearch); !ok {
+		t.Fatal("ActJQLSearch not dispatched")
+	}
+	if app.editingManagedTab != 0 {
+		t.Fatalf("editingManagedTab = %d, want 0", app.editingManagedTab)
+	}
+	if got := app.jqlModal.InputValue(); got != "old query" {
+		t.Errorf("prefill = %q, want %q", got, "old query")
+	}
+
+	app.handleJQLSearchResult(jqlSearchResultMsg{
+		jql:    "new query",
+		issues: []jira.Issue{{Key: "ABC-9", Summary: "s"}},
+	})
+
+	if app.savedTabs[0].JQL != "new query" {
+		t.Errorf("store JQL = %q, want new query", app.savedTabs[0].JQL)
+	}
+	saved := config.LoadSavedTabs()
+	if len(saved) != 1 || saved[0].JQL != "new query" {
+		t.Errorf("persisted = %+v, want one entry with new query", saved)
+	}
+	if app.issuesList.IsJQLTab() {
+		t.Error("no transient JQL tab should be created on in-place edit")
+	}
+	if !app.issuesList.IsManagedTab() || app.issuesList.ActiveTab().Name != testManagedName {
+		t.Errorf("active tab should remain managed %q, got managed=%v name=%q",
+			testManagedName, app.issuesList.IsManagedTab(), app.issuesList.ActiveTab().Name)
+	}
+	if app.editingManagedTab != -1 {
+		t.Errorf("editingManagedTab should reset to -1, got %d", app.editingManagedTab)
+	}
+}
+
+func TestEditManagedTab_multilineQueryNormalized(t *testing.T) {
+	t.Setenv("LAZYJIRA_CONFIG_DIR", t.TempDir())
+	app := newManagedTabApp(t, "project = ABC\nAND status = Open\nORDER BY updated DESC")
+
+	if _, _, ok := app.handleTabAction(ActJQLSearch); !ok {
+		t.Fatal("ActJQLSearch not dispatched")
+	}
+
+	got := app.jqlModal.InputValue()
+	want := "project = ABC AND status = Open ORDER BY updated DESC"
+	if got != want {
+		t.Errorf("multi-line query must prefill single-line: got %q, want %q", got, want)
+	}
+}
+
+func TestPromote_multilineConfigQueryStoredSingleLine(t *testing.T) {
+	t.Setenv("LAZYJIRA_CONFIG_DIR", t.TempDir())
+	app := newAppWithFake(t, &jiratest.FakeClient{T: t})
+	app.demoMode = true
+	app.keymap = DefaultKeymap()
+	app.projectKey = testProjectABC
+	app.issuesList.SetTabs([]config.IssueTabConfig{
+		{Name: "Multi", JQL: "project = ABC\nAND status = Open\nORDER BY updated DESC"},
+	})
+	app.issuesList.RebuildTabs(testProjectABC)
+	app.issuesList.SetTabIndex(0) // config Multi
+
+	app.handleTabAction(ActManageTab) // promote
+	app.handleInputConfirmed(components.InputConfirmedMsg{Text: "Multi"})
+
+	if len(app.savedTabs) != 1 {
+		t.Fatalf("want 1 saved tab, got %+v", app.savedTabs)
+	}
+	want := "project = ABC AND status = Open ORDER BY updated DESC"
+	if app.savedTabs[0].JQL != want {
+		t.Errorf("stored JQL must be normalized single-line:\n got %q\nwant %q", app.savedTabs[0].JQL, want)
+	}
+}
+
+func TestEditManagedTab_onlyManagedTabs(t *testing.T) {
+	t.Setenv("LAZYJIRA_CONFIG_DIR", t.TempDir())
+	app := newManagedTabApp(t, "managed")
+	app.issuesList.SetTabIndex(app.issuesList.HomeTabIndex()) // config "All"
+	if app.issuesList.IsManagedTab() {
+		t.Fatal("setup: expected a config tab, not managed")
+	}
+
+	if _, _, ok := app.handleTabAction(ActJQLSearch); !ok {
+		t.Fatal("ActJQLSearch not dispatched")
+	}
+	if app.editingManagedTab != -1 {
+		t.Errorf("config tab must not target the store, editingManagedTab = %d", app.editingManagedTab)
+	}
+}
+
+func TestJQLSaveTab_fromModal_savesManagedTab(t *testing.T) {
+	t.Setenv("LAZYJIRA_CONFIG_DIR", t.TempDir())
+	app := newAppWithFake(t, &jiratest.FakeClient{T: t})
+	app.demoMode = true
+	app.projectKey = testProjectABC
+	app.issuesList.SetTabs([]config.IssueTabConfig{{Name: "All", JQL: "x"}})
+	app.issuesList.SetSavedTabs(nil)
+	app.savedTabs = nil
+	app.issuesList.RebuildTabs(testProjectABC)
+	app.jqlModal.Show("project = X", nil)
+
+	app.Update(components.JQLSaveTabMsg{Query: "project = X"})
+	if app.jqlModal.IsVisible() {
+		t.Error("JQL modal should hide before the name prompt")
+	}
+	app.handleInputConfirmed(components.InputConfirmedMsg{Text: "Saved Q"})
+
+	saved := config.LoadSavedTabs()
+	if len(saved) != 1 || saved[0].Name != "Saved Q" || saved[0].JQL != "project = X" {
+		t.Errorf("persisted = %+v, want one Saved Q / project = X", saved)
+	}
+}
+
+func TestHelpBar_jqlModal_hasSaveTabHint(t *testing.T) {
+	t.Parallel()
+	app := appForKeybindings(t)
+	app.jqlModal.Show("", nil)
+
+	found := false
+	for _, it := range app.helpBarItems() {
+		if it.Description == "save tab" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("jqlModal help bar must include a 'save tab' hint, got %+v", app.helpBarItems())
+	}
+}

--- a/pkg/tui/handlers_managedtabs.go
+++ b/pkg/tui/handlers_managedtabs.go
@@ -1,0 +1,136 @@
+package tui
+
+import (
+	"slices"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/textfuel/lazyjira/v2/pkg/config"
+	"github.com/textfuel/lazyjira/v2/pkg/tui/components"
+)
+
+// startManageTab opens the manage prompt for the active tab: save a transient
+// JQL tab, or promote a config tab into the managed store. The query and page
+// size are captured into editCtx so the single editTabName confirm path is
+// source-agnostic.
+func (a *App) startManageTab() (tea.Model, tea.Cmd) {
+	if a.side != sideLeft || a.leftFocus != focusIssues {
+		return a, nil
+	}
+	switch {
+	case a.issuesList.IsJQLTab():
+		a.inputModal.Show("Save tab", "")
+		a.editContext = editCtx{kind: editTabName, tabJQL: a.issuesList.JQLQuery()}
+	case a.issuesList.IsConfigTab():
+		cfg := a.issuesList.ActiveTab()
+		a.inputModal.Show("Promote tab", cfg.Name)
+		a.editContext = editCtx{kind: editTabName, tabJQL: cfg.JQL, tabMaxResults: cfg.MaxResults}
+	}
+	return a, nil
+}
+
+// saveManagedTab persists jql as a named managed tab bound to the current
+// project, then jumps to the new tab and fetches it. An empty name or query is
+// rejected; a name already used by a managed tab in this project is warned about
+// but still saved (shadowing semantics match Promote). Promote never triggers
+// the warning: a config tab is only promotable while no same-named managed tab
+// shadows it.
+func (a *App) saveManagedTab(name, jql string, maxResults *int) tea.Cmd {
+	if name == "" || jql == "" {
+		return nil
+	}
+	// Idempotent: a managed tab with this name already visible in the project is
+	// not duplicated. Jump to it instead; to change its query, edit in place (s).
+	for _, mt := range a.savedTabs {
+		if mt.Name == name && (mt.Project == "" || mt.Project == a.projectKey) {
+			a.helpBar.SetStatusMsg("a tab named " + name + " already exists")
+			a.jumpToManagedTab(name)
+			return nil
+		}
+	}
+	a.savedTabs = append(a.savedTabs, config.ManagedTab{Name: name, JQL: normalizeJQL(jql), Project: a.projectKey, MaxResults: maxResults})
+	if err := config.SaveSavedTabs(a.savedTabs); err != nil {
+		a.helpBar.SetStatusMsg("save tabs: " + err.Error())
+	}
+	a.issuesList.SetSavedTabs(a.savedTabs)
+	a.jumpToManagedTab(name)
+	return a.fetchActiveTab()
+}
+
+// reorderManagedTab swaps the active managed tab with its visible managed
+// neighbor in direction dir (-1 left, +1 right), within the project-filtered
+// managed section. No-op on non-managed tabs and at the section edges. The
+// active tab follows the moved entry.
+func (a *App) reorderManagedTab(dir int) tea.Cmd {
+	if !a.issuesList.IsManagedTab() {
+		return nil
+	}
+	visible := a.issuesList.VisibleManagedStoreIndices()
+	pos := slices.Index(visible, a.issuesList.ActiveManagedStoreIdx())
+	target := pos + dir
+	if pos < 0 || target < 0 || target >= len(visible) {
+		return nil
+	}
+	name := a.issuesList.ActiveTab().Name
+	i, j := visible[pos], visible[target]
+	a.savedTabs[i], a.savedTabs[j] = a.savedTabs[j], a.savedTabs[i]
+	if err := config.SaveSavedTabs(a.savedTabs); err != nil {
+		a.helpBar.SetStatusMsg("save tabs: " + err.Error())
+	}
+	a.issuesList.SetSavedTabs(a.savedTabs)
+	a.jumpToManagedTab(name)
+	return a.fetchActiveTab()
+}
+
+// startDeleteManagedTab asks for confirmation before removing the active managed
+// tab from the store. No-op on config or transient tabs.
+func (a *App) startDeleteManagedTab() (tea.Model, tea.Cmd) {
+	if a.side != sideLeft || a.leftFocus != focusIssues {
+		return a, nil
+	}
+	if !a.issuesList.IsManagedTab() {
+		return a, nil
+	}
+	storeIdx := a.issuesList.ActiveManagedStoreIdx()
+	a.onSelect = func(item components.ModalItem) tea.Cmd {
+		if item.ID == "yes" {
+			return a.deleteManagedTab(storeIdx)
+		}
+		return nil
+	}
+	a.modal.Show("Delete tab?", []components.ModalItem{
+		{ID: "yes", Label: "Yes"},
+		{ID: "no", Label: "No"},
+	})
+	return a, nil
+}
+
+// deleteManagedTab removes the store entry at storeIdx, persists, and rebuilds.
+// A shadowed config tab of the same name reappears (un-promote).
+func (a *App) deleteManagedTab(storeIdx int) tea.Cmd {
+	if storeIdx < 0 || storeIdx >= len(a.savedTabs) {
+		return nil
+	}
+	a.savedTabs = append(a.savedTabs[:storeIdx], a.savedTabs[storeIdx+1:]...)
+	if err := config.SaveSavedTabs(a.savedTabs); err != nil {
+		a.helpBar.SetStatusMsg("save tabs: " + err.Error())
+	}
+	a.issuesList.SetSavedTabs(a.savedTabs)
+	return a.fetchActiveTab()
+}
+
+// jumpToManagedTab moves the active tab to the managed tab named name, if
+// visible. It cycles the visible bar via the public tab API.
+func (a *App) jumpToManagedTab(name string) {
+	il := a.issuesList
+	start := il.GetTabIndex()
+	for {
+		if il.IsManagedTab() && il.ActiveTab().Name == name {
+			return
+		}
+		il.NextTab()
+		if il.GetTabIndex() == start {
+			return
+		}
+	}
+}

--- a/pkg/tui/handlers_managedtabs_test.go
+++ b/pkg/tui/handlers_managedtabs_test.go
@@ -1,0 +1,444 @@
+package tui
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+
+	"github.com/textfuel/lazyjira/v2/pkg/config"
+	"github.com/textfuel/lazyjira/v2/pkg/jira"
+	"github.com/textfuel/lazyjira/v2/pkg/jira/jiratest"
+	"github.com/textfuel/lazyjira/v2/pkg/tui/components"
+)
+
+// newSaveTabApp builds an app focused on a transient JQL tab in project ABC.
+func newSaveTabApp(t *testing.T, jql string) *App {
+	t.Helper()
+	app := newAppWithFake(t, &jiratest.FakeClient{T: t})
+	app.demoMode = true
+	app.projectKey = testProjectABC
+	app.issuesList.SetTabs([]config.IssueTabConfig{{Name: "All", JQL: "x"}})
+	app.issuesList.SetSavedTabs(nil)
+	app.savedTabs = nil
+	app.issuesList.RebuildTabs(testProjectABC)
+	app.issuesList.AddJQLTab(jql)
+	return app
+}
+
+func TestSaveTab_appendsAndPersists(t *testing.T) {
+	t.Setenv("LAZYJIRA_CONFIG_DIR", t.TempDir())
+	app := newSaveTabApp(t, "project = ABC AND status = Open")
+
+	if _, _, ok := app.handleTabAction(ActManageTab); !ok {
+		t.Fatal("ActManageTab not dispatched")
+	}
+	app.handleInputConfirmed(components.InputConfirmedMsg{Text: "My Bugs"})
+
+	saved := config.LoadSavedTabs()
+	if len(saved) != 1 {
+		t.Fatalf("LoadSavedTabs len = %d, want 1: %+v", len(saved), saved)
+	}
+	got := saved[0]
+	if got.Name != "My Bugs" || got.JQL != "project = ABC AND status = Open" || got.Project != testProjectABC {
+		t.Errorf("persisted tab = %+v", got)
+	}
+}
+
+func TestSaveTab_emptyJQL_rejected(t *testing.T) {
+	t.Setenv("LAZYJIRA_CONFIG_DIR", t.TempDir())
+	app := newSaveTabApp(t, "")
+
+	app.handleTabAction(ActManageTab)
+	app.handleInputConfirmed(components.InputConfirmedMsg{Text: "Empty"})
+
+	if len(app.savedTabs) != 0 {
+		t.Errorf("empty-JQL tab must be rejected, savedTabs = %+v", app.savedTabs)
+	}
+	if got := config.LoadSavedTabs(); len(got) != 0 {
+		t.Errorf("nothing should persist, got %+v", got)
+	}
+}
+
+func TestSaveTab_appearsAsManagedTab(t *testing.T) {
+	t.Setenv("LAZYJIRA_CONFIG_DIR", t.TempDir())
+	app := newSaveTabApp(t, "project = ABC")
+
+	app.handleTabAction(ActManageTab)
+	app.handleInputConfirmed(components.InputConfirmedMsg{Text: "Saved"})
+
+	if !app.issuesList.IsManagedTab() || app.issuesList.ActiveTab().Name != "Saved" {
+		t.Errorf("after save, active tab should be managed Saved, got managed=%v name=%q",
+			app.issuesList.IsManagedTab(), app.issuesList.ActiveTab().Name)
+	}
+	if names := visibleTabNames(app); !slices.Contains(names, "Saved") {
+		t.Errorf("Saved must appear in tab bar, got %v", names)
+	}
+}
+
+func TestSaveTab_duplicateName_rejectedIdempotent(t *testing.T) {
+	t.Setenv("LAZYJIRA_CONFIG_DIR", t.TempDir())
+	app := newSaveTabApp(t, "project = ABC")
+	app.savedTabs = []config.ManagedTab{{Name: "Dup", JQL: "old", Project: testProjectABC}}
+	app.issuesList.SetSavedTabs(app.savedTabs)
+	app.issuesList.AddJQLTab("project = ABC")
+
+	app.handleTabAction(ActManageTab)
+	app.handleInputConfirmed(components.InputConfirmedMsg{Text: "Dup"})
+
+	if len(app.savedTabs) != 1 {
+		t.Errorf("duplicate name must not be appended (idempotent), savedTabs = %+v", app.savedTabs)
+	}
+	if app.helpBar.StatusMsg() == "" {
+		t.Error("duplicate name must surface a warning")
+	}
+}
+
+func TestSaveTab_persistError_surfaced(t *testing.T) {
+	// A config dir that cannot be created (a file stands where the dir parent
+	// must be) forces SaveSavedTabs to fail.
+	tmp := t.TempDir()
+	blocker := filepath.Join(tmp, "blocker")
+	if err := os.WriteFile(blocker, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("LAZYJIRA_CONFIG_DIR", filepath.Join(blocker, "nested"))
+	app := newSaveTabApp(t, "project = ABC")
+
+	app.handleTabAction(ActManageTab)
+	app.handleInputConfirmed(components.InputConfirmedMsg{Text: "Boom"})
+
+	if app.helpBar.StatusMsg() == "" {
+		t.Error("persist error must be surfaced via help bar")
+	}
+}
+
+func TestManageTab_dispatchedNotFallthrough(t *testing.T) {
+	t.Parallel()
+	app := newAppWithFake(t, &jiratest.FakeClient{T: t})
+	app.demoMode = true
+	app.projectKey = testProjectABC
+	app.issuesList.SetTabs([]config.IssueTabConfig{{Name: "All", JQL: "x"}})
+
+	// On a config tab (not JQL) the action must still be handled, never
+	// forwarded to the panel as a raw keypress.
+	if _, _, ok := app.handleTabAction(ActManageTab); !ok {
+		t.Error("ActManageTab must be dispatched even on a non-JQL tab")
+	}
+}
+
+func TestDeleteManagedTab_removesFromStore(t *testing.T) {
+	t.Setenv("LAZYJIRA_CONFIG_DIR", t.TempDir())
+	app := newAppWithFake(t, &jiratest.FakeClient{T: t})
+	app.demoMode = true
+	app.projectKey = testProjectABC
+	app.issuesList.SetTabs([]config.IssueTabConfig{{Name: "All", JQL: "x"}})
+	app.savedTabs = []config.ManagedTab{{Name: testManagedName, JQL: "b", Project: testProjectABC}}
+	app.issuesList.SetSavedTabs(app.savedTabs)
+	app.issuesList.RebuildTabs(testProjectABC)
+	app.issuesList.SetTabIndex(0) // managed Bugs
+
+	if _, _, ok := app.handleTabAction(ActDeleteManagedTab); !ok {
+		t.Fatal("ActDeleteManagedTab not dispatched")
+	}
+	app.handleModalSelected(components.ModalSelectedMsg{Item: components.ModalItem{ID: "yes"}})
+
+	if len(app.savedTabs) != 0 {
+		t.Errorf("deleted tab must be removed, savedTabs = %+v", app.savedTabs)
+	}
+	if got := config.LoadSavedTabs(); len(got) != 0 {
+		t.Errorf("removal must persist, got %+v", got)
+	}
+}
+
+func TestDeleteManagedTab_unPromoteRevealsConfig(t *testing.T) {
+	t.Setenv("LAZYJIRA_CONFIG_DIR", t.TempDir())
+	app := newAppWithFake(t, &jiratest.FakeClient{T: t})
+	app.demoMode = true
+	app.projectKey = testProjectABC
+	app.issuesList.SetTabs([]config.IssueTabConfig{{Name: testManagedName, JQL: "cfg"}})
+	app.savedTabs = []config.ManagedTab{{Name: testManagedName, JQL: "managed", Project: testProjectABC}}
+	app.issuesList.SetSavedTabs(app.savedTabs)
+	app.issuesList.RebuildTabs(testProjectABC)
+	app.issuesList.SetTabIndex(0) // managed Bugs shadows config Bugs
+
+	app.handleTabAction(ActDeleteManagedTab)
+	app.handleModalSelected(components.ModalSelectedMsg{Item: components.ModalItem{ID: "yes"}})
+
+	if !slices.Contains(visibleTabNames(app), testManagedName) {
+		t.Errorf("config Bugs must reappear after un-promote, got %v", visibleTabNames(app))
+	}
+	if app.issuesList.IsManagedTab() && app.issuesList.ActiveTab().Name == testManagedName {
+		t.Error("Bugs should now be the config tab, not managed")
+	}
+}
+
+func TestDeleteManagedTab_noopOnConfigTab(t *testing.T) {
+	t.Setenv("LAZYJIRA_CONFIG_DIR", t.TempDir())
+	app := newAppWithFake(t, &jiratest.FakeClient{T: t})
+	app.demoMode = true
+	app.projectKey = testProjectABC
+	app.issuesList.SetTabs([]config.IssueTabConfig{{Name: "All", JQL: "x"}})
+	app.savedTabs = []config.ManagedTab{{Name: testManagedName, JQL: "b", Project: testProjectABC}}
+	app.issuesList.SetSavedTabs(app.savedTabs)
+	app.issuesList.RebuildTabs(testProjectABC)
+	app.issuesList.SetTabIndex(app.issuesList.HomeTabIndex()) // config tab
+
+	if _, _, ok := app.handleTabAction(ActDeleteManagedTab); !ok {
+		t.Error("ActDeleteManagedTab must be dispatched (handled), even on config tab")
+	}
+	// No confirm modal callback should have been registered.
+	if app.onSelect != nil {
+		t.Error("no delete confirmation expected on a config tab")
+	}
+	if len(app.savedTabs) != 1 {
+		t.Errorf("config-tab delete must be a no-op, savedTabs = %+v", app.savedTabs)
+	}
+}
+
+// At startup the issue list must be assembled for the pre-selected project, so
+// a project-bound managed tab is visible and shadows its config namesake. The
+// original bug left issuesList.projectKey == "" while a.projectKey was the
+// first project: the config tab stayed visible/promotable and the dup-check
+// (which uses a.projectKey) then warned on promote.
+func TestStartup_managedTabShadowsConfigForInitialProject(t *testing.T) {
+	t.Setenv("LAZYJIRA_CONFIG_DIR", t.TempDir())
+	if err := config.SaveSavedTabs([]config.ManagedTab{
+		{Name: "MyTab", JQL: "project = ABC", Project: testProjectABC},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	fake := &jiratest.FakeClient{T: t}
+	fake.SetOnRequestFunc = func(_ func(jira.RequestLog)) {}
+	fake.DiscoverFieldsFunc = func(_ context.Context) error { return nil }
+	cfg := &config.Config{
+		Jira:      config.JiraConfig{Host: "example.atlassian.net", Email: "t@example.com"},
+		Projects:  []config.ProjectConfig{{Key: testProjectABC}},
+		IssueTabs: []config.IssueTabConfig{{Name: "MyTab", JQL: "project = ABC"}},
+	}
+
+	app := NewApp(cfg, fake)
+
+	names := visibleTabNames(app)
+	if len(names) != 1 || names[0] != "MyTab" {
+		t.Fatalf("visible tabs = %v, want exactly one MyTab (config shadowed)", names)
+	}
+	if !app.issuesList.IsManagedTab() {
+		t.Errorf("startup MyTab should be the managed tab, not the config one")
+	}
+}
+
+func TestPromote_thenManagedAndEditable(t *testing.T) {
+	t.Setenv("LAZYJIRA_CONFIG_DIR", t.TempDir())
+	fake := &jiratest.FakeClient{T: t}
+	fake.SetOnRequestFunc = func(_ func(jira.RequestLog)) {}
+	fake.DiscoverFieldsFunc = func(_ context.Context) error { return nil }
+	cfg := &config.Config{
+		Jira:      config.JiraConfig{Host: "h", Email: "e"},
+		Projects:  []config.ProjectConfig{{Key: testProjectABC}},
+		IssueTabs: []config.IssueTabConfig{{Name: "MyTab", JQL: "project = ABC AND status = Open"}},
+	}
+	app := NewApp(cfg, fake)
+	app.keymap = DefaultKeymap()
+
+	if app.issuesList.IsManagedTab() {
+		t.Fatal("setup: startup tab should be config")
+	}
+
+	app.handleTabAction(ActManageTab)
+	app.handleInputConfirmed(components.InputConfirmedMsg{Text: "MyTab"})
+
+	if app.helpBar.StatusMsg() != "" {
+		t.Errorf("promote must not warn, got %q", app.helpBar.StatusMsg())
+	}
+	if !app.issuesList.IsManagedTab() {
+		t.Errorf("after promote, active tab should be managed; visible=%v", visibleTabNames(app))
+	}
+
+	app.handleTabAction(ActJQLSearch)
+	if got := app.jqlModal.InputValue(); got != "project = ABC AND status = Open" {
+		t.Errorf("s prefill = %q, want the managed tab's query", got)
+	}
+}
+
+// Real-world startup: cfg.Projects is empty, so the project is learned from the
+// server via handleProjectsLoaded. That handler must sync the tab list's
+// project filter, otherwise managed tabs stay hidden and their config namesakes
+// remain visible/promotable (the desync behind the recurring promote warning).
+func TestProjectsLoaded_syncsManagedTabFilter(t *testing.T) {
+	t.Setenv("LAZYJIRA_CONFIG_DIR", t.TempDir())
+	app := newAppWithFake(t, &jiratest.FakeClient{T: t})
+	app.demoMode = true
+	// projectKey is "" (no project known yet); the list assembled for "".
+	app.issuesList.SetTabs([]config.IssueTabConfig{{Name: "MyTab", JQL: "project = ABC"}})
+	app.savedTabs = []config.ManagedTab{{Name: "MyTab", JQL: "project = ABC", Project: testProjectABC}}
+	app.issuesList.SetSavedTabs(app.savedTabs)
+	if app.issuesList.IsManagedTab() {
+		t.Fatal("precondition: managed MyTab must be hidden while projectKey is empty")
+	}
+
+	app.handleProjectsLoaded(projectsLoadedMsg{projects: []jira.Project{{Key: testProjectABC}}})
+
+	if app.projectKey != testProjectABC {
+		t.Fatalf("projectKey = %q, want %q", app.projectKey, testProjectABC)
+	}
+	names := visibleTabNames(app)
+	count := 0
+	for _, n := range names {
+		if n == "MyTab" {
+			count++
+		}
+	}
+	if count != 1 || !app.issuesList.IsManagedTab() {
+		t.Errorf("managed MyTab must shadow config MyTab after projects load: visible=%v managed=%v",
+			names, app.issuesList.IsManagedTab())
+	}
+}
+
+func TestDeleteManagedTab_dispatchedNotFallthrough(t *testing.T) {
+	t.Parallel()
+	app := newAppWithFake(t, &jiratest.FakeClient{T: t})
+	app.demoMode = true
+	app.issuesList.SetTabs([]config.IssueTabConfig{{Name: "All", JQL: "x"}})
+
+	if _, _, ok := app.handleTabAction(ActDeleteManagedTab); !ok {
+		t.Error("ActDeleteManagedTab must be dispatched, not fall through")
+	}
+}
+
+func TestPromote_copiesConfigToStore(t *testing.T) {
+	t.Setenv("LAZYJIRA_CONFIG_DIR", t.TempDir())
+	app := newAppWithFake(t, &jiratest.FakeClient{T: t})
+	app.demoMode = true
+	app.projectKey = testProjectABC
+	mr := 25
+	app.issuesList.SetTabs([]config.IssueTabConfig{{Name: testManagedName, JQL: "type = Bug", MaxResults: &mr}})
+	app.issuesList.SetSavedTabs(nil)
+	app.savedTabs = nil
+	app.issuesList.RebuildTabs(testProjectABC)
+	app.issuesList.SetTabIndex(app.issuesList.HomeTabIndex())
+
+	if _, _, ok := app.handleTabAction(ActManageTab); !ok {
+		t.Fatal("ActManageTab not dispatched on config tab")
+	}
+	app.handleInputConfirmed(components.InputConfirmedMsg{Text: testManagedName})
+
+	saved := config.LoadSavedTabs()
+	if len(saved) != 1 {
+		t.Fatalf("LoadSavedTabs len = %d, want 1: %+v", len(saved), saved)
+	}
+	got := saved[0]
+	if got.Name != testManagedName || got.JQL != "type = Bug" || got.Project != testProjectABC {
+		t.Errorf("promoted tab = %+v", got)
+	}
+	if got.MaxResults == nil || *got.MaxResults != 25 {
+		t.Errorf("MaxResults not copied: %v", got.MaxResults)
+	}
+}
+
+func TestPromote_shadowsOriginal(t *testing.T) {
+	t.Setenv("LAZYJIRA_CONFIG_DIR", t.TempDir())
+	app := newAppWithFake(t, &jiratest.FakeClient{T: t})
+	app.demoMode = true
+	app.projectKey = testProjectABC
+	app.issuesList.SetTabs([]config.IssueTabConfig{{Name: testManagedName, JQL: "cfg"}})
+	app.issuesList.SetSavedTabs(nil)
+	app.savedTabs = nil
+	app.issuesList.RebuildTabs(testProjectABC)
+	app.issuesList.SetTabIndex(app.issuesList.HomeTabIndex())
+
+	app.handleTabAction(ActManageTab)
+	app.handleInputConfirmed(components.InputConfirmedMsg{Text: testManagedName})
+
+	if !app.issuesList.IsManagedTab() || app.issuesList.ActiveTab().Name != testManagedName {
+		t.Errorf("after promote, active Bugs must be managed, got managed=%v name=%q",
+			app.issuesList.IsManagedTab(), app.issuesList.ActiveTab().Name)
+	}
+	count := 0
+	for _, n := range visibleTabNames(app) {
+		if n == testManagedName {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("Bugs must appear once after promote (config original shadowed), got %d in %v",
+			count, visibleTabNames(app))
+	}
+}
+
+// newReorderApp builds an app with the given managed store, focused on the
+// issues list of the given project.
+func newReorderApp(t *testing.T, tabs []config.ManagedTab, project string) *App {
+	t.Helper()
+	app := newAppWithFake(t, &jiratest.FakeClient{T: t})
+	app.demoMode = true
+	app.projectKey = project
+	app.issuesList.SetTabs([]config.IssueTabConfig{{Name: "All", JQL: "x"}})
+	app.savedTabs = tabs
+	app.issuesList.SetSavedTabs(tabs)
+	app.issuesList.RebuildTabs(project)
+	return app
+}
+
+func TestReorder_swapsManagedOrder(t *testing.T) {
+	t.Setenv("LAZYJIRA_CONFIG_DIR", t.TempDir())
+	app := newReorderApp(t, []config.ManagedTab{
+		{Name: "A", JQL: "a", Project: testProjectABC},
+		{Name: "B", JQL: "b", Project: testProjectABC},
+	}, testProjectABC)
+	app.issuesList.SetTabIndex(0) // managed A
+
+	if _, _, ok := app.handleTabAction(ActReorderTabRight); !ok {
+		t.Fatal("ActReorderTabRight not dispatched")
+	}
+
+	if app.savedTabs[0].Name != "B" || app.savedTabs[1].Name != "A" {
+		t.Errorf("after move-right, store order = %+v", app.savedTabs)
+	}
+	if got := config.LoadSavedTabs(); len(got) != 2 || got[0].Name != "B" || got[1].Name != "A" {
+		t.Errorf("reorder must persist, got %+v", got)
+	}
+	if app.issuesList.ActiveTab().Name != "A" {
+		t.Errorf("active tab must follow the moved entry, got %q", app.issuesList.ActiveTab().Name)
+	}
+}
+
+func TestReorder_respectsProjectFilter(t *testing.T) {
+	t.Setenv("LAZYJIRA_CONFIG_DIR", t.TempDir())
+	app := newReorderApp(t, []config.ManagedTab{
+		{Name: "Foreign", JQL: "f", Project: "XYZ"},    // store 0, hidden under ABC
+		{Name: "A", JQL: "a", Project: testProjectABC}, // store 1, visible pos 0
+		{Name: "B", JQL: "b", Project: testProjectABC}, // store 2, visible pos 1
+	}, testProjectABC)
+	app.issuesList.SetTabIndex(0) // managed A
+	if !app.issuesList.IsManagedTab() || app.issuesList.ActiveTab().Name != "A" {
+		t.Fatalf("setup: want active managed A, got %q", app.issuesList.ActiveTab().Name)
+	}
+
+	app.handleTabAction(ActReorderTabRight)
+
+	if app.savedTabs[0].Name != "Foreign" {
+		t.Errorf("foreign-project entry must be untouched, store = %+v", app.savedTabs)
+	}
+	if app.savedTabs[1].Name != "B" || app.savedTabs[2].Name != "A" {
+		t.Errorf("only visible managed entries swapped, store = %+v", app.savedTabs)
+	}
+}
+
+func TestReorder_noopAtEdges(t *testing.T) {
+	t.Setenv("LAZYJIRA_CONFIG_DIR", t.TempDir())
+	app := newReorderApp(t, []config.ManagedTab{
+		{Name: "A", JQL: "a", Project: testProjectABC},
+		{Name: "B", JQL: "b", Project: testProjectABC},
+	}, testProjectABC)
+	app.issuesList.SetTabIndex(0) // managed A at the left edge
+
+	if _, _, ok := app.handleTabAction(ActReorderTabLeft); !ok {
+		t.Fatal("ActReorderTabLeft not dispatched")
+	}
+
+	if app.savedTabs[0].Name != "A" || app.savedTabs[1].Name != "B" {
+		t.Errorf("move-left at left edge must be a no-op, store = %+v", app.savedTabs)
+	}
+}

--- a/pkg/tui/handlers_modal.go
+++ b/pkg/tui/handlers_modal.go
@@ -189,6 +189,7 @@ func (a *App) handleInputCancelled() (tea.Model, tea.Cmd) {
 		a.createForm.Resume()
 	}
 	if ctx.returnToJQLModal {
+		a.editingManagedTab = ctx.prevEditingManagedTab
 		a.jqlModal.Show(ctx.tabJQL, LoadJQLHistory())
 	}
 	return a, nil

--- a/pkg/tui/handlers_modal.go
+++ b/pkg/tui/handlers_modal.go
@@ -179,12 +179,18 @@ func (a *App) handleInputConfirmed(msg components.InputConfirmedMsg) (tea.Model,
 	return a, nil
 }
 
-// handleInputCancelled clears edit context
+// handleInputCancelled clears edit context. A save-tab prompt opened via Ctrl+S
+// from the JQL search modal reopens that search with the pending query, so an
+// aborted save does not discard the user's in-progress query.
 func (a *App) handleInputCancelled() (tea.Model, tea.Cmd) {
-	if a.editContext.kind == editCreateField {
+	ctx := a.editContext
+	a.editContext = editCtx{}
+	if ctx.kind == editCreateField {
 		a.createForm.Resume()
 	}
-	a.editContext = editCtx{}
+	if ctx.returnToJQLModal {
+		a.jqlModal.Show(ctx.tabJQL, LoadJQLHistory())
+	}
 	return a, nil
 }
 

--- a/pkg/tui/handlers_modal.go
+++ b/pkg/tui/handlers_modal.go
@@ -173,6 +173,8 @@ func (a *App) handleInputConfirmed(msg components.InputConfirmedMsg) (tea.Model,
 				return a, gitCreateBranch(a.gitRepoPath, msg.Text)
 			}
 		}
+	case editTabName:
+		return a, a.saveManagedTab(strings.TrimSpace(msg.Text), ctx.tabJQL, ctx.tabMaxResults)
 	}
 	return a, nil
 }

--- a/pkg/tui/jqlprefill.go
+++ b/pkg/tui/jqlprefill.go
@@ -11,9 +11,18 @@ import (
 const currentUserMarker = "__currentUser__"
 
 var (
-	jqlAndRe = regexp.MustCompile(`(?i)\s+AND\s+`)
-	jqlEqRe  = regexp.MustCompile(`^\s*(\w+)\s*=\s*(.+?)\s*$`)
+	jqlAndRe        = regexp.MustCompile(`(?i)\s+AND\s+`)
+	jqlEqRe         = regexp.MustCompile(`^\s*(\w+)\s*=\s*(.+?)\s*$`)
+	jqlWhitespaceRe = regexp.MustCompile(`\s+`)
 )
+
+// normalizeJQL collapses runs of whitespace (including the newlines allowed in
+// multi-line config.yml block scalars) into single spaces, so a query is
+// editable in the single-line JQL input. Whitespace is insignificant in JQL,
+// so this preserves meaning.
+func normalizeJQL(jql string) string {
+	return strings.TrimSpace(jqlWhitespaceRe.ReplaceAllString(jql, " "))
+}
 
 // ParseJQLPrefill extracts simple equality clauses from JQL
 // Skips OR, NOT, IN and complex functions except currentUser()

--- a/pkg/tui/keybindings.go
+++ b/pkg/tui/keybindings.go
@@ -173,10 +173,17 @@ func (a *App) helpBarItems() []components.HelpItem {
 		}
 		return items
 	case a.jqlModal.IsVisible():
+		// Enter and Ctrl+S do different things depending on whether the modal is
+		// editing an existing managed tab (Enter overwrites it) or running an
+		// ad-hoc search (Enter searches); label them by what they actually do.
+		enterDesc, saveDesc := "search", "save tab"
+		if a.editingManagedTab >= 0 {
+			enterDesc, saveDesc = "update tab", "save as new tab"
+		}
 		return []components.HelpItem{
-			{Key: "enter", Description: "search"},
+			{Key: "enter", Description: enterDesc},
 			{Key: "tab", Description: "switch focus"},
-			{Key: "ctrl+s", Description: "save tab"},
+			{Key: "ctrl+s", Description: saveDesc},
 			{Key: "esc", Description: "cancel"},
 		}
 	case a.showHelp:

--- a/pkg/tui/keybindings.go
+++ b/pkg/tui/keybindings.go
@@ -73,6 +73,21 @@ func (a *App) ContextBindings() []Binding {
 			a.bind(ActCloseJQLTab, "close JQL tab"),
 			Binding{"[]", "switch tab"},
 		)
+		// Tab-management keys depend on the active tab kind so the reference
+		// never advertises an action that does nothing on the current tab.
+		switch {
+		case a.issuesList.IsJQLTab():
+			bindings = append(bindings, a.bind(ActManageTab, "save as managed tab"))
+		case a.issuesList.IsConfigTab():
+			bindings = append(bindings, a.bind(ActManageTab, "promote to managed tab"))
+		case a.issuesList.IsManagedTab():
+			bindings = append(bindings,
+				a.bind(ActJQLSearch, "edit query"),
+				a.bind(ActDeleteManagedTab, "delete managed tab"),
+				a.bind(ActReorderTabLeft, "move tab left"),
+				a.bind(ActReorderTabRight, "move tab right"),
+			)
+		}
 		bindings = append(bindings, a.customCommandBindings(config.CtxIssues)...)
 		return bindings
 
@@ -161,6 +176,7 @@ func (a *App) helpBarItems() []components.HelpItem {
 		return []components.HelpItem{
 			{Key: "enter", Description: "search"},
 			{Key: "tab", Description: "switch focus"},
+			{Key: "ctrl+s", Description: "save tab"},
 			{Key: "esc", Description: "cancel"},
 		}
 	case a.showHelp:
@@ -204,6 +220,18 @@ func (a *App) helpBarItems() []components.HelpItem {
 		if a.issuesList.IsJQLTab() {
 			items = append(items, components.HelpItem{Key: km.Keys(ActCloseJQLTab), Description: "close JQL"})
 		}
+		switch {
+		case a.issuesList.IsJQLTab():
+			items = append(items, components.HelpItem{Key: km.Keys(ActManageTab), Description: "save tab"})
+		case a.issuesList.IsConfigTab():
+			items = append(items, components.HelpItem{Key: km.Keys(ActManageTab), Description: "promote tab"})
+		case a.issuesList.IsManagedTab():
+			items = append(items,
+				components.HelpItem{Key: km.Keys(ActJQLSearch), Description: "edit query"},
+				components.HelpItem{Key: km.Keys(ActDeleteManagedTab), Description: "delete tab"},
+				components.HelpItem{Key: km.Keys(ActReorderTabLeft) + km.Keys(ActReorderTabRight), Description: "move tab"},
+			)
+		}
 		cur := a.currentIssue()
 		enterDesc := "detail"
 		if cur != nil {
@@ -222,8 +250,12 @@ func (a *App) helpBarItems() []components.HelpItem {
 			components.HelpItem{Key: km.Keys(ActPriority), Description: "priority"},
 			components.HelpItem{Key: km.Keys(ActCreateBranch), Description: "branch"},
 			components.HelpItem{Key: km.Keys(ActNew), Description: "create"},
-			components.HelpItem{Key: km.Keys(ActJQLSearch), Description: "JQL search"},
 		)
+		// On a managed tab the JQL key edits that tab's query (shown above);
+		// elsewhere it starts a fresh search.
+		if !a.issuesList.IsManagedTab() {
+			items = append(items, components.HelpItem{Key: km.Keys(ActJQLSearch), Description: "JQL search"})
+		}
 		if a.canCreateSubtask() {
 			items = append(items, components.HelpItem{Key: km.Keys(ActCreateSubtask), Description: "subtask"})
 		}

--- a/pkg/tui/keymap.go
+++ b/pkg/tui/keymap.go
@@ -12,40 +12,44 @@ type Action string
 
 // Actions each can be remapped to different keys via config
 const (
-	ActQuit           Action = "quit"
-	ActHelp           Action = "help"
-	ActSearch         Action = "search"
-	ActSwitchPanel    Action = "switchPanel"
-	ActFocusRight     Action = "focusRight"
-	ActFocusLeft      Action = "focusLeft"
-	ActSelect         Action = "select" // primary: mark active + open
-	ActOpen           Action = "open"   // secondary: open/preview without marking
-	ActPrevTab        Action = "prevTab"
-	ActNextTab        Action = "nextTab"
-	ActFocusDetail    Action = "focusDetail"
-	ActFocusStatus    Action = "focusStatus"
-	ActFocusIssues    Action = "focusIssues"
-	ActFocusInfo      Action = "focusInfo"
-	ActFocusProj      Action = "focusProjects"
-	ActCopyURL        Action = "copyURL"
-	ActBrowser        Action = "browser"
-	ActURLPicker      Action = "urlPicker"
-	ActTransition     Action = "transition"
-	ActRefresh        Action = "refresh"
-	ActRefreshAll     Action = "refreshAll"
-	ActInfoTab        Action = "infoTab" // legacy: now focuses Info panel
-	ActEdit           Action = "edit"
-	ActComments       Action = "comments"
-	ActNew            Action = "new"
-	ActPriority       Action = "editPriority"
-	ActAssignee       Action = "editAssignee"
-	ActJQLSearch      Action = "jqlSearch"
-	ActCloseJQLTab    Action = "closeJQLTab"
-	ActCreateBranch   Action = "createBranch"
-	ActCreateIssue    Action = "createIssue"
-	ActCreateSubtask  Action = "createSubtask"
-	ActDuplicateIssue Action = "duplicateIssue"
-	ActShowParent     Action = "showParent"
+	ActQuit             Action = "quit"
+	ActHelp             Action = "help"
+	ActSearch           Action = "search"
+	ActSwitchPanel      Action = "switchPanel"
+	ActFocusRight       Action = "focusRight"
+	ActFocusLeft        Action = "focusLeft"
+	ActSelect           Action = "select" // primary: mark active + open
+	ActOpen             Action = "open"   // secondary: open/preview without marking
+	ActPrevTab          Action = "prevTab"
+	ActNextTab          Action = "nextTab"
+	ActFocusDetail      Action = "focusDetail"
+	ActFocusStatus      Action = "focusStatus"
+	ActFocusIssues      Action = "focusIssues"
+	ActFocusInfo        Action = "focusInfo"
+	ActFocusProj        Action = "focusProjects"
+	ActCopyURL          Action = "copyURL"
+	ActBrowser          Action = "browser"
+	ActURLPicker        Action = "urlPicker"
+	ActTransition       Action = "transition"
+	ActRefresh          Action = "refresh"
+	ActRefreshAll       Action = "refreshAll"
+	ActInfoTab          Action = "infoTab" // legacy: now focuses Info panel
+	ActEdit             Action = "edit"
+	ActComments         Action = "comments"
+	ActNew              Action = "new"
+	ActPriority         Action = "editPriority"
+	ActAssignee         Action = "editAssignee"
+	ActJQLSearch        Action = "jqlSearch"
+	ActCloseJQLTab      Action = "closeJQLTab"
+	ActCreateBranch     Action = "createBranch"
+	ActCreateIssue      Action = "createIssue"
+	ActCreateSubtask    Action = "createSubtask"
+	ActDuplicateIssue   Action = "duplicateIssue"
+	ActShowParent       Action = "showParent"
+	ActManageTab        Action = "manageTab"
+	ActDeleteManagedTab Action = "deleteManagedTab"
+	ActReorderTabLeft   Action = "reorderTabLeft"
+	ActReorderTabRight  Action = "reorderTabRight"
 
 	ActNavDown     Action = "navDown"
 	ActNavUp       Action = "navUp"
@@ -66,39 +70,43 @@ type Keymap map[Action][]string
 // DefaultKeymap returns the default key bindings
 func DefaultKeymap() Keymap {
 	return Keymap{
-		ActQuit:           {"q", "ctrl+c"},
-		ActHelp:           {"?"},
-		ActSearch:         {"/"},
-		ActSwitchPanel:    {"tab"},
-		ActFocusRight:     {"l", "right"},
-		ActFocusLeft:      {"h", "left", "esc"},
-		ActSelect:         {" "},
-		ActOpen:           {"enter"},
-		ActPrevTab:        {"["},
-		ActNextTab:        {"]"},
-		ActFocusDetail:    {"0"},
-		ActFocusStatus:    {"1"},
-		ActFocusIssues:    {"2"},
-		ActFocusInfo:      {"3"},
-		ActFocusProj:      {"4"},
-		ActCopyURL:        {"y"},
-		ActBrowser:        {"o"},
-		ActURLPicker:      {"u"},
-		ActTransition:     {"t"},
-		ActRefresh:        {"r"},
-		ActRefreshAll:     {"R"},
-		ActInfoTab:        {"i"},
-		ActEdit:           {"e"},
-		ActComments:       {"c"},
-		ActNew:            {"n"},
-		ActPriority:       {"p"},
-		ActAssignee:       {"a"},
-		ActJQLSearch:      {"s"},
-		ActCloseJQLTab:    {"x"},
-		ActCreateBranch:   {"b"},
-		ActDuplicateIssue: {"ctrl+n"},
-		ActCreateSubtask:  {"S"},
-		ActShowParent:     {"backspace"},
+		ActQuit:             {"q", "ctrl+c"},
+		ActHelp:             {"?"},
+		ActSearch:           {"/"},
+		ActSwitchPanel:      {"tab"},
+		ActFocusRight:       {"l", "right"},
+		ActFocusLeft:        {"h", "left", "esc"},
+		ActSelect:           {" "},
+		ActOpen:             {"enter"},
+		ActPrevTab:          {"["},
+		ActNextTab:          {"]"},
+		ActFocusDetail:      {"0"},
+		ActFocusStatus:      {"1"},
+		ActFocusIssues:      {"2"},
+		ActFocusInfo:        {"3"},
+		ActFocusProj:        {"4"},
+		ActCopyURL:          {"y"},
+		ActBrowser:          {"o"},
+		ActURLPicker:        {"u"},
+		ActTransition:       {"t"},
+		ActRefresh:          {"r"},
+		ActRefreshAll:       {"R"},
+		ActInfoTab:          {"i"},
+		ActEdit:             {"e"},
+		ActComments:         {"c"},
+		ActNew:              {"n"},
+		ActPriority:         {"p"},
+		ActAssignee:         {"a"},
+		ActJQLSearch:        {"s"},
+		ActCloseJQLTab:      {"x"},
+		ActCreateBranch:     {"b"},
+		ActDuplicateIssue:   {"ctrl+n"},
+		ActCreateSubtask:    {"S"},
+		ActShowParent:       {"backspace"},
+		ActManageTab:        {"M"},
+		ActDeleteManagedTab: {"D"},
+		ActReorderTabLeft:   {"<"},
+		ActReorderTabRight:  {">"},
 
 		ActNavDown:     {"j", "down", "ctrl+j"},
 		ActNavUp:       {"k", "up", "ctrl+k"},
@@ -150,6 +158,10 @@ func KeymapFromConfig(kcfg config.KeybindingConfig) Keymap {
 	set(ActCreateBranch, kcfg.Issues.CreateBranch)
 	set(ActCreateIssue, kcfg.Issues.CreateIssue)
 	set(ActCreateSubtask, kcfg.Issues.CreateSubtask)
+	set(ActManageTab, kcfg.Issues.ManageTab)
+	set(ActDeleteManagedTab, kcfg.Issues.DeleteManagedTab)
+	set(ActReorderTabLeft, kcfg.Issues.ReorderTabLeft)
+	set(ActReorderTabRight, kcfg.Issues.ReorderTabRight)
 	// Detail
 	set(ActFocusLeft, kcfg.Detail.FocusLeft)
 	set(ActInfoTab, kcfg.Detail.InfoTab)

--- a/pkg/tui/keymap_test.go
+++ b/pkg/tui/keymap_test.go
@@ -31,6 +31,37 @@ func TestKeymapFromConfig_EmptyKeepsDefaults(t *testing.T) {
 	testkit.AssertSliceEqual(t, "quit default preserved", keymap[ActQuit], defaults[ActQuit])
 }
 
+func TestDefaultKeymap_managedTabKeys(t *testing.T) {
+	t.Parallel()
+
+	km := DefaultKeymap()
+
+	testkit.AssertEqual(t, "manageTab default", km.Match("M"), ActManageTab)
+	testkit.AssertEqual(t, "deleteManagedTab default", km.Match("D"), ActDeleteManagedTab)
+	testkit.AssertEqual(t, "reorderTabLeft default", km.Match("<"), ActReorderTabLeft)
+	testkit.AssertEqual(t, "reorderTabRight default", km.Match(">"), ActReorderTabRight)
+	// No collision with existing single-key bindings.
+	testkit.AssertEqual(t, "S stays createSubtask", km.Match("S"), ActCreateSubtask)
+	testkit.AssertEqual(t, "x stays closeJQLTab", km.Match("x"), ActCloseJQLTab)
+}
+
+func TestKeymapFromConfig_overridesManagedTabKeys(t *testing.T) {
+	t.Parallel()
+
+	var kcfg config.KeybindingConfig
+	kcfg.Issues.ManageTab = "ctrl+s"
+	kcfg.Issues.DeleteManagedTab = "ctrl+d"
+	kcfg.Issues.ReorderTabLeft = "ctrl+h"
+	kcfg.Issues.ReorderTabRight = "ctrl+l"
+
+	km := KeymapFromConfig(kcfg)
+
+	testkit.AssertSliceEqual(t, "manageTab override", km[ActManageTab], []string{"ctrl+s"})
+	testkit.AssertSliceEqual(t, "deleteManagedTab override", km[ActDeleteManagedTab], []string{"ctrl+d"})
+	testkit.AssertSliceEqual(t, "reorderTabLeft override", km[ActReorderTabLeft], []string{"ctrl+h"})
+	testkit.AssertSliceEqual(t, "reorderTabRight override", km[ActReorderTabRight], []string{"ctrl+l"})
+}
+
 func TestKeymap_MatchUnknownReturnsEmpty(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/tui/managedtabs_test.go
+++ b/pkg/tui/managedtabs_test.go
@@ -1,0 +1,123 @@
+package tui
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/textfuel/lazyjira/v2/pkg/config"
+	"github.com/textfuel/lazyjira/v2/pkg/jira"
+	"github.com/textfuel/lazyjira/v2/pkg/jira/jiratest"
+)
+
+// visibleTabNames enumerates the issue list's visible tab labels via the public
+// tab-navigation API (the underlying slice is unexported in package views).
+func visibleTabNames(app *App) []string {
+	il := app.issuesList
+	start := il.GetTabIndex()
+	var names []string
+	for {
+		names = append(names, il.ActiveTab().Name)
+		il.NextTab()
+		if il.GetTabIndex() == start {
+			break
+		}
+	}
+	return names
+}
+
+func TestProjectSwitch_refiltersManaged(t *testing.T) {
+	t.Parallel()
+	app := newAppWithFake(t, &jiratest.FakeClient{T: t})
+	app.demoMode = true
+	app.issuesList.SetTabs([]config.IssueTabConfig{{Name: "All", JQL: "x"}})
+	app.issuesList.SetSavedTabs([]config.ManagedTab{
+		{Name: "ABC-Bugs", JQL: "a", Project: testProjectABC},
+		{Name: "Global", JQL: "g", Project: ""},
+	})
+
+	app.selectProject(&jira.Project{Key: testProjectABC})
+	if got := visibleTabNames(app); !slices.Contains(got, "ABC-Bugs") || !slices.Contains(got, "Global") {
+		t.Fatalf("under ABC want ABC-Bugs and Global, got %v", got)
+	}
+
+	app.selectProject(&jira.Project{Key: "XYZ"})
+	got := visibleTabNames(app)
+	if slices.Contains(got, "ABC-Bugs") {
+		t.Errorf("after switch to XYZ, ABC-Bugs must be hidden, got %v", got)
+	}
+	if !slices.Contains(got, "Global") {
+		t.Errorf("global managed tab must survive project switch, got %v", got)
+	}
+}
+
+func TestHelpBarItems_managedTabKeysVisible(t *testing.T) {
+	t.Parallel()
+	descs := func(app *App) []string {
+		items := app.helpBarItems()
+		out := make([]string, 0, len(items))
+		for _, it := range items {
+			out = append(out, it.Description)
+		}
+		return out
+	}
+
+	// Transient JQL tab → "save tab"
+	jqlApp := appForKeybindings(t)
+	jqlApp.side, jqlApp.leftFocus = sideLeft, focusIssues
+	jqlApp.issuesList.SetTabs([]config.IssueTabConfig{{Name: "All", JQL: "x"}})
+	jqlApp.issuesList.AddJQLTab("project = X")
+	if got := descs(jqlApp); !slices.Contains(got, "save tab") {
+		t.Errorf("JQL tab help bar missing 'save tab': %v", got)
+	}
+
+	// Config tab → "promote tab"
+	cfgApp := appForKeybindings(t)
+	cfgApp.side, cfgApp.leftFocus = sideLeft, focusIssues
+	cfgApp.issuesList.SetTabs([]config.IssueTabConfig{{Name: "All", JQL: "x"}})
+	if got := descs(cfgApp); !slices.Contains(got, "promote tab") {
+		t.Errorf("config tab help bar missing 'promote tab': %v", got)
+	}
+
+	// Managed tab → "delete tab" + "move tab"
+	mApp := appForKeybindings(t)
+	mApp.side, mApp.leftFocus = sideLeft, focusIssues
+	mApp.projectKey = testProjectABC
+	mApp.issuesList.SetTabs([]config.IssueTabConfig{{Name: "All", JQL: "x"}})
+	mApp.issuesList.SetSavedTabs([]config.ManagedTab{{Name: testManagedName, JQL: "b", Project: testProjectABC}})
+	mApp.issuesList.RebuildTabs(testProjectABC)
+	mApp.issuesList.SetTabIndex(0) // managed tab
+	got := descs(mApp)
+	if !slices.Contains(got, "delete tab") || !slices.Contains(got, "move tab") {
+		t.Errorf("managed tab help bar missing delete/move: %v", got)
+	}
+	if !slices.Contains(got, "edit query") {
+		t.Errorf("managed tab help bar must show 'edit query' (discoverable s): %v", got)
+	}
+	if slices.Contains(got, "promote tab") {
+		t.Errorf("managed tab must not show 'promote tab': %v", got)
+	}
+}
+
+func TestTabFetch_staleEpoch_dropped(t *testing.T) {
+	t.Parallel()
+	app := newAppWithFake(t, &jiratest.FakeClient{T: t})
+	app.leftFocus = focusProjects // skip preview side effects in the active-tab branch
+	app.issuesList.SetTabs([]config.IssueTabConfig{{Name: "All", JQL: "x"}})
+
+	staleEpoch := app.issuesList.TabEpoch()
+	app.issuesList.RebuildTabs(testProjectABC) // a save/delete-style reassembly bumps the epoch
+	freshEpoch := app.issuesList.TabEpoch()
+	if freshEpoch == staleEpoch {
+		t.Fatal("RebuildTabs must bump the tab epoch")
+	}
+
+	app.handleIssuesLoaded(issuesLoadedMsg{tab: 0, issues: []jira.Issue{{Key: "PLAT-1"}}, epoch: staleEpoch})
+	if app.issuesList.HasCachedTab() {
+		t.Error("stale-epoch fetch result must be dropped, not stored")
+	}
+
+	app.handleIssuesLoaded(issuesLoadedMsg{tab: 0, issues: []jira.Issue{{Key: "PLAT-2"}}, epoch: freshEpoch})
+	if !app.issuesList.HasCachedTab() {
+		t.Error("current-epoch fetch result must be applied")
+	}
+}

--- a/pkg/tui/navigation.go
+++ b/pkg/tui/navigation.go
@@ -112,9 +112,9 @@ func (a *App) navigateToIssue(key string) {
 		a.showCachedIssue(key)
 		return
 	}
-	// Switch to first tab (typically "All") and try again.
-	if a.issuesList.GetTabIndex() != 0 {
-		a.issuesList.SetTabIndex(0)
+	// Switch to the home tab (typically "All") and try again.
+	if a.issuesList.GetTabIndex() != a.issuesList.HomeTabIndex() {
+		a.issuesList.SetTabIndex(a.issuesList.HomeTabIndex())
 		if a.issuesList.SelectByKey(key) {
 			a.side = sideLeft
 			a.leftFocus = focusIssues

--- a/pkg/tui/testconsts_test.go
+++ b/pkg/tui/testconsts_test.go
@@ -1,7 +1,9 @@
 package tui
 
 const (
-	testKey     = "PLAT-1"
-	testProject = "PLAT"
-	testSummary = "summary"
+	testKey         = "PLAT-1"
+	testProject     = "PLAT"
+	testSummary     = "summary"
+	testProjectABC  = "ABC"
+	testManagedName = "Bugs"
 )

--- a/pkg/tui/views/issues.go
+++ b/pkg/tui/views/issues.go
@@ -54,6 +54,11 @@ type IssuesList struct {
 	filter           string
 	tabs             []tab
 	tab              int
+	configTabs       []config.IssueTabConfig // raw config.yml tabs, before assembly
+	savedTabs        []config.ManagedTab     // raw managed store, before assembly
+	projectKey       string                  // current project, for managed-tab filtering
+	tabEpoch         int                     // bumped on every reassembly; guards stale tab fetches
+	jqlOriginTab     int                     // tab to return to when the JQL tab is closed
 	userEmail        string
 	keyColWidth      int
 	fields           []string
@@ -125,11 +130,53 @@ func (m *IssuesList) SetPriorityIcons(icons map[string]string) {
 	m.priorityIconCols = max
 }
 
+// SetTabs sets the raw config.yml tabs and reassembles the visible bar. It
+// assembles immediately (rather than deferring to the next external trigger)
+// so m.tabs is never empty between this setter and a project switch.
 func (m *IssuesList) SetTabs(tabs []config.IssueTabConfig) {
-	m.tabs = make([]tab, len(tabs))
-	for i, c := range tabs {
-		m.tabs[i] = tab{kind: tabKindConfig, cfg: c, storeIdx: -1}
+	m.configTabs = tabs
+	m.RebuildTabs(m.projectKey)
+}
+
+// SetSavedTabs sets the raw managed-tab store and reassembles the visible bar.
+func (m *IssuesList) SetSavedTabs(tabs []config.ManagedTab) {
+	m.savedTabs = tabs
+	m.RebuildTabs(m.projectKey)
+}
+
+// RebuildTabs assembles the visible tab bar for projectKey: managed tabs first
+// (filtered to project=="" or ==projectKey, in store order), then config tabs
+// whose name is not shadowed by a managed tab. Transient tabs are not
+// re-injected. Each managed tab carries its store index for later mutation.
+func (m *IssuesList) RebuildTabs(projectKey string) {
+	m.projectKey = projectKey
+	m.tabEpoch++
+
+	var assembled []tab
+	shadow := make(map[string]bool)
+	for i, mt := range m.savedTabs {
+		if mt.Project != "" && mt.Project != projectKey {
+			continue
+		}
+		assembled = append(assembled, tab{
+			kind:     tabKindManaged,
+			cfg:      config.IssueTabConfig{Name: mt.Name, JQL: mt.JQL, MaxResults: mt.MaxResults},
+			storeIdx: i,
+		})
+		shadow[mt.Name] = true
 	}
+	for _, ct := range m.configTabs {
+		if shadow[ct.Name] {
+			continue
+		}
+		assembled = append(assembled, tab{kind: tabKindConfig, cfg: ct, storeIdx: -1})
+	}
+
+	m.tabs = assembled
+	if m.tab < 0 || m.tab >= len(m.tabs) {
+		m.tab = m.HomeTabIndex()
+	}
+	m.loadFromCache()
 }
 func (m *IssuesList) SetUserEmail(email string) { m.userEmail = email }
 func (m *IssuesList) ActiveTab() config.IssueTabConfig {
@@ -139,20 +186,23 @@ func (m *IssuesList) ActiveTab() config.IssueTabConfig {
 	return config.IssueTabConfig{}
 }
 
-// AddJQLTab creates or replaces the JQL tab with the given query
+// AddJQLTab creates or replaces the JQL tab with the given query. On creation
+// it records the current tab as the origin to return to when the tab is closed.
 func (m *IssuesList) AddJQLTab(jql string) {
 	if idx, ok := m.jqlTabIndex(); ok {
 		m.jqlQuery = jql
 		m.tab = idx
 		return
 	}
+	m.jqlOriginTab = m.tab
 	m.tabs = append(m.tabs, tab{kind: tabKindJQLSearch, cfg: config.IssueTabConfig{Name: "JQL"}, storeIdx: -1})
 	m.jqlQuery = jql
 	m.tab = len(m.tabs) - 1
 	m.loadFromCache()
 }
 
-// RemoveJQLTab removes the JQL tab and switches to tab 0
+// RemoveJQLTab removes the JQL tab and returns to the origin tab it was opened
+// from, falling back to the home tab if that origin is no longer valid.
 func (m *IssuesList) RemoveJQLTab() {
 	idx, ok := m.jqlTabIndex()
 	if !ok {
@@ -160,7 +210,11 @@ func (m *IssuesList) RemoveJQLTab() {
 	}
 	m.tabs = m.tabs[:idx]
 	m.jqlQuery = ""
-	m.tab = 0
+	if m.jqlOriginTab >= 0 && m.jqlOriginTab < len(m.tabs) {
+		m.tab = m.jqlOriginTab
+	} else {
+		m.tab = m.HomeTabIndex()
+	}
 	m.loadFromCache()
 }
 
@@ -225,7 +279,7 @@ func (m *IssuesList) RemoveHierarchyTab() {
 	m.tabs = append(m.tabs[:idx], m.tabs[idx+1:]...)
 	m.hierarchyTitle = ""
 	m.hierarchyStack = nil
-	m.tab = 0
+	m.tab = m.HomeTabIndex()
 	m.loadFromCache()
 }
 
@@ -237,6 +291,38 @@ func (m *IssuesList) HasHierarchyTab() bool {
 func (m *IssuesList) IsHierarchyTab() bool {
 	idx, ok := m.hierarchyTabIndex()
 	return ok && m.tab == idx
+}
+
+// IsManagedTab reports whether the active tab originates from the managed store.
+func (m *IssuesList) IsManagedTab() bool {
+	return m.tab >= 0 && m.tab < len(m.tabs) && m.tabs[m.tab].kind == tabKindManaged
+}
+
+// IsConfigTab reports whether the active tab originates from config.yml.
+func (m *IssuesList) IsConfigTab() bool {
+	return m.tab >= 0 && m.tab < len(m.tabs) && m.tabs[m.tab].kind == tabKindConfig
+}
+
+// ActiveManagedStoreIdx returns the active tab's index in the managed store, or
+// -1 when the active tab is not managed.
+func (m *IssuesList) ActiveManagedStoreIdx() int {
+	if m.IsManagedTab() {
+		return m.tabs[m.tab].storeIdx
+	}
+	return -1
+}
+
+// VisibleManagedStoreIndices returns the store indices of the currently visible
+// managed tabs, in visible (left-to-right) order. Reorder maps a visible
+// neighbor back to its store entry through this.
+func (m *IssuesList) VisibleManagedStoreIndices() []int {
+	var idxs []int
+	for i := range m.tabs {
+		if m.tabs[i].kind == tabKindManaged {
+			idxs = append(idxs, m.tabs[i].storeIdx)
+		}
+	}
+	return idxs
 }
 
 // The current hierarchy tab title ("Children"/"Parent"/"Link").
@@ -279,6 +365,23 @@ func (m *IssuesList) loadFromCache() {
 }
 
 func (m *IssuesList) GetTabIndex() int { return m.tab }
+
+// TabEpoch returns the current reassembly generation. A tab fetch captures it
+// at issue time; a result whose epoch no longer matches targets a stale tab
+// layout and must be discarded.
+func (m *IssuesList) TabEpoch() int { return m.tabEpoch }
+
+// HomeTabIndex returns the index of the first config tab (the primary issue
+// list), or 0 if none exists. With managed tabs prepended, index 0 is no
+// longer necessarily the home list.
+func (m *IssuesList) HomeTabIndex() int {
+	for i := range m.tabs {
+		if m.tabs[i].kind == tabKindConfig {
+			return i
+		}
+	}
+	return 0
+}
 
 func (m *IssuesList) CurrentIssues() []jira.Issue { return m.allIssues }
 
@@ -370,7 +473,7 @@ func (m *IssuesList) InvalidateTabCache() {
 	m.hierarchyTitle = ""
 	m.hierarchyStack = nil
 	if m.tab >= len(m.tabs) {
-		m.tab = 0
+		m.tab = m.HomeTabIndex()
 	}
 }
 
@@ -416,19 +519,20 @@ func (m *IssuesList) FindInAnyTab(key string) (int, bool) {
 	return -1, false
 }
 
-// InjectIssue adds an issue to tab 0 cache if not already present
+// InjectIssue adds an issue to the home tab's cache if not already present
 func (m *IssuesList) InjectIssue(issue jira.Issue) {
 	if len(m.tabs) == 0 {
 		return
 	}
-	cached := m.tabs[0].issues
+	h := m.HomeTabIndex()
+	cached := m.tabs[h].issues
 	for _, iss := range cached {
 		if iss.Key == issue.Key {
 			return
 		}
 	}
-	m.tabs[0].issues = append([]jira.Issue{issue}, cached...)
-	m.tabs[0].loaded = true
+	m.tabs[h].issues = append([]jira.Issue{issue}, cached...)
+	m.tabs[h].loaded = true
 }
 
 // SelectByKey moves cursor to the issue with the given key and returns true if found

--- a/pkg/tui/views/issues.go
+++ b/pkg/tui/views/issues.go
@@ -26,14 +26,34 @@ type TabSwitchedMsg struct {
 
 const statusOpen = "○"
 
+// tabKind distinguishes the source/lifecycle of a tab in the visible bar.
+type tabKind int
+
+const (
+	tabKindConfig    tabKind = iota // from config.yml issueTabs
+	tabKindManaged                  // from saved_tabs.yml (Phase 2)
+	tabKindJQLSearch                // transient JQL search
+	tabKindHierarchy                // transient child/parent
+)
+
+// tab is one entry in the visible tab bar. It carries its kind and, for
+// managed tabs, the store identity (storeIdx) as fields rather than relying
+// on index position.
+type tab struct {
+	kind     tabKind
+	cfg      config.IssueTabConfig // Name, JQL, MaxResults
+	storeIdx int                   // index in savedTabs; -1 when not managed
+	issues   []jira.Issue          // loaded issues (was tabCache[idx])
+	loaded   bool                  // distinguishes "not loaded" from "empty"
+}
+
 type IssuesList struct {
 	components.ListBase
 	issues           []jira.Issue
 	allIssues        []jira.Issue
 	filter           string
-	tabs             []config.IssueTabConfig
+	tabs             []tab
 	tab              int
-	tabCache         map[int][]jira.Issue
 	userEmail        string
 	keyColWidth      int
 	fields           []string
@@ -45,14 +65,32 @@ type IssuesList struct {
 	priorityIcons    map[string]string
 	priorityIconCols int
 	jqlQuery         string
-	jqlTabIdx        int
-	hierarchyTabIdx  int
 	hierarchyTitle   string
 	hierarchyStack   *navstack.NavStack
 }
 
 func NewIssuesList() *IssuesList {
-	return &IssuesList{theme: theme.Default, jqlTabIdx: -1, hierarchyTabIdx: -1}
+	return &IssuesList{theme: theme.Default}
+}
+
+// jqlTabIndex returns the index of the transient JQL tab, or (-1, false).
+func (m *IssuesList) jqlTabIndex() (int, bool) {
+	for i := range m.tabs {
+		if m.tabs[i].kind == tabKindJQLSearch {
+			return i, true
+		}
+	}
+	return -1, false
+}
+
+// hierarchyTabIndex returns the index of the transient hierarchy tab, or (-1, false).
+func (m *IssuesList) hierarchyTabIndex() (int, bool) {
+	for i := range m.tabs {
+		if m.tabs[i].kind == tabKindHierarchy {
+			return i, true
+		}
+	}
+	return -1, false
 }
 
 func (m *IssuesList) SetFields(fields []string) { m.fields = fields }
@@ -86,39 +124,41 @@ func (m *IssuesList) SetPriorityIcons(icons map[string]string) {
 	}
 	m.priorityIconCols = max
 }
-func (m *IssuesList) SetTabs(tabs []config.IssueTabConfig) { m.tabs = tabs }
-func (m *IssuesList) SetUserEmail(email string)            { m.userEmail = email }
+
+func (m *IssuesList) SetTabs(tabs []config.IssueTabConfig) {
+	m.tabs = make([]tab, len(tabs))
+	for i, c := range tabs {
+		m.tabs[i] = tab{kind: tabKindConfig, cfg: c, storeIdx: -1}
+	}
+}
+func (m *IssuesList) SetUserEmail(email string) { m.userEmail = email }
 func (m *IssuesList) ActiveTab() config.IssueTabConfig {
 	if m.tab >= 0 && m.tab < len(m.tabs) {
-		return m.tabs[m.tab]
+		return m.tabs[m.tab].cfg
 	}
 	return config.IssueTabConfig{}
 }
 
 // AddJQLTab creates or replaces the JQL tab with the given query
 func (m *IssuesList) AddJQLTab(jql string) {
-	if m.jqlTabIdx >= 0 {
+	if idx, ok := m.jqlTabIndex(); ok {
 		m.jqlQuery = jql
-		m.tab = m.jqlTabIdx
+		m.tab = idx
 		return
 	}
-	m.tabs = append(m.tabs, config.IssueTabConfig{Name: "JQL", JQL: ""})
-	m.jqlTabIdx = len(m.tabs) - 1
+	m.tabs = append(m.tabs, tab{kind: tabKindJQLSearch, cfg: config.IssueTabConfig{Name: "JQL"}, storeIdx: -1})
 	m.jqlQuery = jql
-	m.tab = m.jqlTabIdx
+	m.tab = len(m.tabs) - 1
 	m.loadFromCache()
 }
 
 // RemoveJQLTab removes the JQL tab and switches to tab 0
 func (m *IssuesList) RemoveJQLTab() {
-	if m.jqlTabIdx < 0 {
+	idx, ok := m.jqlTabIndex()
+	if !ok {
 		return
 	}
-	m.tabs = m.tabs[:m.jqlTabIdx]
-	if m.tabCache != nil {
-		delete(m.tabCache, m.jqlTabIdx)
-	}
-	m.jqlTabIdx = -1
+	m.tabs = m.tabs[:idx]
 	m.jqlQuery = ""
 	m.tab = 0
 	m.loadFromCache()
@@ -126,12 +166,14 @@ func (m *IssuesList) RemoveJQLTab() {
 
 // HasJQLTab returns true if a JQL tab currently exists
 func (m *IssuesList) HasJQLTab() bool {
-	return m.jqlTabIdx >= 0
+	_, ok := m.jqlTabIndex()
+	return ok
 }
 
 // IsJQLTab returns true if the currently active tab is the JQL tab
 func (m *IssuesList) IsJQLTab() bool {
-	return m.jqlTabIdx >= 0 && m.tab == m.jqlTabIdx
+	idx, ok := m.jqlTabIndex()
+	return ok && m.tab == idx
 }
 
 // JQLQuery returns the raw JQL query for the JQL tab
@@ -142,36 +184,33 @@ func (m *IssuesList) JQLQuery() string {
 // Appends and focuses a hierarchy tab. If one already exists, behaves
 // like ReplaceHierarchyTabContent and returns the existing index.
 func (m *IssuesList) AddHierarchyTab(title string, issues []jira.Issue) int {
-	if m.hierarchyTabIdx >= 0 {
+	if idx, ok := m.hierarchyTabIndex(); ok {
 		m.ReplaceHierarchyTabContent(title, issues)
-		return m.hierarchyTabIdx
+		return idx
 	}
-	m.tabs = append(m.tabs, config.IssueTabConfig{Name: title, JQL: ""})
-	m.hierarchyTabIdx = len(m.tabs) - 1
+	m.tabs = append(m.tabs, tab{kind: tabKindHierarchy, cfg: config.IssueTabConfig{Name: title}, storeIdx: -1})
+	idx := len(m.tabs) - 1
 	m.hierarchyTitle = title
 	m.hierarchyStack = navstack.NewNavStack()
-	if m.tabCache == nil {
-		m.tabCache = make(map[int][]jira.Issue)
-	}
-	m.tabCache[m.hierarchyTabIdx] = issues
-	m.tab = m.hierarchyTabIdx
+	m.tabs[idx].issues = issues
+	m.tabs[idx].loaded = true
+	m.tab = idx
 	m.loadFromCache()
-	return m.hierarchyTabIdx
+	return idx
 }
 
 // Replaces the hierarchy tab's title and issue list while keeping the
 // tab index and stack stable. No-op if no hierarchy tab.
 func (m *IssuesList) ReplaceHierarchyTabContent(title string, issues []jira.Issue) {
-	if m.hierarchyTabIdx < 0 {
+	idx, ok := m.hierarchyTabIndex()
+	if !ok {
 		return
 	}
 	m.hierarchyTitle = title
-	m.tabs[m.hierarchyTabIdx] = config.IssueTabConfig{Name: title, JQL: ""}
-	if m.tabCache == nil {
-		m.tabCache = make(map[int][]jira.Issue)
-	}
-	m.tabCache[m.hierarchyTabIdx] = issues
-	if m.tab == m.hierarchyTabIdx {
+	m.tabs[idx].cfg = config.IssueTabConfig{Name: title}
+	m.tabs[idx].issues = issues
+	m.tabs[idx].loaded = true
+	if m.tab == idx {
 		m.loadFromCache()
 	}
 }
@@ -179,14 +218,11 @@ func (m *IssuesList) ReplaceHierarchyTabContent(title string, issues []jira.Issu
 // Removes the hierarchy tab, drops its stack, and switches to tab 0.
 // No-op if no hierarchy tab.
 func (m *IssuesList) RemoveHierarchyTab() {
-	if m.hierarchyTabIdx < 0 {
+	idx, ok := m.hierarchyTabIndex()
+	if !ok {
 		return
 	}
-	if m.tabCache != nil {
-		delete(m.tabCache, m.hierarchyTabIdx)
-	}
-	m.tabs = append(m.tabs[:m.hierarchyTabIdx], m.tabs[m.hierarchyTabIdx+1:]...)
-	m.hierarchyTabIdx = -1
+	m.tabs = append(m.tabs[:idx], m.tabs[idx+1:]...)
 	m.hierarchyTitle = ""
 	m.hierarchyStack = nil
 	m.tab = 0
@@ -194,11 +230,13 @@ func (m *IssuesList) RemoveHierarchyTab() {
 }
 
 func (m *IssuesList) HasHierarchyTab() bool {
-	return m.hierarchyTabIdx >= 0
+	_, ok := m.hierarchyTabIndex()
+	return ok
 }
 
 func (m *IssuesList) IsHierarchyTab() bool {
-	return m.hierarchyTabIdx >= 0 && m.tab == m.hierarchyTabIdx
+	idx, ok := m.hierarchyTabIndex()
+	return ok && m.tab == idx
 }
 
 // The current hierarchy tab title ("Children"/"Parent"/"Link").
@@ -229,13 +267,12 @@ func (m *IssuesList) PrevTab() {
 }
 
 func (m *IssuesList) loadFromCache() {
-	if m.tabCache != nil {
-		if cached, ok := m.tabCache[m.tab]; ok {
-			m.allIssues = cached
-			m.updateKeyColWidth(cached)
-			m.applyFilter()
-			return
-		}
+	if m.tab >= 0 && m.tab < len(m.tabs) && m.tabs[m.tab].loaded {
+		cached := m.tabs[m.tab].issues
+		m.allIssues = cached
+		m.updateKeyColWidth(cached)
+		m.applyFilter()
+		return
 	}
 	m.allIssues = nil
 	m.applyFilter()
@@ -260,10 +297,10 @@ func (m *IssuesList) SetIssues(issues []jira.Issue) {
 		selectedKey = sel.Key
 	}
 
-	if m.tabCache == nil {
-		m.tabCache = make(map[int][]jira.Issue)
+	if m.tab >= 0 && m.tab < len(m.tabs) {
+		m.tabs[m.tab].issues = issues
+		m.tabs[m.tab].loaded = true
 	}
-	m.tabCache[m.tab] = issues
 
 	m.allIssues = issues
 	m.updateKeyColWidth(issues)
@@ -285,10 +322,8 @@ func (m *IssuesList) PatchIssue(updated *jira.Issue) {
 		}
 	}
 	patch(m.allIssues)
-	if m.tabCache != nil {
-		if cached, ok := m.tabCache[m.tab]; ok {
-			patch(cached)
-		}
+	if m.tab >= 0 && m.tab < len(m.tabs) && m.tabs[m.tab].loaded {
+		patch(m.tabs[m.tab].issues)
 	}
 	m.applyFilterKeepCursor()
 }
@@ -302,39 +337,36 @@ func (m *IssuesList) updateKeyColWidth(issues []jira.Issue) {
 	}
 }
 
-// HasCachedTab returns true if the current tab has cached data
+// HasCachedTab returns true if the current tab has loaded data
 func (m *IssuesList) HasCachedTab() bool {
-	if m.tabCache == nil {
-		return false
-	}
-	_, ok := m.tabCache[m.tab]
-	return ok
+	return m.tab >= 0 && m.tab < len(m.tabs) && m.tabs[m.tab].loaded
 }
 
-// SetIssuesForTab stores issues in the cache for a specific tab without updating the display
+// SetIssuesForTab stores issues for a specific tab without updating the display.
+// Out-of-bounds indices are ignored (stale async fetch after a tab rebuild).
 func (m *IssuesList) SetIssuesForTab(tab int, issues []jira.Issue) {
-	if m.tabCache == nil {
-		m.tabCache = make(map[int][]jira.Issue)
+	if tab < 0 || tab >= len(m.tabs) {
+		return
 	}
-	m.tabCache[tab] = issues
+	m.tabs[tab].issues = issues
+	m.tabs[tab].loaded = true
 }
 
-// InvalidateTabCache clears all cached tab data and removes transient tabs (JQL and Hierarchy).
+// InvalidateTabCache drops loaded issues from persistent tabs and removes
+// transient tabs (JQL and Hierarchy). Surviving tabs reset to not-loaded so
+// the next access refetches.
 func (m *IssuesList) InvalidateTabCache() {
-	m.tabCache = nil
-	trimFrom := len(m.tabs)
-	if m.jqlTabIdx >= 0 && m.jqlTabIdx < trimFrom {
-		trimFrom = m.jqlTabIdx
+	kept := m.tabs[:0:0]
+	for _, t := range m.tabs {
+		if t.kind == tabKindJQLSearch || t.kind == tabKindHierarchy {
+			continue
+		}
+		t.issues = nil
+		t.loaded = false
+		kept = append(kept, t)
 	}
-	if m.hierarchyTabIdx >= 0 && m.hierarchyTabIdx < trimFrom {
-		trimFrom = m.hierarchyTabIdx
-	}
-	if trimFrom < len(m.tabs) {
-		m.tabs = m.tabs[:trimFrom]
-	}
-	m.jqlTabIdx = -1
+	m.tabs = kept
 	m.jqlQuery = ""
-	m.hierarchyTabIdx = -1
 	m.hierarchyTitle = ""
 	m.hierarchyStack = nil
 	if m.tab >= len(m.tabs) {
@@ -371,13 +403,13 @@ func (m *IssuesList) FindInAnyTab(key string) (int, bool) {
 			return m.tab, true
 		}
 	}
-	for tab, issues := range m.tabCache {
-		if tab == m.tab {
+	for i := range m.tabs {
+		if i == m.tab {
 			continue
 		}
-		for _, issue := range issues {
+		for _, issue := range m.tabs[i].issues {
 			if issue.Key == key {
-				return tab, true
+				return i, true
 			}
 		}
 	}
@@ -386,16 +418,17 @@ func (m *IssuesList) FindInAnyTab(key string) (int, bool) {
 
 // InjectIssue adds an issue to tab 0 cache if not already present
 func (m *IssuesList) InjectIssue(issue jira.Issue) {
-	if m.tabCache == nil {
-		m.tabCache = make(map[int][]jira.Issue)
+	if len(m.tabs) == 0 {
+		return
 	}
-	cached := m.tabCache[0]
+	cached := m.tabs[0].issues
 	for _, iss := range cached {
 		if iss.Key == issue.Key {
 			return
 		}
 	}
-	m.tabCache[0] = append([]jira.Issue{issue}, cached...)
+	m.tabs[0].issues = append([]jira.Issue{issue}, cached...)
+	m.tabs[0].loaded = true
 }
 
 // SelectByKey moves cursor to the issue with the given key and returns true if found
@@ -503,7 +536,7 @@ func (m *IssuesList) ClickTabAt(x int) bool {
 	sepW := 3
 	pos := prefix
 	for i, t := range m.tabs {
-		labelW := len(t.Name)
+		labelW := len(t.cfg.Name)
 		var zoneEnd int
 		if i < len(m.tabs)-1 {
 			zoneEnd = pos + labelW + sepW
@@ -542,9 +575,9 @@ func (m *IssuesList) buildTitle(maxTitleW int) string {
 	labelW := make([]int, len(m.tabs))
 	for i, t := range m.tabs {
 		if i == m.tab {
-			labels[i] = activeStyle.Render(t.Name)
+			labels[i] = activeStyle.Render(t.cfg.Name)
 		} else {
-			labels[i] = inactiveStyle.Render(t.Name)
+			labels[i] = inactiveStyle.Render(t.cfg.Name)
 		}
 		labelW[i] = lipgloss.Width(labels[i])
 	}
@@ -564,7 +597,7 @@ func (m *IssuesList) buildTitle(maxTitleW int) string {
 	// If the active tab label alone exceeds the budget, truncate it so the
 	// title never returns wider than maxTitleW regardless of label length.
 	if budget > 0 && labelW[m.tab] > budget {
-		truncated := components.TruncateEnd(m.tabs[m.tab].Name, budget)
+		truncated := components.TruncateEnd(m.tabs[m.tab].cfg.Name, budget)
 		labels[m.tab] = activeStyle.Render(truncated)
 		labelW[m.tab] = lipgloss.Width(labels[m.tab])
 	}

--- a/pkg/tui/views/issues_assembly_test.go
+++ b/pkg/tui/views/issues_assembly_test.go
@@ -1,0 +1,215 @@
+package views
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/textfuel/lazyjira/v2/pkg/config"
+	"github.com/textfuel/lazyjira/v2/pkg/jira"
+)
+
+func TestSetTabs_assemblesImmediately(t *testing.T) {
+	t.Parallel()
+	cfgs := []config.IssueTabConfig{
+		{Name: "All", JQL: "x"},
+		{Name: "Mine", JQL: "y"},
+	}
+	m := NewIssuesList()
+	m.SetTabs(cfgs)
+
+	if len(m.tabs) != 2 {
+		t.Fatalf("SetTabs must assemble immediately: len(tabs) = %d, want 2", len(m.tabs))
+	}
+	if got := m.ActiveTab(); got != cfgs[0] {
+		t.Errorf("ActiveTab() = %+v, want %+v", got, cfgs[0])
+	}
+}
+
+func TestRebuildTabs_managedBeforeConfig(t *testing.T) {
+	t.Parallel()
+	m := NewIssuesList()
+	m.SetTabs([]config.IssueTabConfig{{Name: "All", JQL: "x"}})
+	m.SetSavedTabs([]config.ManagedTab{{Name: "Bugs", JQL: "type=Bug", Project: "ABC"}})
+
+	m.RebuildTabs("ABC")
+
+	if len(m.tabs) != 2 {
+		t.Fatalf("len(tabs) = %d, want 2", len(m.tabs))
+	}
+	if m.tabs[0].kind != tabKindManaged || m.tabs[0].cfg.Name != "Bugs" {
+		t.Errorf("tab 0 = %+v, want managed Bugs first", m.tabs[0])
+	}
+	if m.tabs[1].kind != tabKindConfig || m.tabs[1].cfg.Name != "All" {
+		t.Errorf("tab 1 = %+v, want config All", m.tabs[1])
+	}
+}
+
+func TestRebuildTabs_filtersByProject(t *testing.T) {
+	t.Parallel()
+	m := NewIssuesList()
+	m.SetTabs(nil)
+	m.SetSavedTabs([]config.ManagedTab{
+		{Name: "ABC-Bugs", JQL: "a", Project: "ABC"},
+		{Name: "XYZ-Bugs", JQL: "b", Project: "XYZ"},
+		{Name: "Global", JQL: "c", Project: ""},
+	})
+
+	m.RebuildTabs("ABC")
+
+	names := tabNames(m)
+	if !slices.Contains(names, "ABC-Bugs") || !slices.Contains(names, "Global") {
+		t.Errorf("visible tabs = %v, want ABC-Bugs and Global", names)
+	}
+	if slices.Contains(names, "XYZ-Bugs") {
+		t.Errorf("visible tabs = %v, want XYZ-Bugs hidden under project ABC", names)
+	}
+}
+
+func TestRebuildTabs_shadowsConfigByName(t *testing.T) {
+	t.Parallel()
+	m := NewIssuesList()
+	m.SetTabs([]config.IssueTabConfig{{Name: "Bugs", JQL: "cfg"}, {Name: "All", JQL: "x"}})
+	m.SetSavedTabs([]config.ManagedTab{{Name: "Bugs", JQL: "managed", Project: "ABC"}})
+
+	m.RebuildTabs("ABC")
+
+	bugsCount := 0
+	for _, tb := range m.tabs {
+		if tb.cfg.Name == "Bugs" {
+			bugsCount++
+			if tb.kind != tabKindManaged {
+				t.Errorf("visible Bugs tab kind = %d, want managed (config shadowed)", tb.kind)
+			}
+		}
+	}
+	if bugsCount != 1 {
+		t.Errorf("Bugs tab count = %d, want 1 (config shadowed by managed)", bugsCount)
+	}
+}
+
+func TestRebuildTabs_setsStoreIdx(t *testing.T) {
+	t.Parallel()
+	m := NewIssuesList()
+	m.SetTabs(nil)
+	m.SetSavedTabs([]config.ManagedTab{
+		{Name: "XYZ-only", JQL: "a", Project: "XYZ"}, // store index 0, filtered out under ABC
+		{Name: "ABC-Bugs", JQL: "b", Project: "ABC"}, // store index 1, visible
+	})
+
+	m.RebuildTabs("ABC")
+
+	if len(m.tabs) != 1 {
+		t.Fatalf("len(tabs) = %d, want 1 visible", len(m.tabs))
+	}
+	if m.tabs[0].storeIdx != 1 {
+		t.Errorf("storeIdx = %d, want 1 (position in store, not visible slice)", m.tabs[0].storeIdx)
+	}
+}
+
+func TestVisibleManagedStoreIndices(t *testing.T) {
+	t.Parallel()
+	m := NewIssuesList()
+	m.SetTabs([]config.IssueTabConfig{{Name: "All", JQL: "x"}})
+	m.SetSavedTabs([]config.ManagedTab{
+		{Name: "XYZ-only", JQL: "a", Project: "XYZ"}, // store 0, filtered out under ABC
+		{Name: "ABC-Bugs", JQL: "b", Project: "ABC"}, // store 1, visible
+		{Name: "Global", JQL: "g", Project: ""},      // store 2, visible
+	})
+	m.RebuildTabs("ABC")
+
+	if got, want := m.VisibleManagedStoreIndices(), []int{1, 2}; !slices.Equal(got, want) {
+		t.Errorf("VisibleManagedStoreIndices() = %v, want %v", got, want)
+	}
+}
+
+func TestHomeTabIndex_skipsManaged(t *testing.T) {
+	t.Parallel()
+	m := NewIssuesList()
+	m.SetTabs([]config.IssueTabConfig{{Name: "All", JQL: "x"}})
+	m.SetSavedTabs([]config.ManagedTab{{Name: "Bugs", JQL: "b", Project: "ABC"}})
+	m.RebuildTabs("ABC")
+
+	if got := m.HomeTabIndex(); got != 1 {
+		t.Errorf("HomeTabIndex() = %d, want 1 (first config tab, managed at 0)", got)
+	}
+}
+
+func TestInjectIssue_targetsHomeNotManaged(t *testing.T) {
+	t.Parallel()
+	m := NewIssuesList()
+	m.SetTabs([]config.IssueTabConfig{{Name: "All", JQL: "x"}})
+	m.SetSavedTabs([]config.ManagedTab{{Name: "Bugs", JQL: "b", Project: "ABC"}})
+	m.RebuildTabs("ABC")
+
+	m.InjectIssue(jira.Issue{Key: "PLAT-1"})
+
+	m.SetTabIndex(m.HomeTabIndex())
+	if got := len(m.CurrentIssues()); got != 1 {
+		t.Errorf("home tab CurrentIssues = %d, want 1 (issue injected here)", got)
+	}
+	m.SetTabIndex(0) // managed tab
+	if got := len(m.CurrentIssues()); got != 0 {
+		t.Errorf("managed tab CurrentIssues = %d, want 0 (must not receive injection)", got)
+	}
+}
+
+// homeAndManaged builds a bar of one managed tab (index 0) and one config tab
+// (index 1), so "go home" and "go to index 0" are distinguishable.
+func homeAndManaged(t *testing.T) *IssuesList {
+	t.Helper()
+	m := NewIssuesList()
+	m.SetTabs([]config.IssueTabConfig{{Name: "All", JQL: "x"}})
+	m.SetSavedTabs([]config.ManagedTab{{Name: "Bugs", JQL: "b", Project: "ABC"}})
+	m.RebuildTabs("ABC")
+	return m
+}
+
+func TestRemoveHierarchyTab_returnsToHomeNotManaged(t *testing.T) {
+	t.Parallel()
+	m := homeAndManaged(t)
+	m.AddHierarchyTab("Children", []jira.Issue{{Key: "CHILD-1"}})
+
+	m.RemoveHierarchyTab()
+
+	if got := m.GetTabIndex(); got != m.HomeTabIndex() {
+		t.Errorf("tab after close = %d, want %d (home, not the managed tab at 0)", got, m.HomeTabIndex())
+	}
+}
+
+func TestInvalidateTabCache_clampsToHomeNotManaged(t *testing.T) {
+	t.Parallel()
+	m := homeAndManaged(t)
+	m.AddJQLTab("project = ABC") // transient tab, becomes active
+
+	m.InvalidateTabCache() // drops it, leaving m.tab out of range
+
+	if got := m.GetTabIndex(); got != m.HomeTabIndex() {
+		t.Errorf("tab after invalidate = %d, want %d (home, not the managed tab at 0)", got, m.HomeTabIndex())
+	}
+}
+
+func TestRebuildTabs_clampsToHomeNotManaged(t *testing.T) {
+	t.Parallel()
+	m := NewIssuesList()
+	m.SetTabs([]config.IssueTabConfig{{Name: "All", JQL: "x"}})
+	m.SetSavedTabs([]config.ManagedTab{
+		{Name: "ABC-Bugs", JQL: "b", Project: "ABC"}, // visible under ABC only
+		{Name: "Global", JQL: "g", Project: ""},      // visible everywhere
+	})
+	m.RebuildTabs("ABC")
+	m.SetTabIndex(2) // the config tab, last under ABC
+
+	m.RebuildTabs("XYZ") // one managed tab fewer, so index 2 no longer exists
+
+	if got := m.GetTabIndex(); got != m.HomeTabIndex() {
+		t.Errorf("tab after project switch = %d, want %d (home, not the managed tab at 0)", got, m.HomeTabIndex())
+	}
+}
+
+func tabNames(m *IssuesList) []string {
+	names := make([]string, len(m.tabs))
+	for i, tb := range m.tabs {
+		names[i] = tb.cfg.Name
+	}
+	return names
+}

--- a/pkg/tui/views/issues_managed_query_test.go
+++ b/pkg/tui/views/issues_managed_query_test.go
@@ -1,0 +1,52 @@
+package views
+
+import (
+	"testing"
+
+	"github.com/textfuel/lazyjira/v2/pkg/config"
+)
+
+func TestIsManagedTab(t *testing.T) {
+	t.Parallel()
+	m := NewIssuesList()
+	m.SetTabs([]config.IssueTabConfig{{Name: "All", JQL: "x"}})
+	m.SetSavedTabs([]config.ManagedTab{{Name: "Bugs", JQL: "b", Project: "ABC"}})
+	m.RebuildTabs("ABC")
+
+	m.SetTabIndex(0) // managed
+	if !m.IsManagedTab() {
+		t.Error("tab 0 is managed, IsManagedTab() = false")
+	}
+	if m.IsConfigTab() {
+		t.Error("tab 0 is managed, IsConfigTab() = true")
+	}
+
+	m.SetTabIndex(1) // config
+	if !m.IsConfigTab() {
+		t.Error("tab 1 is config, IsConfigTab() = false")
+	}
+	if m.IsManagedTab() {
+		t.Error("tab 1 is config, IsManagedTab() = true")
+	}
+}
+
+func TestActiveManagedStoreIdx(t *testing.T) {
+	t.Parallel()
+	m := NewIssuesList()
+	m.SetTabs([]config.IssueTabConfig{{Name: "All", JQL: "x"}})
+	m.SetSavedTabs([]config.ManagedTab{
+		{Name: "XYZ-only", JQL: "a", Project: "XYZ"}, // store index 0, hidden under ABC
+		{Name: "ABC-Bugs", JQL: "b", Project: "ABC"}, // store index 1, visible
+	})
+	m.RebuildTabs("ABC")
+
+	m.SetTabIndex(0) // managed ABC-Bugs
+	if got := m.ActiveManagedStoreIdx(); got != 1 {
+		t.Errorf("ActiveManagedStoreIdx() = %d, want 1 (store position, not visible)", got)
+	}
+
+	m.SetTabIndex(1) // config All
+	if got := m.ActiveManagedStoreIdx(); got != -1 {
+		t.Errorf("ActiveManagedStoreIdx() on config tab = %d, want -1", got)
+	}
+}

--- a/pkg/tui/views/issues_test.go
+++ b/pkg/tui/views/issues_test.go
@@ -1,0 +1,94 @@
+package views
+
+import (
+	"testing"
+
+	"github.com/textfuel/lazyjira/v2/pkg/config"
+	"github.com/textfuel/lazyjira/v2/pkg/jira"
+)
+
+func TestSetTabs_wrapsConfigAsKindConfig(t *testing.T) {
+	t.Parallel()
+	cfgs := []config.IssueTabConfig{
+		{Name: "All", JQL: "x"},
+		{Name: "Mine", JQL: "y"},
+	}
+	m := NewIssuesList()
+	m.SetTabs(cfgs)
+
+	if len(m.tabs) != len(cfgs) {
+		t.Fatalf("len(tabs) = %d, want %d", len(m.tabs), len(cfgs))
+	}
+	for i, tb := range m.tabs {
+		if tb.kind != tabKindConfig {
+			t.Errorf("tab %d kind = %d, want tabKindConfig", i, tb.kind)
+		}
+		if tb.storeIdx != -1 {
+			t.Errorf("tab %d storeIdx = %d, want -1 (not managed)", i, tb.storeIdx)
+		}
+	}
+	if got := m.ActiveTab(); got != cfgs[0] {
+		t.Errorf("ActiveTab() = %+v, want %+v", got, cfgs[0])
+	}
+}
+
+func TestTransientTabs_addRemoveByKind(t *testing.T) {
+	t.Parallel()
+	m := listWithTabs(config.IssueTabConfig{Name: "All", JQL: "x"})
+
+	m.AddJQLTab("project = FOO")
+	if !m.IsJQLTab() {
+		t.Fatal("active tab should be the JQL tab after AddJQLTab")
+	}
+	m.AddHierarchyTab("Child", []jira.Issue{{Key: "C-1"}})
+	if !m.IsHierarchyTab() {
+		t.Fatal("active tab should be the hierarchy tab after AddHierarchyTab")
+	}
+	if !m.HasJQLTab() {
+		t.Fatal("JQL tab should coexist with hierarchy tab")
+	}
+	if len(m.tabs) != 3 {
+		t.Fatalf("len(tabs) = %d, want 3 (config + JQL + hierarchy)", len(m.tabs))
+	}
+
+	m.InvalidateTabCache()
+
+	if m.HasJQLTab() || m.HasHierarchyTab() {
+		t.Error("InvalidateTabCache should drop transient tabs")
+	}
+	if len(m.tabs) != 1 || m.tabs[0].kind != tabKindConfig {
+		t.Errorf("config tab should survive: tabs=%d", len(m.tabs))
+	}
+}
+
+func TestTabCache_loadedDistinctFromEmpty(t *testing.T) {
+	t.Parallel()
+	m := listWithTabs(config.IssueTabConfig{Name: "All", JQL: "x"})
+
+	if m.HasCachedTab() {
+		t.Error("HasCachedTab() = true before any load, want false")
+	}
+
+	m.SetIssues([]jira.Issue{}) // loaded, but zero hits
+	if !m.HasCachedTab() {
+		t.Error("HasCachedTab() = false after SetIssues with empty slice, want true (loaded != empty)")
+	}
+
+	m.SetIssues([]jira.Issue{{Key: "PLAT-1", Summary: "old"}})
+	m.PatchIssue(&jira.Issue{Key: "PLAT-1", Summary: "new"})
+	if got := m.CurrentIssues()[0].Summary; got != "new" {
+		t.Errorf("PatchIssue summary = %q, want new", got)
+	}
+}
+
+func TestSetIssuesForTab_staleIndex_noop(t *testing.T) {
+	t.Parallel()
+	m := listWithTabs(config.IssueTabConfig{Name: "All", JQL: "x"})
+
+	// Index beyond len(tabs) must not panic (stale async fetch after rebuild).
+	m.SetIssuesForTab(99, []jira.Issue{{Key: "PLAT-9"}})
+
+	if _, ok := m.FindInAnyTab("PLAT-9"); ok {
+		t.Error("issues from an out-of-bounds tab index must not be stored")
+	}
+}

--- a/pkg/tui/views/issues_test.go
+++ b/pkg/tui/views/issues_test.go
@@ -61,6 +61,25 @@ func TestTransientTabs_addRemoveByKind(t *testing.T) {
 	}
 }
 
+func TestRemoveJQLTab_returnsToOrigin(t *testing.T) {
+	t.Parallel()
+	m := listWithTabs(
+		config.IssueTabConfig{Name: "All", JQL: "x"},
+		config.IssueTabConfig{Name: "Mine", JQL: "y"},
+	)
+	m.SetTabIndex(1) // user is on "Mine" when opening JQL search
+
+	m.AddJQLTab("project = FOO")
+	if !m.IsJQLTab() {
+		t.Fatal("expected JQL tab active after AddJQLTab")
+	}
+
+	m.RemoveJQLTab()
+	if got := m.GetTabIndex(); got != 1 {
+		t.Errorf("after closing JQL tab, GetTabIndex() = %d, want 1 (origin tab)", got)
+	}
+}
+
 func TestTabCache_loadedDistinctFromEmpty(t *testing.T) {
 	t.Parallel()
 	m := listWithTabs(config.IssueTabConfig{Name: "All", JQL: "x"})


### PR DESCRIPTION
Closes #114

Implements the proposal from the issue: save a JQL search as a named
tab, promote a config tab into the store, delete and reorder from the
tab bar. Store format and keys are documented in `Config.md` and
`Keybindings.md`.

Commit 1 is a behavior-preserving refactor, split out so it can be
reviewed on its own: the index-positional tab model becomes a tab
struct that carries its own issues, so the cache can no longer drift
from the tab it belongs to. Public API unchanged, existing tab tests
pass unmodified.
