### PR TITLE
Link and unlink issues, delete subtasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ make build-demo
 - **JQL search** with autocomplete, syntax highlighting, and persistent history
 - **4-panel layout** - issues, projects, detail, status - with vim-style navigation
 - **Inline editing** - transitions, priority, assignee, labels, comments, description (`$EDITOR`)
+- **Relations** - view, create and remove issue links; create and delete subtasks
 - **Configurable** - custom keybindings (including navigation keys), JQL tabs, issue columns, custom fields
 - **Themes** - default ANSI palette plus all four Catppuccin flavors (Latte, Frappé, Macchiato, Mocha)
 - **Adaptive** - side-by-side or stacked layout, mouse support
@@ -200,7 +201,7 @@ Press `?` inside the app for all keybindings.
 - [x] Searchable keybindings help popup
 - [x] Scroll detail panel without switching focus
 - [x] Create subtasks from TUI
-- [ ] Link issues (add/remove issue links)
+- [x] Link issues (add/remove issue links)
 - [ ] CLI mode (non-interactive commands for scripting and automation)
 - [ ] Robust issue type changer (handle subtask/parent unlinking, field validation)
 - [ ] Clickable hyperlinks in terminal (OSC 8) for URLs in descriptions and comments

--- a/docs/Config.md
+++ b/docs/Config.md
@@ -393,6 +393,8 @@ keybinding:
     transition: "t"
     browser: "o"
     createBranch: "b"
+    linkIssue: "L"
+    deleteSelection: "D"
 ```
 
 Only include keys you want to change. Missing keys keep their defaults.

--- a/docs/Keybindings.md
+++ b/docs/Keybindings.md
@@ -41,6 +41,15 @@ Detail scroll keys (`J`/`K`/`ctrl+f`/`ctrl+b`) can be remapped via `keybinding.d
 | `b` | Create branch from issue |
 | `s` | JQL search |
 | `x` | Close JQL tab |
+| `L` | Link the issue to another one: pick a relation, then the target key |
+
+## Info panel
+
+| Key | Action |
+| --- | --- |
+| `[` / `]` | Switch tab (Info / Lnk / Sub) |
+| `L` | Link the issue to another one |
+| `D` | Delete the link or subtask under the cursor, after confirming |
 
 ## Help popup
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -166,6 +166,9 @@ type IssueKeys struct {
 	CreateBranch  string `yaml:"createBranch"`
 	CreateIssue   string `yaml:"createIssue"`
 	CreateSubtask string `yaml:"createSubtask"`
+	LinkIssue     string `yaml:"linkIssue"`
+	// DeleteSelection removes the link or subtask under the Info cursor.
+	DeleteSelection string `yaml:"deleteSelection"`
 }
 
 type ProjectKeys struct {

--- a/pkg/jira/client.go
+++ b/pkg/jira/client.go
@@ -29,6 +29,10 @@ type ClientInterface interface {
 	UpdateIssue(ctx context.Context, issueKey string, fields map[string]any) error
 	RemoveIssueParent(ctx context.Context, issueKey string) error
 	GetPriorities(ctx context.Context) ([]Priority, error)
+	GetIssueLinkTypes(ctx context.Context) ([]IssueLinkType, error)
+	CreateIssueLink(ctx context.Context, typeName, inwardKey, outwardKey string) error
+	DeleteIssueLink(ctx context.Context, linkID string) error
+	DeleteIssue(ctx context.Context, issueKey string, deleteSubtasks bool) error
 	CreateIssue(ctx context.Context, fields map[string]any) (*Issue, error)
 	GetCreateMeta(ctx context.Context, projectKey, issueTypeID string) ([]CreateMetaField, error)
 	GetComments(ctx context.Context, issueKey string) ([]Comment, error)
@@ -542,6 +546,48 @@ func (c *Client) GetPriorities(ctx context.Context) ([]Priority, error) {
 		return nil, fmt.Errorf("get priorities: %w", err)
 	}
 	return raw, nil
+}
+
+func (c *Client) GetIssueLinkTypes(ctx context.Context) ([]IssueLinkType, error) {
+	var raw struct {
+		IssueLinkTypes []IssueLinkType `json:"issueLinkTypes"`
+	}
+	if err := c.do(ctx, http.MethodGet, "/issueLinkType", nil, &raw); err != nil {
+		return nil, fmt.Errorf("get issue link types: %w", err)
+	}
+	return raw.IssueLinkTypes, nil
+}
+
+// CreateIssueLink links two issues. The direction is carried by the argument
+// order: inwardKey is the issue the link points at ("is blocked by" side),
+// outwardKey the one it points from ("blocks" side).
+func (c *Client) CreateIssueLink(ctx context.Context, typeName, inwardKey, outwardKey string) error {
+	body := map[string]any{
+		"type":         map[string]string{"name": typeName},
+		"inwardIssue":  map[string]string{"key": inwardKey},
+		"outwardIssue": map[string]string{"key": outwardKey},
+	}
+	if err := c.do(ctx, http.MethodPost, "/issueLink", body, nil); err != nil {
+		return fmt.Errorf("create %s link %s -> %s: %w", typeName, outwardKey, inwardKey, err)
+	}
+	return nil
+}
+
+func (c *Client) DeleteIssueLink(ctx context.Context, linkID string) error {
+	if err := c.do(ctx, http.MethodDelete, "/issueLink/"+linkID, nil, nil); err != nil {
+		return fmt.Errorf("delete issue link %s: %w", linkID, err)
+	}
+	return nil
+}
+
+// DeleteIssue removes an issue. Jira rejects the call with 400 when the issue
+// has subtasks and deleteSubtasks is false, so callers can retry after asking.
+func (c *Client) DeleteIssue(ctx context.Context, issueKey string, deleteSubtasks bool) error {
+	path := fmt.Sprintf("/issue/%s?deleteSubtasks=%t", issueKey, deleteSubtasks)
+	if err := c.do(ctx, http.MethodDelete, path, nil, nil); err != nil {
+		return fmt.Errorf("delete issue %s: %w", issueKey, err)
+	}
+	return nil
 }
 
 func (c *Client) CreateIssue(ctx context.Context, fields map[string]any) (*Issue, error) {

--- a/pkg/jira/client_links_test.go
+++ b/pkg/jira/client_links_test.go
@@ -1,0 +1,99 @@
+package jira
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/textfuel/lazyjira/v2/pkg/internal/testkit"
+)
+
+func TestGetIssueLinkTypes(t *testing.T) {
+	t.Parallel()
+	client, recorded := newRecordingClient(t, cloudOpts(), testkit.StubResponse{
+		Status: http.StatusOK,
+		Body:   `{"issueLinkTypes":[{"id":"10000","name":"Blocks","inward":"is blocked by","outward":"blocks"}]}`,
+	})
+
+	types, err := client.GetIssueLinkTypes(context.Background())
+	if err != nil {
+		t.Fatalf("GetIssueLinkTypes: %v", err)
+	}
+	if recorded.Path != "/rest/api/3/issueLinkType" {
+		t.Errorf("path = %q", recorded.Path)
+	}
+	if len(types) != 1 || types[0].Name != "Blocks" || types[0].Outward != "blocks" {
+		t.Errorf("types = %+v", types)
+	}
+}
+
+func TestCreateIssueLinkSendsDirectionalPayload(t *testing.T) {
+	t.Parallel()
+	client, recorded := newRecordingClient(t, cloudOpts(), testkit.StubResponse{Status: http.StatusCreated})
+
+	if err := client.CreateIssueLink(context.Background(), "Blocks", "PLAT-2", "PLAT-1"); err != nil {
+		t.Fatalf("CreateIssueLink: %v", err)
+	}
+
+	if recorded.Method != http.MethodPost || recorded.Path != "/rest/api/3/issueLink" {
+		t.Errorf("%s %s", recorded.Method, recorded.Path)
+	}
+
+	var body struct {
+		Type         struct{ Name string } `json:"type"`
+		InwardIssue  struct{ Key string }  `json:"inwardIssue"`
+		OutwardIssue struct{ Key string }  `json:"outwardIssue"`
+	}
+	if err := json.Unmarshal(recorded.Body, &body); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if body.Type.Name != "Blocks" {
+		t.Errorf("type = %q", body.Type.Name)
+	}
+	if body.InwardIssue.Key != "PLAT-2" || body.OutwardIssue.Key != "PLAT-1" {
+		t.Errorf("inward = %q, outward = %q", body.InwardIssue.Key, body.OutwardIssue.Key)
+	}
+}
+
+func TestDeleteIssueLink(t *testing.T) {
+	t.Parallel()
+	client, recorded := newRecordingClient(t, cloudOpts(), testkit.StubResponse{Status: http.StatusNoContent})
+
+	if err := client.DeleteIssueLink(context.Background(), "10042"); err != nil {
+		t.Fatalf("DeleteIssueLink: %v", err)
+	}
+	if recorded.Method != http.MethodDelete || recorded.Path != "/rest/api/3/issueLink/10042" {
+		t.Errorf("%s %s", recorded.Method, recorded.Path)
+	}
+}
+
+func TestDeleteIssuePassesDeleteSubtasks(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name     string
+		subtasks bool
+		want     string
+	}{
+		{"without subtasks", false, "false"},
+		{"with subtasks", true, "true"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			client, recorded := newRecordingClient(t, cloudOpts(), testkit.StubResponse{Status: http.StatusNoContent})
+
+			if err := client.DeleteIssue(context.Background(), errorTestIssueKey, tc.subtasks); err != nil {
+				t.Fatalf("DeleteIssue: %v", err)
+			}
+			if recorded.Method != http.MethodDelete {
+				t.Errorf("method = %s", recorded.Method)
+			}
+			if recorded.Path != "/rest/api/3/issue/"+errorTestIssueKey {
+				t.Errorf("path = %q", recorded.Path)
+			}
+			if got := recorded.Query.Get("deleteSubtasks"); got != tc.want {
+				t.Errorf("deleteSubtasks = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/jira/demo.go
+++ b/pkg/jira/demo.go
@@ -575,6 +575,116 @@ func (d *DemoClient) GetPriorities(_ context.Context) ([]Priority, error) {
 		{ID: "4", Name: "Low"},
 	}, nil
 }
+func (d *DemoClient) GetIssueLinkTypes(_ context.Context) ([]IssueLinkType, error) {
+	d.logRequest("GET", "/issueLinkType")
+	return []IssueLinkType{
+		{ID: "10000", Name: "Blocks", Inward: "is blocked by", Outward: "blocks"},
+		{ID: "10001", Name: "Relates", Inward: "relates to", Outward: "relates to"},
+		{ID: "10002", Name: "Duplicate", Inward: "is duplicated by", Outward: "duplicates"},
+	}, nil
+}
+
+func (d *DemoClient) CreateIssueLink(ctx context.Context, typeName, inwardKey, outwardKey string) error {
+	d.logRequest("POST", "/issueLink")
+	inward, ok := d.issueIndex[inwardKey]
+	if !ok {
+		return fmt.Errorf("issue %s not found", inwardKey)
+	}
+	outward, ok := d.issueIndex[outwardKey]
+	if !ok {
+		return fmt.Errorf("issue %s not found", outwardKey)
+	}
+	types, _ := d.GetIssueLinkTypes(ctx)
+	var linkType *IssueLinkType
+	for i := range types {
+		if strings.EqualFold(types[i].Name, typeName) {
+			linkType = &types[i]
+			break
+		}
+	}
+	if linkType == nil {
+		return fmt.Errorf("unknown link type %q", typeName)
+	}
+
+	id := strconv.Itoa(d.nextLinkID())
+	// Both endpoints carry the same link, each pointing at the other. The side
+	// an issue stores decides how it is phrased: the outward end reads
+	// "blocks X", the inward end "is blocked by Y".
+	outward.IssueLinks = append(outward.IssueLinks, IssueLink{
+		ID: id, Type: linkType, OutwardIssue: &Issue{Key: inward.Key, Summary: inward.Summary, Status: inward.Status},
+	})
+	inward.IssueLinks = append(inward.IssueLinks, IssueLink{
+		ID: id, Type: linkType, InwardIssue: &Issue{Key: outward.Key, Summary: outward.Summary, Status: outward.Status},
+	})
+	return nil
+}
+
+func (d *DemoClient) nextLinkID() int {
+	maxID := 20000
+	for _, iss := range d.issueIndex {
+		for _, l := range iss.IssueLinks {
+			if n, err := strconv.Atoi(l.ID); err == nil && n >= maxID {
+				maxID = n + 1
+			}
+		}
+	}
+	return maxID
+}
+
+func (d *DemoClient) DeleteIssueLink(_ context.Context, linkID string) error {
+	d.logRequest("DELETE", "/issueLink/"+linkID)
+	found := false
+	for _, iss := range d.issueIndex {
+		kept := iss.IssueLinks[:0]
+		for _, l := range iss.IssueLinks {
+			if l.ID == linkID {
+				found = true
+				continue
+			}
+			kept = append(kept, l)
+		}
+		iss.IssueLinks = kept
+	}
+	if !found {
+		return fmt.Errorf("issue link %s not found", linkID)
+	}
+	return nil
+}
+
+func (d *DemoClient) DeleteIssue(_ context.Context, issueKey string, deleteSubtasks bool) error {
+	d.logRequest("DELETE", "/issue/"+issueKey)
+	iss, ok := d.issueIndex[issueKey]
+	if !ok {
+		return fmt.Errorf("issue %s not found", issueKey)
+	}
+	if len(iss.Subtasks) > 0 && !deleteSubtasks {
+		return fmt.Errorf("issue %s has subtasks: pass deleteSubtasks to remove them too", issueKey)
+	}
+
+	remove := []string{issueKey}
+	if deleteSubtasks {
+		for _, sub := range iss.Subtasks {
+			remove = append(remove, sub.Key)
+		}
+	}
+	for _, key := range remove {
+		delete(d.issueIndex, key)
+		delete(d.comments, key)
+		delete(d.changelog, key)
+		for projectKey, list := range d.issues {
+			kept := list[:0]
+			for _, candidate := range list {
+				if candidate.Key == key {
+					continue
+				}
+				kept = append(kept, candidate)
+			}
+			d.issues[projectKey] = kept
+		}
+	}
+	return nil
+}
+
 func (d *DemoClient) GetSprints(_ context.Context, _ int) ([]Sprint, error) {
 	d.logRequest("GET", "/board/1/sprint")
 	return []Sprint{
@@ -952,6 +1062,12 @@ func (d *DemoClient) initDemoData() {
 	for _, iss := range mobiIssues {
 		d.addIssue("MOBI", iss)
 	}
+
+	// Issue links, so the Lnk tab has something to show.
+	ctx := context.Background()
+	_ = d.CreateIssueLink(ctx, "Blocks", "SHOP-2", "SHOP-1")
+	_ = d.CreateIssueLink(ctx, "Relates", "SHOP-3", "SHOP-1")
+	_ = d.CreateIssueLink(ctx, "Blocks", "SHOP-9", "SHOP-2")
 
 	// Comments
 	d.comments["SHOP-1"] = []Comment{

--- a/pkg/jira/demoserver.go
+++ b/pkg/jira/demoserver.go
@@ -87,11 +87,28 @@ func (s *DemoServer) handle(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodPost {
 			s.handleCreateIssue(w, r)
 		}
-	case strings.HasPrefix(path, "/issue/"):
-		key := strings.TrimPrefix(path, "/issue/")
-		if r.Method == http.MethodPut {
-			s.handleUpdateIssue(w, r, key)
+	case path == "/issueLink":
+		if r.Method == http.MethodPost {
+			s.handleCreateIssueLink(w, r)
 		} else {
+			http.NotFound(w, r)
+		}
+	case strings.HasPrefix(path, "/issueLink/"):
+		if r.Method == http.MethodDelete {
+			s.handleDeleteIssueLink(w, strings.TrimPrefix(path, "/issueLink/"))
+		} else {
+			http.NotFound(w, r)
+		}
+	case path == "/issueLinkType":
+		s.handleIssueLinkTypes(w)
+	case strings.HasPrefix(path, "/issue/"):
+		key, _, _ := strings.Cut(strings.TrimPrefix(path, "/issue/"), "?")
+		switch r.Method {
+		case http.MethodPut:
+			s.handleUpdateIssue(w, r, key)
+		case http.MethodDelete:
+			s.handleDeleteIssue(w, r, key)
+		default:
 			s.handleIssue(w, key)
 		}
 	case path == "/priority":
@@ -352,6 +369,46 @@ func (s *DemoServer) handleAddComment(w http.ResponseWriter, r *http.Request, ke
 		return
 	}
 	writeJSON(w, commentToJSON(comment))
+}
+
+func (s *DemoServer) handleIssueLinkTypes(w http.ResponseWriter) {
+	types, _ := s.data.GetIssueLinkTypes(context.Background())
+	writeJSON(w, map[string]any{"issueLinkTypes": types})
+}
+
+func (s *DemoServer) handleCreateIssueLink(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		Type         struct{ Name string } `json:"type"`
+		InwardIssue  struct{ Key string }  `json:"inwardIssue"`
+		OutwardIssue struct{ Key string }  `json:"outwardIssue"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(w, "bad request", http.StatusBadRequest)
+		return
+	}
+	err := s.data.CreateIssueLink(context.Background(), body.Type.Name, body.InwardIssue.Key, body.OutwardIssue.Key)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	w.WriteHeader(http.StatusCreated)
+}
+
+func (s *DemoServer) handleDeleteIssueLink(w http.ResponseWriter, linkID string) {
+	if err := s.data.DeleteIssueLink(context.Background(), linkID); err != nil {
+		http.Error(w, err.Error(), http.StatusNotFound)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (s *DemoServer) handleDeleteIssue(w http.ResponseWriter, r *http.Request, key string) {
+	deleteSubtasks := r.URL.Query().Get("deleteSubtasks") == "true"
+	if err := s.data.DeleteIssue(context.Background(), key, deleteSubtasks); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
 }
 
 func (s *DemoServer) handlePriorities(w http.ResponseWriter) {

--- a/pkg/jira/jiratest/fake.go
+++ b/pkg/jira/jiratest/fake.go
@@ -30,6 +30,24 @@ type GetTransitionsCall struct {
 	Key string
 }
 
+type CreateIssueLinkCall struct {
+	Ctx        context.Context
+	TypeName   string
+	InwardKey  string
+	OutwardKey string
+}
+
+type DeleteIssueLinkCall struct {
+	Ctx    context.Context
+	LinkID string
+}
+
+type DeleteIssueCall struct {
+	Ctx            context.Context
+	Key            string
+	DeleteSubtasks bool
+}
+
 type DoTransitionCall struct {
 	Ctx          context.Context
 	Key          string
@@ -161,6 +179,10 @@ type FakeClient struct {
 	UpdateIssueFunc                   func(ctx context.Context, key string, fields map[string]any) error
 	RemoveIssueParentFunc             func(ctx context.Context, key string) error
 	GetPrioritiesFunc                 func(ctx context.Context) ([]jira.Priority, error)
+	GetIssueLinkTypesFunc             func(ctx context.Context) ([]jira.IssueLinkType, error)
+	CreateIssueLinkFunc               func(ctx context.Context, typeName, inwardKey, outwardKey string) error
+	DeleteIssueLinkFunc               func(ctx context.Context, linkID string) error
+	DeleteIssueFunc                   func(ctx context.Context, key string, deleteSubtasks bool) error
 	CreateIssueFunc                   func(ctx context.Context, fields map[string]any) (*jira.Issue, error)
 	GetCreateMetaFunc                 func(ctx context.Context, projectKey, issueTypeID string) ([]jira.CreateMetaField, error)
 	GetCommentsFunc                   func(ctx context.Context, key string) ([]jira.Comment, error)
@@ -195,6 +217,10 @@ type FakeClient struct {
 	UpdateIssueCalls                   []UpdateIssueCall
 	RemoveIssueParentCalls             []RemoveIssueParentCall
 	GetPrioritiesCalls                 []context.Context
+	GetIssueLinkTypesCalls             []context.Context
+	CreateIssueLinkCalls               []CreateIssueLinkCall
+	DeleteIssueLinkCalls               []DeleteIssueLinkCall
+	DeleteIssueCalls                   []DeleteIssueCall
 	CreateIssueCalls                   []CreateIssueCall
 	GetCreateMetaCalls                 []GetCreateMetaCall
 	GetCommentsCalls                   []GetCommentsCall
@@ -354,6 +380,44 @@ func (f *FakeClient) GetPriorities(ctx context.Context) ([]jira.Priority, error)
 		return nil, nil
 	}
 	return f.GetPrioritiesFunc(ctx)
+}
+
+func (f *FakeClient) GetIssueLinkTypes(ctx context.Context) ([]jira.IssueLinkType, error) {
+	f.GetIssueLinkTypesCalls = append(f.GetIssueLinkTypesCalls, ctx)
+	if f.GetIssueLinkTypesFunc == nil {
+		f.fatal("GetIssueLinkTypes")
+		return nil, nil
+	}
+	return f.GetIssueLinkTypesFunc(ctx)
+}
+
+func (f *FakeClient) CreateIssueLink(ctx context.Context, typeName, inwardKey, outwardKey string) error {
+	f.CreateIssueLinkCalls = append(f.CreateIssueLinkCalls, CreateIssueLinkCall{
+		Ctx: ctx, TypeName: typeName, InwardKey: inwardKey, OutwardKey: outwardKey,
+	})
+	if f.CreateIssueLinkFunc == nil {
+		f.fatal("CreateIssueLink")
+		return nil
+	}
+	return f.CreateIssueLinkFunc(ctx, typeName, inwardKey, outwardKey)
+}
+
+func (f *FakeClient) DeleteIssueLink(ctx context.Context, linkID string) error {
+	f.DeleteIssueLinkCalls = append(f.DeleteIssueLinkCalls, DeleteIssueLinkCall{Ctx: ctx, LinkID: linkID})
+	if f.DeleteIssueLinkFunc == nil {
+		f.fatal("DeleteIssueLink")
+		return nil
+	}
+	return f.DeleteIssueLinkFunc(ctx, linkID)
+}
+
+func (f *FakeClient) DeleteIssue(ctx context.Context, key string, deleteSubtasks bool) error {
+	f.DeleteIssueCalls = append(f.DeleteIssueCalls, DeleteIssueCall{Ctx: ctx, Key: key, DeleteSubtasks: deleteSubtasks})
+	if f.DeleteIssueFunc == nil {
+		f.fatal("DeleteIssue")
+		return nil
+	}
+	return f.DeleteIssueFunc(ctx, key, deleteSubtasks)
 }
 
 func (f *FakeClient) CreateIssue(ctx context.Context, fields map[string]any) (*jira.Issue, error) {

--- a/pkg/jira/models.go
+++ b/pkg/jira/models.go
@@ -148,6 +148,7 @@ type IssueLink struct {
 }
 
 type IssueLinkType struct {
+	ID      string `json:"id"`
 	Name    string `json:"name"`
 	Inward  string `json:"inward"`
 	Outward string `json:"outward"`

--- a/pkg/tui/app.go
+++ b/pkg/tui/app.go
@@ -62,6 +62,7 @@ const (
 	editBranch
 	editCreateField
 	editCreateDesc
+	editLinkTarget
 )
 
 type editCtx struct {
@@ -696,6 +697,13 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		a.detailView.UpdateIssueData(msg.issue)
 		a.issuesList.PatchIssue(msg.issue)
 		return a, nil
+	case issueLinkTypesLoadedMsg:
+		return a.handleIssueLinkTypesLoaded(msg)
+	case issueLinkChangedMsg:
+		return a.handleIssueLinkChanged(msg)
+	case issueDeletedMsg:
+		return a.handleIssueDeleted(msg)
+
 	case views.ProjectHoveredMsg:
 		if msg.Project != nil {
 			a.detailView.SetProject(msg.Project)

--- a/pkg/tui/commands.go
+++ b/pkg/tui/commands.go
@@ -356,6 +356,68 @@ func fetchPriorities(client jira.ClientInterface) tea.Cmd {
 	}
 }
 
+type issueLinkTypesLoadedMsg struct{ types []jira.IssueLinkType }
+
+// issueLinkChangedMsg reports that the links of issueKey changed and its
+// detail has to be refetched.
+type issueLinkChangedMsg struct{ issueKey string }
+
+// issueDeletedMsg reports a deleted issue. parentKey, when set, is the issue
+// whose subtask list has to be refreshed.
+type issueDeletedMsg struct {
+	issueKey  string
+	parentKey string
+}
+
+// errCmd reports a validation failure through the normal error path, without
+// touching the API.
+func errCmd(format string, args ...any) tea.Cmd {
+	return func() tea.Msg {
+		return errorMsg{err: fmt.Errorf(format, args...)}
+	}
+}
+
+func fetchIssueLinkTypes(client jira.ClientInterface) tea.Cmd {
+	return func() tea.Msg {
+		types, err := client.GetIssueLinkTypes(context.Background())
+		if err != nil {
+			return errorMsg{err: err}
+		}
+		return issueLinkTypesLoadedMsg{types: types}
+	}
+}
+
+// createIssueLink links two issues. refreshKey is the issue whose detail the
+// UI reloads afterwards.
+func createIssueLink(client jira.ClientInterface, typeName, inwardKey, outwardKey, refreshKey string) tea.Cmd {
+	return func() tea.Msg {
+		if err := client.CreateIssueLink(context.Background(), typeName, inwardKey, outwardKey); err != nil {
+			return errorMsg{err: err}
+		}
+		return issueLinkChangedMsg{issueKey: refreshKey}
+	}
+}
+
+func deleteIssueLink(client jira.ClientInterface, linkID, refreshKey string) tea.Cmd {
+	return func() tea.Msg {
+		if err := client.DeleteIssueLink(context.Background(), linkID); err != nil {
+			return errorMsg{err: err}
+		}
+		return issueLinkChangedMsg{issueKey: refreshKey}
+	}
+}
+
+// deleteIssue removes an issue along with its subtasks: the confirmation the
+// user already answered covers them.
+func deleteIssue(client jira.ClientInterface, issueKey, parentKey string) tea.Cmd {
+	return func() tea.Msg {
+		if err := client.DeleteIssue(context.Background(), issueKey, true); err != nil {
+			return errorMsg{err: err}
+		}
+		return issueDeletedMsg{issueKey: issueKey, parentKey: parentKey}
+	}
+}
+
 func fetchMyself(client jira.ClientInterface) tea.Cmd {
 	return func() tea.Msg {
 		user, err := client.GetMyself(context.Background())

--- a/pkg/tui/components/modal.go
+++ b/pkg/tui/components/modal.go
@@ -231,6 +231,12 @@ func (m *Modal) IsVisible() bool   { return m.visible }
 func (m *Modal) IsSearching() bool { return m.searching }
 func (m *Modal) IsChecklist() bool { return m.checklist }
 
+// Title is the heading currently displayed.
+func (m *Modal) Title() string { return m.title }
+
+// Items are the rows currently offered, in display order.
+func (m *Modal) Items() []ModalItem { return m.items }
+
 // SearchView renders the modal search bar for external use
 func (m *Modal) SearchView(_ int) string {
 	return RenderFilterBarInput(&m.filterInput)

--- a/pkg/tui/handlers_keys.go
+++ b/pkg/tui/handlers_keys.go
@@ -420,6 +420,12 @@ func (a *App) handleIssueAction(action Action) (tea.Model, tea.Cmd, bool) {
 		m, cmd := a.startCreateIssue()
 		return m, cmd, true
 
+	case ActLinkIssue:
+		return a.startLinkIssue()
+
+	case ActDeleteSelection:
+		return a.startDeleteSelection()
+
 	case ActCreateSubtask:
 		if a.canCreateSubtask() {
 			m, cmd := a.startCreateSubtask()

--- a/pkg/tui/handlers_modal.go
+++ b/pkg/tui/handlers_modal.go
@@ -162,6 +162,8 @@ func (a *App) handleInputConfirmed(msg components.InputConfirmedMsg) (tea.Model,
 			a.optimisticFieldUpdate(ctx.issueKey, ctx.fieldID, msg.Text)
 			return a, updateIssueField(a.client, ctx.issueKey, ctx.fieldID, msg.Text)
 		}
+	case editLinkTarget:
+		return a, a.applyLinkTarget(ctx, msg.Text)
 	case editBranch:
 		if msg.Text != "" {
 			switch git.ResolveBranchAction(a.gitRepoPath, msg.Text) {

--- a/pkg/tui/keybindings.go
+++ b/pkg/tui/keybindings.go
@@ -71,6 +71,7 @@ func (a *App) ContextBindings() []Binding {
 			a.bind(ActNew, "create issue"),
 			a.bind(ActDuplicateIssue, "duplicate issue"),
 			a.bind(ActCloseJQLTab, "close JQL tab"),
+			a.bind(ActLinkIssue, "link to another issue"),
 			Binding{"[]", "switch tab"},
 		)
 		bindings = append(bindings, a.customCommandBindings(config.CtxIssues)...)
@@ -86,6 +87,8 @@ func (a *App) ContextBindings() []Binding {
 			a.bind(ActAssignee, "change assignee"),
 			a.bind(ActBrowser, "open issue in browser"),
 			a.bind(ActURLPicker, "open URL picker"),
+			a.bind(ActLinkIssue, "link to another issue"),
+			a.bind(ActDeleteSelection, "delete link or subtask"),
 			a.bind(ActFocusRight, "next panel"),
 			a.bind(ActFocusLeft, "previous panel"),
 		)
@@ -237,7 +240,15 @@ func (a *App) helpBarItems() []components.HelpItem {
 			components.HelpItem{Key: km.Keys(ActTransition), Description: "transition"},
 			components.HelpItem{Key: km.Keys(ActPriority), Description: "priority"},
 			components.HelpItem{Key: km.Keys(ActAssignee), Description: "assignee"},
+			components.HelpItem{Key: km.Keys(ActLinkIssue), Description: "link"},
 		)
+		switch a.infoPanel.ActiveTab() {
+		case views.InfoTabLinks:
+			items = append(items, components.HelpItem{Key: km.Keys(ActDeleteSelection), Description: "remove link"})
+		case views.InfoTabSubtasks:
+			items = append(items, components.HelpItem{Key: km.Keys(ActDeleteSelection), Description: "delete subtask"})
+		case views.InfoTabFields:
+		}
 		items = append(items, a.customCommandHelpItems(config.CtxInfo)...)
 		items = append(items, components.HelpItem{Key: km.Keys(ActHelp), Description: "help"})
 		return items

--- a/pkg/tui/keymap.go
+++ b/pkg/tui/keymap.go
@@ -46,6 +46,11 @@ const (
 	ActCreateSubtask  Action = "createSubtask"
 	ActDuplicateIssue Action = "duplicateIssue"
 	ActShowParent     Action = "showParent"
+	// ActLinkIssue links the current issue to another one.
+	ActLinkIssue Action = "linkIssue"
+	// ActDeleteSelection removes the link or subtask under the cursor.
+	// Not "x": that closes the JQL tab.
+	ActDeleteSelection Action = "deleteSelection"
 
 	ActNavDown     Action = "navDown"
 	ActNavUp       Action = "navUp"
@@ -100,6 +105,9 @@ func DefaultKeymap() Keymap {
 		ActCreateSubtask:  {"S"},
 		ActShowParent:     {"backspace"},
 
+		ActLinkIssue:       {"L"},
+		ActDeleteSelection: {"D"},
+
 		ActNavDown:     {"j", "down", "ctrl+j"},
 		ActNavUp:       {"k", "up", "ctrl+k"},
 		ActNavTop:      {"g", "home"},
@@ -150,6 +158,8 @@ func KeymapFromConfig(kcfg config.KeybindingConfig) Keymap {
 	set(ActCreateBranch, kcfg.Issues.CreateBranch)
 	set(ActCreateIssue, kcfg.Issues.CreateIssue)
 	set(ActCreateSubtask, kcfg.Issues.CreateSubtask)
+	set(ActLinkIssue, kcfg.Issues.LinkIssue)
+	set(ActDeleteSelection, kcfg.Issues.DeleteSelection)
 	// Detail
 	set(ActFocusLeft, kcfg.Detail.FocusLeft)
 	set(ActInfoTab, kcfg.Detail.InfoTab)

--- a/pkg/tui/links.go
+++ b/pkg/tui/links.go
@@ -1,0 +1,238 @@
+package tui
+
+import (
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/textfuel/lazyjira/v2/pkg/jira"
+	"github.com/textfuel/lazyjira/v2/pkg/tui/components"
+	"github.com/textfuel/lazyjira/v2/pkg/tui/views"
+)
+
+const (
+	// linkOutward marks the direction in which the current issue is the
+	// subject of the relation ("this blocks that").
+	linkOutward = "out"
+	linkInward  = "in"
+
+	confirmYes = "__yes__"
+)
+
+// startLinkIssue asks for a link type, then for the issue to link to.
+func (a *App) startLinkIssue() (tea.Model, tea.Cmd, bool) {
+	subject := a.linkSubject()
+	if subject == "" {
+		return a, nil, true
+	}
+	a.onSelect = a.makeLinkTypeCallback(subject)
+	*a.logFlag = true
+	return a, fetchIssueLinkTypes(a.client), true
+}
+
+// linkSubject is the issue a new link attaches to. With the Info panel focused
+// that is the issue it is showing: entering its Lnk or Sub tab previews the
+// related issue in the detail panel, so currentIssue would attach the link to
+// the neighbour the user is merely looking at.
+func (a *App) linkSubject() string {
+	if a.side == sideLeft && a.leftFocus == focusInfo {
+		if key := a.infoPanel.IssueKey(); key != "" {
+			return key
+		}
+	}
+	if cur := a.currentIssue(); cur != nil {
+		return cur.Key
+	}
+	return ""
+}
+
+// handleIssueLinkTypesLoaded lists each link type once per direction, since
+// "blocks" and "is blocked by" are the same type read from opposite ends.
+func (a *App) handleIssueLinkTypesLoaded(msg issueLinkTypesLoadedMsg) (tea.Model, tea.Cmd) {
+	items := make([]components.ModalItem, 0, len(msg.types)*2)
+	for _, t := range msg.types {
+		items = append(items, components.ModalItem{
+			ID:    t.Name + "|" + linkOutward,
+			Label: t.Outward,
+			Hint:  t.Name,
+		})
+		// A symmetric type ("relates to" both ways) needs only one row.
+		if !strings.EqualFold(t.Inward, t.Outward) {
+			items = append(items, components.ModalItem{
+				ID:    t.Name + "|" + linkInward,
+				Label: t.Inward,
+				Hint:  t.Name,
+			})
+		}
+	}
+	if len(items) == 0 {
+		a.onSelect = nil
+		a.statusPanel.SetError("no issue link types available")
+		return a, nil
+	}
+	a.modal.Show("Link type", items)
+	return a, nil
+}
+
+// makeLinkTypeCallback turns the chosen link type into the second prompt: the
+// key of the issue to link to.
+func (a *App) makeLinkTypeCallback(issueKey string) onSelectFunc {
+	return func(item components.ModalItem) tea.Cmd {
+		if !strings.Contains(item.ID, "|") {
+			return nil
+		}
+		// The chosen type and direction ride along in fieldID until the
+		// target key comes back from the input modal.
+		a.editContext = editCtx{kind: editLinkTarget, issueKey: issueKey, fieldID: item.ID}
+		a.inputModal.Show(item.Label+" …", "")
+		a.inputModal.SetHints(a.linkCandidateKeys(issueKey))
+		return nil
+	}
+}
+
+// linkCandidateKeys offers the issues already on screen as link targets, so
+// the common case needs no typing.
+func (a *App) linkCandidateKeys(exclude string) []string {
+	issues := a.issuesList.CurrentIssues()
+	keys := make([]string, 0, len(issues))
+	for _, issue := range issues {
+		if issue.Key == exclude {
+			continue
+		}
+		keys = append(keys, issue.Key)
+	}
+	return keys
+}
+
+// applyLinkTarget creates the link once the target key is known. The direction
+// chosen decides which side of the relation the current issue sits on.
+func (a *App) applyLinkTarget(ctx editCtx, target string) tea.Cmd {
+	target = strings.ToUpper(strings.TrimSpace(target))
+	if target == "" {
+		return nil
+	}
+	if !parentKeyRegex.MatchString(target) {
+		return errCmd("invalid issue key %q (expected PROJ-123)", target)
+	}
+	typeName, direction, ok := strings.Cut(ctx.fieldID, "|")
+	if !ok {
+		return nil
+	}
+
+	inward, outward := target, ctx.issueKey
+	if direction == linkInward {
+		inward, outward = ctx.issueKey, target
+	}
+	*a.logFlag = true
+	return createIssueLink(a.client, typeName, inward, outward, ctx.issueKey)
+}
+
+// startDeleteSelection deletes whatever the cursor is on: a link in the Lnk
+// tab, a subtask in the Sub tab. Both ask first.
+func (a *App) startDeleteSelection() (tea.Model, tea.Cmd, bool) {
+	if a.side != sideLeft || a.leftFocus != focusInfo {
+		return a, nil, true
+	}
+	switch a.infoPanel.ActiveTab() {
+	case views.InfoTabLinks:
+		return a.confirmDeleteLink()
+	case views.InfoTabSubtasks:
+		return a.confirmDeleteSubtask()
+	case views.InfoTabFields:
+	}
+	return a, nil, true
+}
+
+func (a *App) confirmDeleteLink() (tea.Model, tea.Cmd, bool) {
+	link := a.infoPanel.SelectedLink()
+	issue := a.infoPanel.SelectedLinkIssue()
+	if link == nil || link.ID == "" || issue == nil {
+		return a, nil, true
+	}
+	owner := a.infoPanel.IssueKey()
+	linkID := link.ID
+
+	question := "Remove link to " + issue.Key + "?"
+	if relation := linkedIssueRelation(link); relation != "" {
+		question = "Remove \"" + relation + " " + issue.Key + "\"?"
+	}
+
+	a.confirm(question, func() tea.Cmd {
+		*a.logFlag = true
+		return deleteIssueLink(a.client, linkID, owner)
+	})
+	return a, nil, true
+}
+
+func (a *App) confirmDeleteSubtask() (tea.Model, tea.Cmd, bool) {
+	sub := a.infoPanel.SelectedSubtaskIssue()
+	if sub == nil {
+		return a, nil, true
+	}
+	parent := a.infoPanel.IssueKey()
+	key := sub.Key
+
+	a.confirm("Delete "+key+" permanently?", func() tea.Cmd {
+		*a.logFlag = true
+		return deleteIssue(a.client, key, parent)
+	})
+	return a, nil, true
+}
+
+// confirm shows a two-option modal and runs onYes only if the user picks Yes.
+// Destructive actions never run straight off a keypress.
+func (a *App) confirm(question string, onYes func() tea.Cmd) {
+	a.onSelect = func(item components.ModalItem) tea.Cmd {
+		if item.ID != confirmYes {
+			return nil
+		}
+		return onYes()
+	}
+	a.modal.Show(question, []components.ModalItem{
+		{ID: "__no__", Label: "No, keep it"},
+		{ID: confirmYes, Label: "Yes, delete"},
+	})
+}
+
+// handleIssueLinkChanged refreshes the issue whose links or subtasks changed,
+// dropping the stale cache first so the refetch is not served from it.
+func (a *App) handleIssueLinkChanged(msg issueLinkChangedMsg) (tea.Model, tea.Cmd) {
+	if msg.issueKey == "" {
+		return a, nil
+	}
+	delete(a.issueCache, msg.issueKey)
+	delete(a.childrenCache, msg.issueKey)
+	return a, fetchIssueDetail(a.client, msg.issueKey)
+}
+
+// handleIssueDeleted drops the issue everywhere it is remembered and reloads
+// the list it came from.
+func (a *App) handleIssueDeleted(msg issueDeletedMsg) (tea.Model, tea.Cmd) {
+	delete(a.issueCache, msg.issueKey)
+	delete(a.childrenCache, msg.issueKey)
+	if msg.issueKey == a.previewKey {
+		a.previewKey = ""
+	}
+
+	cmds := []tea.Cmd{a.fetchActiveTab()}
+	if msg.parentKey != "" && msg.parentKey != msg.issueKey {
+		delete(a.issueCache, msg.parentKey)
+		delete(a.childrenCache, msg.parentKey)
+		cmds = append(cmds, fetchIssueDetail(a.client, msg.parentKey))
+	}
+	return a, tea.Batch(cmds...)
+}
+
+// linkedIssueRelation phrases a link the way the Lnk tab renders it, so a
+// confirmation prompt repeats the row the user is looking at. The pairing --
+// outwardIssue with the outward phrase, inwardIssue with the inward one --
+// matches renderLinkRowPairs.
+func linkedIssueRelation(link *jira.IssueLink) string {
+	if link == nil || link.Type == nil {
+		return ""
+	}
+	if link.OutwardIssue != nil {
+		return link.Type.Outward
+	}
+	return link.Type.Inward
+}

--- a/pkg/tui/links_test.go
+++ b/pkg/tui/links_test.go
@@ -1,0 +1,373 @@
+package tui
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/textfuel/lazyjira/v2/pkg/jira"
+	"github.com/textfuel/lazyjira/v2/pkg/jira/jiratest"
+	"github.com/textfuel/lazyjira/v2/pkg/tui/components"
+	"github.com/textfuel/lazyjira/v2/pkg/tui/views"
+)
+
+const (
+	linkKey1 = testProject + "-1"
+	linkKey2 = testProject + "-2"
+)
+
+var blocksType = &jira.IssueLinkType{
+	ID: "10000", Name: "Blocks", Inward: "is blocked by", Outward: "blocks",
+}
+
+// newLinkApp returns an app whose Info panel shows an issue carrying one link
+// and one subtask.
+func newLinkApp(t *testing.T) *App {
+	t.Helper()
+	app := newTestApp()
+	app.client = &jiratest.FakeClient{T: t}
+	app.infoPanel = views.NewInfoPanel()
+	app.statusPanel = views.NewStatusPanel(testProject, "", "")
+	app.keymap = DefaultKeymap()
+	app.issueCache = map[string]*jira.Issue{}
+	app.childrenCache = map[string][]jira.Issue{}
+	logFlag := false
+	app.logFlag = &logFlag
+
+	issue := &jira.Issue{
+		Key:     linkKey1,
+		Summary: testSummary,
+		IssueLinks: []jira.IssueLink{
+			{ID: "500", Type: blocksType, OutwardIssue: &jira.Issue{Key: linkKey2, Summary: "Blocked one"}},
+		},
+		Subtasks: []jira.Issue{{Key: testProject + "-9", Summary: "A subtask"}},
+	}
+	app.issuesList.SetIssues([]jira.Issue{*issue, {Key: linkKey2, Summary: "Blocked one"}})
+	app.issueCache[linkKey1] = issue
+	app.previewKey = linkKey1
+	app.infoPanel.SetIssue(issue)
+	app.side = sideLeft
+	app.leftFocus = focusInfo
+	return app
+}
+
+func TestLinkTypesModalListsBothDirections(t *testing.T) {
+	t.Parallel()
+	app := newLinkApp(t)
+
+	app.handleIssueLinkTypesLoaded(issueLinkTypesLoadedMsg{types: []jira.IssueLinkType{*blocksType}})
+
+	if !app.modal.IsVisible() {
+		t.Fatal("the link type modal was not shown")
+	}
+	items := app.modal.Items()
+	if len(items) != 2 {
+		t.Fatalf("items = %d, want one per direction: %+v", len(items), items)
+	}
+	if items[0].Label != "blocks" || items[1].Label != "is blocked by" {
+		t.Errorf("labels = %q, %q", items[0].Label, items[1].Label)
+	}
+}
+
+func TestLinkTypesModalCollapsesSymmetricTypes(t *testing.T) {
+	t.Parallel()
+	app := newLinkApp(t)
+	relates := jira.IssueLinkType{Name: "Relates", Inward: "relates to", Outward: "relates to"}
+
+	app.handleIssueLinkTypesLoaded(issueLinkTypesLoadedMsg{types: []jira.IssueLinkType{relates}})
+
+	if got := len(app.modal.Items()); got != 1 {
+		t.Errorf("items = %d, want a symmetric type listed once", got)
+	}
+}
+
+func TestLinkTypesEmptyReportsAnError(t *testing.T) {
+	t.Parallel()
+	app := newLinkApp(t)
+	app.onSelect = func(components.ModalItem) tea.Cmd { return nil }
+
+	app.handleIssueLinkTypesLoaded(issueLinkTypesLoadedMsg{})
+
+	if app.modal.IsVisible() {
+		t.Error("an empty type list should not open a modal")
+	}
+	if app.onSelect != nil {
+		t.Error("the pending callback was left dangling")
+	}
+}
+
+func TestLinkTypeSelectionOpensTargetPrompt(t *testing.T) {
+	t.Parallel()
+	app := newLinkApp(t)
+
+	app.makeLinkTypeCallback(linkKey1)(components.ModalItem{ID: "Blocks|out", Label: "blocks"})
+
+	if !app.inputModal.IsVisible() {
+		t.Fatal("the target prompt was not shown")
+	}
+	if app.editContext.kind != editLinkTarget || app.editContext.fieldID != "Blocks|out" {
+		t.Errorf("editContext = %+v", app.editContext)
+	}
+	if !app.inputModal.HasHints() {
+		t.Error("the prompt offers no candidate keys from the list")
+	}
+}
+
+func TestLinkCandidatesExcludeTheIssueItself(t *testing.T) {
+	t.Parallel()
+	app := newLinkApp(t)
+	app.issuesList.SetIssues([]jira.Issue{{Key: linkKey1}, {Key: linkKey2}})
+
+	got := app.linkCandidateKeys(linkKey1)
+
+	if len(got) != 1 || got[0] != linkKey2 {
+		t.Errorf("candidates = %v, want everything but the issue itself", got)
+	}
+}
+
+func TestApplyLinkTargetOutwardDirection(t *testing.T) {
+	t.Parallel()
+	app := newLinkApp(t)
+	fake := &jiratest.FakeClient{T: t}
+	fake.CreateIssueLinkFunc = func(context.Context, string, string, string) error { return nil }
+	app.client = fake
+
+	ctx := editCtx{kind: editLinkTarget, issueKey: linkKey1, fieldID: "Blocks|out"}
+	cmd := app.applyLinkTarget(ctx, linkKey2)
+	if cmd == nil {
+		t.Fatal("no command was produced")
+	}
+	cmd()
+
+	call := fake.CreateIssueLinkCalls[0]
+	if call.TypeName != "Blocks" {
+		t.Errorf("type = %q", call.TypeName)
+	}
+	// "PLAT-1 blocks PLAT-2": the current issue is the outward side.
+	if call.OutwardKey != linkKey1 || call.InwardKey != linkKey2 {
+		t.Errorf("outward = %q, inward = %q", call.OutwardKey, call.InwardKey)
+	}
+}
+
+func TestApplyLinkTargetInwardDirectionSwapsSides(t *testing.T) {
+	t.Parallel()
+	app := newLinkApp(t)
+	fake := &jiratest.FakeClient{T: t}
+	fake.CreateIssueLinkFunc = func(context.Context, string, string, string) error { return nil }
+	app.client = fake
+
+	ctx := editCtx{kind: editLinkTarget, issueKey: linkKey1, fieldID: "Blocks|in"}
+	app.applyLinkTarget(ctx, linkKey2)()
+
+	call := fake.CreateIssueLinkCalls[0]
+	// "PLAT-1 is blocked by PLAT-2": the current issue is now the inward side.
+	if call.InwardKey != linkKey1 || call.OutwardKey != linkKey2 {
+		t.Errorf("inward = %q, outward = %q", call.InwardKey, call.OutwardKey)
+	}
+}
+
+func TestApplyLinkTargetRejectsMalformedKey(t *testing.T) {
+	t.Parallel()
+	app := newLinkApp(t)
+
+	ctx := editCtx{kind: editLinkTarget, issueKey: linkKey1, fieldID: "Blocks|out"}
+	cmd := app.applyLinkTarget(ctx, "not a key")
+	if cmd == nil {
+		t.Fatal("a malformed key produced no result")
+	}
+	msg, ok := cmd().(errorMsg)
+	if !ok {
+		t.Fatalf("message = %T, want errorMsg", cmd())
+	}
+	if !strings.Contains(msg.err.Error(), "invalid issue key") {
+		t.Errorf("error = %v", msg.err)
+	}
+}
+
+func TestApplyLinkTargetIgnoresEmptyInput(t *testing.T) {
+	t.Parallel()
+	app := newLinkApp(t)
+
+	ctx := editCtx{kind: editLinkTarget, issueKey: linkKey1, fieldID: "Blocks|out"}
+	if cmd := app.applyLinkTarget(ctx, "  "); cmd != nil {
+		t.Error("an empty target created a link")
+	}
+}
+
+func TestDeleteLinkAsksBeforeDeleting(t *testing.T) {
+	t.Parallel()
+	app := newLinkApp(t)
+	fake := &jiratest.FakeClient{T: t}
+	fake.DeleteIssueLinkFunc = func(context.Context, string) error { return nil }
+	app.client = fake
+	app.infoPanel.SetActiveTab(views.InfoTabLinks)
+
+	app.startDeleteSelection()
+
+	if !app.modal.IsVisible() {
+		t.Fatal("no confirmation was shown")
+	}
+	if len(fake.DeleteIssueLinkCalls) != 0 {
+		t.Fatal("the link was deleted before the user confirmed")
+	}
+	if title := app.modal.Title(); !strings.Contains(title, linkKey2) {
+		t.Errorf("prompt = %q, want it to name the linked issue", title)
+	}
+
+	app.onSelect(components.ModalItem{ID: confirmYes})()
+
+	if len(fake.DeleteIssueLinkCalls) != 1 || fake.DeleteIssueLinkCalls[0].LinkID != "500" {
+		t.Errorf("DeleteIssueLink calls = %+v", fake.DeleteIssueLinkCalls)
+	}
+}
+
+func TestDeclinedConfirmationDeletesNothing(t *testing.T) {
+	t.Parallel()
+	app := newLinkApp(t)
+	app.infoPanel.SetActiveTab(views.InfoTabLinks)
+	app.startDeleteSelection()
+
+	if cmd := app.onSelect(components.ModalItem{ID: "__no__"}); cmd != nil {
+		t.Error("answering No still ran the delete")
+	}
+}
+
+func TestDeleteSubtaskAsksBeforeDeleting(t *testing.T) {
+	t.Parallel()
+	app := newLinkApp(t)
+	fake := &jiratest.FakeClient{T: t}
+	fake.DeleteIssueFunc = func(context.Context, string, bool) error { return nil }
+	app.client = fake
+	app.infoPanel.SetActiveTab(views.InfoTabSubtasks)
+
+	app.startDeleteSelection()
+	if !app.modal.IsVisible() {
+		t.Fatal("no confirmation was shown")
+	}
+	app.onSelect(components.ModalItem{ID: confirmYes})()
+
+	if len(fake.DeleteIssueCalls) != 1 {
+		t.Fatalf("DeleteIssue calls = %d", len(fake.DeleteIssueCalls))
+	}
+	if got := fake.DeleteIssueCalls[0].Key; got != testProject+"-9" {
+		t.Errorf("deleted %q", got)
+	}
+}
+
+func TestDeleteIgnoredOnTheFieldsTab(t *testing.T) {
+	t.Parallel()
+	app := newLinkApp(t)
+	app.infoPanel.SetActiveTab(views.InfoTabFields)
+
+	app.startDeleteSelection()
+
+	if app.modal.IsVisible() {
+		t.Error("the Fields tab has nothing to delete")
+	}
+}
+
+func TestDeleteIgnoredOutsideTheInfoPanel(t *testing.T) {
+	t.Parallel()
+	app := newLinkApp(t)
+	app.leftFocus = focusIssues
+	app.infoPanel.SetActiveTab(views.InfoTabLinks)
+
+	app.startDeleteSelection()
+
+	if app.modal.IsVisible() {
+		t.Error("delete fired with the Info panel unfocused")
+	}
+}
+
+func TestLinkChangedRefetchesTheIssue(t *testing.T) {
+	t.Parallel()
+	app := newLinkApp(t)
+	fake := &jiratest.FakeClient{T: t}
+	fake.GetIssueFunc = func(_ context.Context, key string) (*jira.Issue, error) {
+		return &jira.Issue{Key: key}, nil
+	}
+	fake.GetCommentsFunc = func(context.Context, string) ([]jira.Comment, error) { return nil, nil }
+	fake.GetChangelogFunc = func(context.Context, string) ([]jira.ChangelogEntry, error) { return nil, nil }
+	app.client = fake
+
+	_, cmd := app.handleIssueLinkChanged(issueLinkChangedMsg{issueKey: linkKey1})
+
+	if _, stale := app.issueCache[linkKey1]; stale {
+		t.Error("the stale issue is still cached; the refetch would be served from it")
+	}
+	if cmd == nil {
+		t.Fatal("no refetch was scheduled")
+	}
+	cmd()
+	if len(fake.GetIssueCalls) == 0 {
+		t.Error("the issue was not refetched")
+	}
+}
+
+func TestIssueDeletedClearsCachesAndReloads(t *testing.T) {
+	t.Parallel()
+	app := newLinkApp(t)
+	sub := testProject + "-9"
+	app.issueCache[sub] = &jira.Issue{Key: sub}
+	app.childrenCache[linkKey1] = []jira.Issue{{Key: sub}}
+	app.previewKey = sub
+
+	app.handleIssueDeleted(issueDeletedMsg{issueKey: sub, parentKey: linkKey1})
+
+	if _, stale := app.issueCache[sub]; stale {
+		t.Error("the deleted issue is still cached")
+	}
+	if _, stale := app.childrenCache[linkKey1]; stale {
+		t.Error("the parent's children cache was not invalidated")
+	}
+	if app.previewKey != "" {
+		t.Errorf("previewKey = %q, want it cleared for a deleted issue", app.previewKey)
+	}
+}
+
+// The prompt must repeat the phrasing of the Lnk row it acts on, which pairs
+// outwardIssue with the outward phrase.
+func TestLinkedIssueRelationMatchesTheRenderedRow(t *testing.T) {
+	t.Parallel()
+	outward := &jira.IssueLink{Type: blocksType, OutwardIssue: &jira.Issue{Key: linkKey2}}
+	if got := linkedIssueRelation(outward); got != "blocks" {
+		t.Errorf("relation = %q", got)
+	}
+
+	inward := &jira.IssueLink{Type: blocksType, InwardIssue: &jira.Issue{Key: linkKey2}}
+	if got := linkedIssueRelation(inward); got != "is blocked by" {
+		t.Errorf("relation = %q", got)
+	}
+	if got := linkedIssueRelation(nil); got != "" {
+		t.Errorf("relation = %q, want empty for a nil link", got)
+	}
+}
+
+// Entering the Lnk or Sub tab previews the related issue in the detail panel,
+// so currentIssue points at the neighbour. A new link must still attach to the
+// issue whose links are on screen.
+func TestLinkAttachesToTheIssueTheInfoPanelShows(t *testing.T) {
+	t.Parallel()
+	app := newLinkApp(t)
+	app.infoPanel.SetActiveTab(views.InfoTabLinks)
+	app.previewKey = linkKey2
+	app.issueCache[linkKey2] = &jira.Issue{Key: linkKey2}
+
+	if got := app.linkSubject(); got != linkKey1 {
+		t.Errorf("link subject = %q, want the issue the Info panel is showing (%s)", got, linkKey1)
+	}
+}
+
+func TestLinkSubjectIsTheOpenIssueElsewhere(t *testing.T) {
+	t.Parallel()
+	app := newLinkApp(t)
+	app.leftFocus = focusIssues
+	app.previewKey = linkKey2
+	app.issueCache[linkKey2] = &jira.Issue{Key: linkKey2}
+
+	if got := app.linkSubject(); got != linkKey2 {
+		t.Errorf("link subject = %q, want the issue on screen (%s)", got, linkKey2)
+	}
+}

--- a/pkg/tui/views/infopanel.go
+++ b/pkg/tui/views/infopanel.go
@@ -214,32 +214,47 @@ func (p *InfoPanel) SelectedLinkKey() string {
 // whatever fields the parent payload carried, typically key + summary +
 // status), or nil when no link is selected.
 func (p *InfoPanel) SelectedLinkIssue() *jira.Issue {
+	_, issue := p.selectedLink()
+	return issue
+}
+
+// SelectedLink returns the whole link under the cursor, which carries the id
+// needed to delete it.
+func (p *InfoPanel) SelectedLink() *jira.IssueLink {
+	link, _ := p.selectedLink()
+	return link
+}
+
+// selectedLink walks the rendered link rows -- one per direction, since a link
+// can name an issue on either side -- and returns the row under the cursor.
+func (p *InfoPanel) selectedLink() (*jira.IssueLink, *jira.Issue) {
 	if p.issue == nil || p.activeTab != InfoTabLinks {
-		return nil
+		return nil, nil
 	}
 	target := p.resolveOriginalIndex()
 	if target < 0 {
-		return nil
+		return nil, nil
 	}
 	idx := 0
-	for _, link := range p.issue.IssueLinks {
+	for i := range p.issue.IssueLinks {
+		link := &p.issue.IssueLinks[i]
 		if link.Type == nil {
 			continue
 		}
 		if link.OutwardIssue != nil {
 			if idx == target {
-				return link.OutwardIssue
+				return link, link.OutwardIssue
 			}
 			idx++
 		}
 		if link.InwardIssue != nil {
 			if idx == target {
-				return link.InwardIssue
+				return link, link.InwardIssue
 			}
 			idx++
 		}
 	}
-	return nil
+	return nil, nil
 }
 
 // SelectedSubtaskKey returns the issue key of the selected subtask


### PR DESCRIPTION
## Summary
- Adds a key to create a link between the current issue and another one, picking the link type and target from a picker.
- Adds a key to remove the selected link or subtask, with a confirmation step.
- Fetches issue link types from Jira instead of hardcoding them.

## Test plan
- `make check` passes.
- Added unit tests covering link creation, link/subtask deletion, and the case where the Info panel is showing a different issue than the one on screen (link must attach to the issue the panel is displaying).

Closes #121