### PR TITLE
Write comments in a popup and reply to one

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -393,6 +393,8 @@ keybinding:
     transition: "t"
     browser: "o"
     createBranch: "b"
+  detail:
+    replyComment: "ctrl+r"
 ```
 
 Only include keys you want to change. Missing keys keep their defaults.

--- a/docs/Keybindings.md
+++ b/docs/Keybindings.md
@@ -42,6 +42,21 @@ Detail scroll keys (`J`/`K`/`ctrl+f`/`ctrl+b`) can be remapped via `keybinding.d
 | `s` | JQL search |
 | `x` | Close JQL tab |
 
+## Comments
+
+| Key | Action |
+| --- | --- |
+| `c` | Go to the comments tab |
+| `n` | Write a new comment in a popup |
+| `ctrl+r` | Reply to the selected comment, prefilled with an @-mention and a quote |
+| `e` | Edit the selected comment in `$EDITOR` |
+
+Inside the comment popup: `ctrl+d` sends, `esc` cancels, and `ctrl+e` moves
+what you have written to `$EDITOR`.
+
+Jira has no threaded replies, so a reply is an ordinary comment that quotes
+and mentions the person being answered.
+
 ## Help popup
 
 | Key | Action |

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -181,6 +181,8 @@ type DetailKeys struct {
 	ScrollUp     string `yaml:"scrollUp"`
 	HalfPageDown string `yaml:"halfPageDown"`
 	HalfPageUp   string `yaml:"halfPageUp"`
+	// ReplyComment quotes the selected comment in a new one.
+	ReplyComment string `yaml:"replyComment"`
 }
 
 type JiraConfig struct {

--- a/pkg/tui/app.go
+++ b/pkg/tui/app.go
@@ -151,6 +151,7 @@ type App struct {
 	jqlModal   components.JQLModal
 	diffView   components.DiffView
 	inputModal components.InputModal
+	textModal  components.TextAreaModal
 	createForm components.CreateForm
 	overlays   components.OverlayStack
 
@@ -385,6 +386,7 @@ func NewAppWithAuth(cfg *config.Config, client jira.ClientInterface, authMethod 
 		&app.createForm,
 		&app.jqlModal,
 		&app.inputModal,
+		&app.textModal,
 		&app.diffView,
 		&app.modal,
 	}
@@ -571,6 +573,13 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return a.handleInputConfirmed(msg)
 	case components.InputCancelledMsg:
 		return a.handleInputCancelled()
+	case components.TextAreaConfirmedMsg:
+		return a.handleTextAreaConfirmed(msg.Text)
+	case components.TextAreaCancelledMsg:
+		a.editContext = editCtx{}
+		return a, nil
+	case components.TextAreaHandoffMsg:
+		return a.handleTextAreaHandoff(msg.Text)
 
 	case components.JQLSubmitMsg:
 		return a.handleJQLSubmit(msg)

--- a/pkg/tui/comments.go
+++ b/pkg/tui/comments.go
@@ -1,0 +1,92 @@
+package tui
+
+import (
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/textfuel/lazyjira/v2/pkg/jira"
+	"github.com/textfuel/lazyjira/v2/pkg/tui/views"
+)
+
+// replyQuoteLines is how much of the quoted comment a reply carries. Long
+// comments are cut so the popup opens on the text being written, not on the
+// quote.
+const replyQuoteLines = 4
+
+// startNewComment opens the comment popup for the issue on screen.
+func (a *App) startNewComment() (tea.Model, tea.Cmd, bool) {
+	cur := a.currentIssue()
+	if cur == nil || a.side != sideRight || a.detailView.ActiveTab() != views.TabComments {
+		return a, nil, true
+	}
+	a.editContext = editCtx{kind: editCommentNew, issueKey: cur.Key}
+	a.textModal.Show("New comment on "+cur.Key, "")
+	return a, nil, true
+}
+
+// startReplyComment opens the comment popup prefilled with a quote of the
+// selected comment. Jira has no threaded replies, so a reply is a normal
+// comment that quotes and mentions the person being answered.
+func (a *App) startReplyComment() (tea.Model, tea.Cmd, bool) {
+	cur := a.currentIssue()
+	if cur == nil || a.side != sideRight || a.detailView.ActiveTab() != views.TabComments {
+		return a, nil, true
+	}
+	cmt := a.detailView.SelectedComment()
+	if cmt == nil {
+		return a, nil, true
+	}
+	a.editContext = editCtx{kind: editCommentNew, issueKey: cur.Key}
+	a.textModal.Show("Reply on "+cur.Key, replyPrefill(cmt))
+	return a, nil, true
+}
+
+// replyPrefill builds the quoted body of a reply: an @-mention of the author
+// followed by their comment as a markdown blockquote.
+func replyPrefill(cmt *jira.Comment) string {
+	var b strings.Builder
+	if cmt.Author != nil && cmt.Author.DisplayName != "" {
+		b.WriteString("@" + mentionToken(cmt.Author.DisplayName) + "\n")
+	}
+
+	lines := strings.Split(strings.TrimRight(cmt.Body, "\n"), "\n")
+	truncated := false
+	if len(lines) > replyQuoteLines {
+		lines = lines[:replyQuoteLines]
+		truncated = true
+	}
+	for _, line := range lines {
+		b.WriteString("> " + line + "\n")
+	}
+	if truncated {
+		b.WriteString("> …\n")
+	}
+	b.WriteString("\n")
+	return b.String()
+}
+
+// mentionToken renders a display name as a single @-token. The mention scanner
+// only reads one word, and turns underscores back into spaces when matching,
+// so "Alice Chen" has to be written "Alice_Chen" to resolve as a whole name.
+func mentionToken(displayName string) string {
+	return strings.Join(strings.Fields(displayName), "_")
+}
+
+// handleTextAreaConfirmed submits what was typed in the comment popup through
+// the same pipeline the $EDITOR flow uses, so mentions and ADF conversion
+// behave identically.
+func (a *App) handleTextAreaConfirmed(text string) (tea.Model, tea.Cmd) {
+	if strings.TrimSpace(text) == "" {
+		a.editContext = editCtx{}
+		return a, nil
+	}
+	*a.logFlag = true
+	return a, a.applyEdit(text)
+}
+
+// handleTextAreaHandoff reopens the popup's content in $EDITOR, keeping the
+// edit context so the result still lands on the right comment.
+func (a *App) handleTextAreaHandoff(text string) (tea.Model, tea.Cmd) {
+	return a, launchEditor(text, ".md")
+}

--- a/pkg/tui/comments_test.go
+++ b/pkg/tui/comments_test.go
@@ -1,0 +1,242 @@
+package tui
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/textfuel/lazyjira/v2/pkg/jira"
+	"github.com/textfuel/lazyjira/v2/pkg/jira/jiratest"
+	"github.com/textfuel/lazyjira/v2/pkg/tui/components"
+	"github.com/textfuel/lazyjira/v2/pkg/tui/views"
+)
+
+func newCommentApp(t *testing.T) (*App, *jira.Issue) {
+	t.Helper()
+	app := newTestApp()
+	app.client = &jiratest.FakeClient{T: t}
+	app.infoPanel = views.NewInfoPanel()
+	app.statusPanel = views.NewStatusPanel(testProject, "", "")
+	app.keymap = DefaultKeymap()
+	app.issueCache = map[string]*jira.Issue{}
+	logFlag := false
+	app.logFlag = &logFlag
+
+	issue := &jira.Issue{
+		Key:     testKey,
+		Summary: testSummary,
+		Comments: []jira.Comment{
+			{ID: "1", Author: &jira.User{DisplayName: "Alice"}, Body: "First thought"},
+			{ID: "2", Author: &jira.User{DisplayName: "Bob"}, Body: "line one\nline two"},
+		},
+	}
+	app.issuesList.SetIssues([]jira.Issue{*issue})
+	app.issueCache[testKey] = issue
+	app.previewKey = testKey
+	app.side = sideRight
+	app.detailView.SetSize(80, 24)
+	app.detailView.SetIssue(issue)
+	app.detailView.SetActiveTab(views.TabComments)
+	return app, issue
+}
+
+func TestNewCommentOpensPopup(t *testing.T) {
+	t.Parallel()
+	app, _ := newCommentApp(t)
+
+	_, cmd, handled := app.startNewComment()
+
+	if !handled {
+		t.Fatal("the action was not handled")
+	}
+	if cmd != nil {
+		t.Error("opening the popup should not run a command")
+	}
+	if !app.textModal.IsVisible() {
+		t.Fatal("the popup is not visible")
+	}
+	if got := app.textModal.Text(); got != "" {
+		t.Errorf("prefill = %q, want an empty buffer", got)
+	}
+	if app.editContext.kind != editCommentNew || app.editContext.issueKey != testKey {
+		t.Errorf("editContext = %+v", app.editContext)
+	}
+}
+
+func TestNewCommentIgnoredOutsideCommentsTab(t *testing.T) {
+	t.Parallel()
+	app, _ := newCommentApp(t)
+	app.detailView.SetActiveTab(views.TabDetails)
+
+	app.startNewComment()
+
+	if app.textModal.IsVisible() {
+		t.Error("the popup opened while the Details tab was active")
+	}
+}
+
+func TestReplyQuotesSelectedComment(t *testing.T) {
+	t.Parallel()
+	app, _ := newCommentApp(t)
+
+	_, _, handled := app.startReplyComment()
+
+	if !handled {
+		t.Fatal("the action was not handled")
+	}
+	got := app.textModal.Text()
+	if !strings.HasPrefix(got, "@Alice\n") {
+		t.Errorf("reply = %q, want it to mention the comment author", got)
+	}
+	if strings.Contains(got, "@Alice ") {
+		t.Errorf("reply = %q: a mention token must not contain spaces", got)
+	}
+	if !strings.Contains(got, "> First thought") {
+		t.Errorf("reply = %q, want the comment quoted", got)
+	}
+	if !strings.HasSuffix(got, "\n\n") {
+		t.Errorf("reply = %q, want a blank line for the answer", got)
+	}
+}
+
+func TestReplyWithoutSelectedCommentIsNoOp(t *testing.T) {
+	t.Parallel()
+	app, issue := newCommentApp(t)
+	issue.Comments = nil
+	app.detailView.SetIssue(issue)
+	app.detailView.SetActiveTab(views.TabComments)
+
+	app.startReplyComment()
+
+	if app.textModal.IsVisible() {
+		t.Error("a reply popup opened with no comment selected")
+	}
+}
+
+func TestReplyPrefillTruncatesLongComments(t *testing.T) {
+	t.Parallel()
+	cmt := &jira.Comment{
+		Author: &jira.User{DisplayName: "Carol"},
+		Body:   "a\nb\nc\nd\ne\nf",
+	}
+
+	got := replyPrefill(cmt)
+
+	if strings.Count(got, "\n> ") < replyQuoteLines-1 {
+		t.Errorf("prefill = %q, want %d quoted lines", got, replyQuoteLines)
+	}
+	if !strings.Contains(got, "> …") {
+		t.Errorf("prefill = %q, want an ellipsis marking the cut", got)
+	}
+	if strings.Contains(got, "> f") {
+		t.Errorf("prefill = %q, want the tail dropped", got)
+	}
+}
+
+// A display name with spaces has to be written as a single underscore token,
+// or the mention scanner resolves only the first word and leaves the rest as
+// literal text ("@Alice Chen" became "@Alice Chen Chen").
+func TestReplyPrefillJoinsMultiWordNames(t *testing.T) {
+	t.Parallel()
+	got := replyPrefill(&jira.Comment{
+		Author: &jira.User{DisplayName: "Alice Chen"},
+		Body:   "hi",
+	})
+
+	if !strings.HasPrefix(got, "@Alice_Chen\n") {
+		t.Errorf("prefill = %q, want @Alice_Chen", got)
+	}
+}
+
+func TestMentionTokenCollapsesWhitespace(t *testing.T) {
+	t.Parallel()
+	if got := mentionToken("  Ana   Maria  Ruiz "); got != "Ana_Maria_Ruiz" {
+		t.Errorf("mentionToken = %q", got)
+	}
+}
+
+func TestReplyPrefillWithoutAuthor(t *testing.T) {
+	t.Parallel()
+	got := replyPrefill(&jira.Comment{Body: "orphan"})
+
+	if strings.HasPrefix(got, "@") {
+		t.Errorf("prefill = %q, want no mention when the author is unknown", got)
+	}
+	if !strings.Contains(got, "> orphan") {
+		t.Errorf("prefill = %q, want the body quoted", got)
+	}
+}
+
+func TestTextAreaConfirmedSubmitsComment(t *testing.T) {
+	t.Parallel()
+	app, _ := newCommentApp(t)
+	app.converter = BuiltinConverter{}
+
+	fake := &jiratest.FakeClient{T: t}
+	fake.AddCommentFunc = func(_ context.Context, key string, body any) (*jira.Comment, error) {
+		return &jira.Comment{ID: "9", Body: body.(string)}, nil
+	}
+	app.client = fake
+	app.startNewComment()
+
+	_, cmd := app.handleTextAreaConfirmed("looks good to me")
+	if cmd == nil {
+		t.Fatal("confirming the popup did not submit the comment")
+	}
+	if msg, ok := cmd().(errorMsg); ok {
+		t.Fatalf("submit failed: %v", msg.err)
+	}
+
+	if len(fake.AddCommentCalls) != 1 {
+		t.Fatalf("AddComment calls = %d, want 1", len(fake.AddCommentCalls))
+	}
+	call := fake.AddCommentCalls[0]
+	if call.Key != testKey {
+		t.Errorf("comment posted on %q, want %s", call.Key, testKey)
+	}
+	if body, _ := call.Body.(string); body != "looks good to me" {
+		t.Errorf("body = %v, want the typed text", call.Body)
+	}
+}
+
+func TestTextAreaConfirmedIgnoresBlankText(t *testing.T) {
+	t.Parallel()
+	app, _ := newCommentApp(t)
+	app.startNewComment()
+
+	_, cmd := app.handleTextAreaConfirmed("   \n  ")
+
+	if cmd != nil {
+		t.Error("a blank comment was submitted")
+	}
+	if app.editContext.kind != editNone {
+		t.Errorf("editContext kind = %v, want it cleared", app.editContext.kind)
+	}
+}
+
+func TestTextAreaCancelClearsEditContext(t *testing.T) {
+	t.Parallel()
+	app, _ := newCommentApp(t)
+	app.startNewComment()
+
+	app.Update(components.TextAreaCancelledMsg{})
+
+	if app.editContext.kind != editNone {
+		t.Errorf("editContext kind = %v, want it cleared on cancel", app.editContext.kind)
+	}
+}
+
+func TestTextAreaHandoffKeepsEditContext(t *testing.T) {
+	t.Parallel()
+	app, _ := newCommentApp(t)
+	app.startNewComment()
+
+	_, cmd := app.handleTextAreaHandoff("draft body")
+
+	if cmd == nil {
+		t.Fatal("the handoff did not launch the editor")
+	}
+	if app.editContext.kind != editCommentNew {
+		t.Errorf("editContext kind = %v, want it preserved across the handoff", app.editContext.kind)
+	}
+}

--- a/pkg/tui/components/inputmodal_test.go
+++ b/pkg/tui/components/inputmodal_test.go
@@ -190,7 +190,7 @@ func TestInputModal_RenderDrawsOnBackground(t *testing.T) {
 func TestInputModal_RenderInvisibleReturnsBackground(t *testing.T) {
 	t.Parallel()
 	m := NewInputModal()
-	bg := "background"
+	bg := testBackground
 	out := m.Render(bg, 80, 24)
 	testkit.AssertEqual(t, "bg passthrough", out, bg)
 }

--- a/pkg/tui/components/textareamodal.go
+++ b/pkg/tui/components/textareamodal.go
@@ -1,0 +1,266 @@
+package components
+
+import (
+	"strconv"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/textfuel/lazyjira/v2/pkg/tui/theme"
+)
+
+// TextAreaConfirmedMsg carries the text the user submitted.
+type TextAreaConfirmedMsg struct{ Text string }
+
+// TextAreaCancelledMsg is sent when the user dismisses the popup.
+type TextAreaCancelledMsg struct{}
+
+// TextAreaHandoffMsg asks the app to reopen the current text in $EDITOR.
+type TextAreaHandoffMsg struct{ Text string }
+
+const (
+	textAreaMinLines = 5
+	textAreaMaxLines = 14
+)
+
+// TextAreaModal is a multi-line text popup.
+//
+// Enter inserts a newline, so submitting needs its own key: ctrl+d (and
+// ctrl+s) send, esc cancels, and ctrl+e hands the buffer to $EDITOR for
+// anything longer than a couple of paragraphs.
+type TextAreaModal struct {
+	title         string
+	lines         []string
+	row, col      int // cursor, in runes
+	offset        int // first visible line
+	visible       bool
+	width, height int
+}
+
+func NewTextAreaModal() TextAreaModal {
+	return TextAreaModal{}
+}
+
+// Show opens the popup with prefill as its initial content, cursor at the end.
+func (m *TextAreaModal) Show(title, prefill string) {
+	m.title = title
+	m.lines = strings.Split(prefill, "\n")
+	m.row = len(m.lines) - 1
+	m.col = len([]rune(m.lines[m.row]))
+	m.offset = 0
+	m.visible = true
+}
+
+func (m *TextAreaModal) Hide()           { m.visible = false }
+func (m *TextAreaModal) IsVisible() bool { return m.visible }
+func (m *TextAreaModal) SetSize(w, h int) {
+	m.width = w
+	m.height = h
+}
+
+// Text returns the current buffer.
+func (m *TextAreaModal) Text() string { return strings.Join(m.lines, "\n") }
+
+func (m *TextAreaModal) Update(msg tea.Msg) (TextAreaModal, tea.Cmd) {
+	if !m.visible {
+		return *m, nil
+	}
+	key, ok := msg.(tea.KeyMsg)
+	if !ok {
+		return *m, nil
+	}
+
+	switch key.Type {
+	case tea.KeyCtrlD, tea.KeyCtrlS:
+		m.visible = false
+		text := m.Text()
+		return *m, func() tea.Msg { return TextAreaConfirmedMsg{Text: text} }
+	case tea.KeyEsc:
+		m.visible = false
+		return *m, func() tea.Msg { return TextAreaCancelledMsg{} }
+	case tea.KeyCtrlE:
+		m.visible = false
+		text := m.Text()
+		return *m, func() tea.Msg { return TextAreaHandoffMsg{Text: text} }
+	case tea.KeyEnter:
+		m.splitLine()
+	case tea.KeyBackspace:
+		m.backspace()
+	case tea.KeyDelete:
+		m.deleteForward()
+	case tea.KeyLeft:
+		m.moveLeft()
+	case tea.KeyRight:
+		m.moveRight()
+	case tea.KeyUp:
+		m.moveVertical(-1)
+	case tea.KeyDown:
+		m.moveVertical(1)
+	case tea.KeyHome, tea.KeyCtrlA:
+		m.col = 0
+	case tea.KeyEnd:
+		m.col = m.lineLen(m.row)
+	case tea.KeyCtrlU:
+		m.lines[m.row] = string([]rune(m.lines[m.row])[m.col:])
+		m.col = 0
+	case tea.KeyCtrlK:
+		m.lines[m.row] = string([]rune(m.lines[m.row])[:m.col])
+	case tea.KeySpace:
+		m.insert(" ")
+	case tea.KeyRunes:
+		m.insert(string(key.Runes))
+	default:
+	}
+	return *m, nil
+}
+
+func (m *TextAreaModal) lineLen(row int) int { return len([]rune(m.lines[row])) }
+
+func (m *TextAreaModal) insert(s string) {
+	runes := []rune(m.lines[m.row])
+	m.lines[m.row] = string(runes[:m.col]) + s + string(runes[m.col:])
+	m.col += len([]rune(s))
+}
+
+func (m *TextAreaModal) splitLine() {
+	runes := []rune(m.lines[m.row])
+	head, tail := string(runes[:m.col]), string(runes[m.col:])
+	m.lines = append(m.lines[:m.row], append([]string{head, tail}, m.lines[m.row+1:]...)...)
+	m.row++
+	m.col = 0
+}
+
+func (m *TextAreaModal) backspace() {
+	if m.col > 0 {
+		runes := []rune(m.lines[m.row])
+		m.lines[m.row] = string(runes[:m.col-1]) + string(runes[m.col:])
+		m.col--
+		return
+	}
+	if m.row == 0 {
+		return
+	}
+	// Joining with the line above puts the cursor at the seam.
+	m.col = m.lineLen(m.row - 1)
+	m.lines[m.row-1] += m.lines[m.row]
+	m.lines = append(m.lines[:m.row], m.lines[m.row+1:]...)
+	m.row--
+}
+
+func (m *TextAreaModal) deleteForward() {
+	runes := []rune(m.lines[m.row])
+	if m.col < len(runes) {
+		m.lines[m.row] = string(runes[:m.col]) + string(runes[m.col+1:])
+		return
+	}
+	if m.row < len(m.lines)-1 {
+		m.lines[m.row] += m.lines[m.row+1]
+		m.lines = append(m.lines[:m.row+1], m.lines[m.row+2:]...)
+	}
+}
+
+func (m *TextAreaModal) moveLeft() {
+	switch {
+	case m.col > 0:
+		m.col--
+	case m.row > 0:
+		m.row--
+		m.col = m.lineLen(m.row)
+	}
+}
+
+func (m *TextAreaModal) moveRight() {
+	switch {
+	case m.col < m.lineLen(m.row):
+		m.col++
+	case m.row < len(m.lines)-1:
+		m.row++
+		m.col = 0
+	}
+}
+
+func (m *TextAreaModal) moveVertical(delta int) {
+	target := m.row + delta
+	if target < 0 || target >= len(m.lines) {
+		return
+	}
+	m.row = target
+	m.col = min(m.col, m.lineLen(m.row))
+}
+
+// visibleLines is how many text rows the popup shows at the current height.
+func (m *TextAreaModal) visibleLines() int {
+	budget := textAreaMaxLines
+	if m.height > 0 {
+		budget = min(budget, max(m.height-6, textAreaMinLines))
+	}
+	return max(min(budget, max(len(m.lines), textAreaMinLines)), 1)
+}
+
+func (m *TextAreaModal) View() string {
+	if !m.visible {
+		return ""
+	}
+
+	contentW := min(max(m.width*7/10, 40), max(m.width-4, 20))
+	innerW := contentW - 2
+	visible := m.visibleLines()
+
+	// Keep the cursor line on screen.
+	if m.row < m.offset {
+		m.offset = m.row
+	} else if m.row >= m.offset+visible {
+		m.offset = m.row - visible + 1
+	}
+	m.offset = min(max(m.offset, 0), max(len(m.lines)-visible, 0))
+
+	cursorStyle := lipgloss.NewStyle().Foreground(theme.ColorCyan)
+	rendered := make([]string, 0, visible)
+	for i := m.offset; i < m.offset+visible; i++ {
+		if i >= len(m.lines) {
+			rendered = append(rendered, strings.Repeat(" ", innerW))
+			continue
+		}
+		line := m.lines[i]
+		if i == m.row {
+			runes := []rune(line)
+			switch {
+			case m.col >= len(runes):
+				line = string(runes) + cursorStyle.Render("█")
+			default:
+				line = string(runes[:m.col]) + cursorStyle.Render(string(runes[m.col])) + string(runes[m.col+1:])
+			}
+		}
+		line = TruncateEnd(line, innerW)
+		if w := lipgloss.Width(line); w < innerW {
+			line += strings.Repeat(" ", innerW-w)
+		}
+		rendered = append(rendered, line)
+	}
+
+	footer := "ctrl+d send · ctrl+e editor · esc cancel"
+	if len(m.lines) > visible {
+		footer = strconv.Itoa(m.row+1) + "/" + strconv.Itoa(len(m.lines)) + " · " + footer
+	}
+	return RenderPanelFull(m.title, footer, strings.Join(rendered, "\n"), contentW, visible, true, nil)
+}
+
+func (m *TextAreaModal) Intercept(msg tea.Msg) (tea.Cmd, bool) {
+	if !m.visible {
+		return nil, false
+	}
+	if _, ok := msg.(tea.KeyMsg); ok {
+		updated, cmd := m.Update(msg)
+		*m = updated
+		return cmd, true
+	}
+	return nil, false
+}
+
+func (m *TextAreaModal) Render(bg string, w, h int) string {
+	if !m.visible {
+		return bg
+	}
+	return centerOverlay(bg, m.View(), w, h)
+}

--- a/pkg/tui/components/textareamodal_test.go
+++ b/pkg/tui/components/textareamodal_test.go
@@ -1,0 +1,269 @@
+package components
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// testBackground stands in for whatever the app already rendered underneath
+// an overlay.
+const testBackground = "background"
+
+func taKey(t tea.KeyType) tea.KeyMsg { return tea.KeyMsg{Type: t} }
+func taRunes(s string) tea.KeyMsg    { return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(s)} }
+func taSend(m *TextAreaModal, k tea.KeyMsg) tea.Cmd {
+	updated, cmd := m.Update(k)
+	*m = updated
+	return cmd
+}
+
+func taType(m *TextAreaModal, s string) {
+	for _, r := range s {
+		if r == '\n' {
+			taSend(m, taKey(tea.KeyEnter))
+			continue
+		}
+		if r == ' ' {
+			taSend(m, taKey(tea.KeySpace))
+			continue
+		}
+		taSend(m, taRunes(string(r)))
+	}
+}
+
+func newShownTextArea(prefill string) *TextAreaModal {
+	m := NewTextAreaModal()
+	m.SetSize(80, 24)
+	m.Show("New comment", prefill)
+	return &m
+}
+
+func TestTextAreaShowStartsWithCursorAtEnd(t *testing.T) {
+	t.Parallel()
+	m := newShownTextArea("hello")
+
+	if !m.IsVisible() {
+		t.Fatal("modal is not visible after Show")
+	}
+	taType(m, "!")
+	if got := m.Text(); got != "hello!" {
+		t.Errorf("Text = %q, want the cursor to have started at the end", got)
+	}
+}
+
+func TestTextAreaEnterInsertsNewline(t *testing.T) {
+	t.Parallel()
+	m := newShownTextArea("")
+	taType(m, "one\ntwo")
+
+	if got := m.Text(); got != "one\ntwo" {
+		t.Errorf("Text = %q", got)
+	}
+	if !m.IsVisible() {
+		t.Error("enter closed the popup; it must insert a newline instead")
+	}
+}
+
+func TestTextAreaCtrlDConfirms(t *testing.T) {
+	t.Parallel()
+	m := newShownTextArea("")
+	taType(m, "ship it")
+
+	cmd := taSend(m, taKey(tea.KeyCtrlD))
+	if cmd == nil {
+		t.Fatal("ctrl+d produced no message")
+	}
+	msg, ok := cmd().(TextAreaConfirmedMsg)
+	if !ok {
+		t.Fatalf("message = %T, want TextAreaConfirmedMsg", cmd())
+	}
+	if msg.Text != "ship it" {
+		t.Errorf("Text = %q", msg.Text)
+	}
+	if m.IsVisible() {
+		t.Error("the popup stayed open after confirming")
+	}
+}
+
+func TestTextAreaCtrlSAlsoConfirms(t *testing.T) {
+	t.Parallel()
+	m := newShownTextArea("body")
+
+	cmd := taSend(m, taKey(tea.KeyCtrlS))
+	if _, ok := cmd().(TextAreaConfirmedMsg); !ok {
+		t.Errorf("ctrl+s produced %T, want TextAreaConfirmedMsg", cmd())
+	}
+}
+
+func TestTextAreaEscCancels(t *testing.T) {
+	t.Parallel()
+	m := newShownTextArea("draft")
+
+	cmd := taSend(m, taKey(tea.KeyEsc))
+	if _, ok := cmd().(TextAreaCancelledMsg); !ok {
+		t.Errorf("message = %T, want TextAreaCancelledMsg", cmd())
+	}
+	if m.IsVisible() {
+		t.Error("esc left the popup open")
+	}
+}
+
+func TestTextAreaCtrlEHandsOffToEditor(t *testing.T) {
+	t.Parallel()
+	m := newShownTextArea("")
+	taType(m, "long text")
+
+	cmd := taSend(m, taKey(tea.KeyCtrlE))
+	msg, ok := cmd().(TextAreaHandoffMsg)
+	if !ok {
+		t.Fatalf("message = %T, want TextAreaHandoffMsg", cmd())
+	}
+	if msg.Text != "long text" {
+		t.Errorf("handoff text = %q, want the current buffer", msg.Text)
+	}
+	if m.IsVisible() {
+		t.Error("the popup stayed open while handing off to the editor")
+	}
+}
+
+func TestTextAreaBackspaceJoinsLines(t *testing.T) {
+	t.Parallel()
+	m := newShownTextArea("")
+	taType(m, "ab\ncd")
+
+	taSend(m, taKey(tea.KeyHome))
+	taSend(m, taKey(tea.KeyBackspace))
+
+	if got := m.Text(); got != "abcd" {
+		t.Errorf("Text = %q, want the lines joined", got)
+	}
+	// The cursor should sit at the seam, so typing lands between b and c.
+	taType(m, "-")
+	if got := m.Text(); got != "ab-cd" {
+		t.Errorf("Text = %q, want the cursor left at the join point", got)
+	}
+}
+
+func TestTextAreaBackspaceAtStartIsNoOp(t *testing.T) {
+	t.Parallel()
+	m := newShownTextArea("abc")
+	taSend(m, taKey(tea.KeyHome))
+	taSend(m, taKey(tea.KeyBackspace))
+
+	if got := m.Text(); got != "abc" {
+		t.Errorf("Text = %q, want it untouched at the very start", got)
+	}
+}
+
+func TestTextAreaDeleteForwardJoinsLines(t *testing.T) {
+	t.Parallel()
+	m := newShownTextArea("ab\ncd")
+	taSend(m, taKey(tea.KeyUp))
+	taSend(m, taKey(tea.KeyEnd))
+	taSend(m, taKey(tea.KeyDelete))
+
+	if got := m.Text(); got != "abcd" {
+		t.Errorf("Text = %q", got)
+	}
+}
+
+func TestTextAreaVerticalMovementClampsColumn(t *testing.T) {
+	t.Parallel()
+	m := newShownTextArea("short\nmuch longer line")
+	// Cursor is at the end of the long line; going up must clamp.
+	taSend(m, taKey(tea.KeyUp))
+	taType(m, "!")
+
+	if got := m.Text(); got != "short!\nmuch longer line" {
+		t.Errorf("Text = %q, want the column clamped to the shorter line", got)
+	}
+}
+
+func TestTextAreaVerticalMovementStopsAtEdges(t *testing.T) {
+	t.Parallel()
+	m := newShownTextArea("only line")
+	taSend(m, taKey(tea.KeyUp))
+	taSend(m, taKey(tea.KeyDown))
+	taType(m, "!")
+
+	if got := m.Text(); !strings.HasSuffix(got, "!") {
+		t.Errorf("Text = %q, want the cursor still on the single line", got)
+	}
+}
+
+func TestTextAreaHorizontalMovementWrapsLines(t *testing.T) {
+	t.Parallel()
+	m := newShownTextArea("ab\ncd")
+	taSend(m, taKey(tea.KeyHome))
+	taSend(m, taKey(tea.KeyLeft)) // to the end of the previous line
+	taType(m, "!")
+
+	if got := m.Text(); got != "ab!\ncd" {
+		t.Errorf("Text = %q, want left at column 0 to wrap to the line above", got)
+	}
+}
+
+func TestTextAreaCtrlUAndCtrlK(t *testing.T) {
+	t.Parallel()
+	m := newShownTextArea("hello world")
+	taSend(m, taKey(tea.KeyHome))
+	for range 6 {
+		taSend(m, taKey(tea.KeyRight))
+	}
+	taSend(m, taKey(tea.KeyCtrlU))
+	if got := m.Text(); got != "world" {
+		t.Errorf("after ctrl+u Text = %q", got)
+	}
+
+	taSend(m, taKey(tea.KeyCtrlK))
+	if got := m.Text(); got != "" {
+		t.Errorf("after ctrl+k Text = %q", got)
+	}
+}
+
+func TestTextAreaIgnoresInputWhenHidden(t *testing.T) {
+	t.Parallel()
+	m := NewTextAreaModal()
+	if cmd, handled := m.Intercept(taRunes("x")); handled || cmd != nil {
+		t.Error("a hidden popup intercepted a key")
+	}
+}
+
+func TestTextAreaViewShowsContentAndHints(t *testing.T) {
+	t.Parallel()
+	m := newShownTextArea("first line")
+	view := m.View()
+
+	for _, want := range []string{"New comment", "first line", "ctrl+d send", "esc cancel"} {
+		if !strings.Contains(view, want) {
+			t.Errorf("view is missing %q:\n%s", want, view)
+		}
+	}
+}
+
+func TestTextAreaViewScrollsToCursor(t *testing.T) {
+	t.Parallel()
+	m := newShownTextArea("")
+	m.SetSize(80, 14) // room for a handful of lines
+	for range 30 {
+		taType(m, "line")
+		taSend(m, taKey(tea.KeyEnter))
+	}
+	taType(m, "LAST")
+
+	view := m.View()
+	if !strings.Contains(view, "LAST") {
+		t.Errorf("the view did not scroll to the cursor line:\n%s", view)
+	}
+}
+
+func TestTextAreaRenderLeavesBackgroundWhenHidden(t *testing.T) {
+	t.Parallel()
+	m := NewTextAreaModal()
+	bg := testBackground
+	if got := m.Render(bg, 80, 24); got != bg {
+		t.Errorf("Render = %q, want the untouched background", got)
+	}
+}

--- a/pkg/tui/handlers_keys.go
+++ b/pkg/tui/handlers_keys.go
@@ -432,12 +432,10 @@ func (a *App) handleIssueAction(action Action) (tea.Model, tea.Cmd, bool) {
 			m, cmd := a.startCreateIssue()
 			return m, cmd, true
 		}
-		cur := a.currentIssue()
-		if cur == nil || a.side != sideRight || a.detailView.ActiveTab() != views.TabComments {
-			return a, nil, true
-		}
-		a.editContext = editCtx{kind: editCommentNew, issueKey: cur.Key}
-		return a, launchEditor("", ".md"), true
+		return a.startNewComment()
+
+	case ActReplyComment:
+		return a.startReplyComment()
 
 	case ActPriority:
 		if cur := a.currentIssue(); cur != nil {

--- a/pkg/tui/handlers_keys_more_test.go
+++ b/pkg/tui/handlers_keys_more_test.go
@@ -524,7 +524,7 @@ func TestHandleIssueAction_MoreBranches(t *testing.T) {
 			wantCmd: true,
 		},
 		{
-			name:   "new on comments tab launches comment editor",
+			name:   "new on comments tab opens the comment popup",
 			action: ActNew,
 			setup: func(app *App, fake *jiratest.FakeClient) {
 				app.side = sideRight
@@ -535,11 +535,13 @@ func TestHandleIssueAction_MoreBranches(t *testing.T) {
 				app.detailView.SetIssue(issue)
 				app.detailView.SetActiveTab(views.TabComments)
 			},
-			wantCmd: true,
 			assert: func(t *testing.T, app *App) {
 				t.Helper()
 				if app.editContext.kind != editCommentNew {
 					t.Errorf("editContext kind = %v, want editCommentNew", app.editContext.kind)
+				}
+				if !app.textModal.IsVisible() {
+					t.Error("the comment popup was not shown")
 				}
 			},
 		},

--- a/pkg/tui/keybindings.go
+++ b/pkg/tui/keybindings.go
@@ -122,6 +122,7 @@ func (a *App) ContextBindings() []Binding {
 			bindings = append(bindings,
 				a.bind(ActEdit, "edit comment"),
 				a.bind(ActNew, "new comment"),
+				a.bind(ActReplyComment, "reply to comment"),
 			)
 		} else {
 			bindings = append(bindings,
@@ -264,6 +265,7 @@ func (a *App) helpBarItems() []components.HelpItem {
 			items = append(items,
 				components.HelpItem{Key: km.Keys(ActEdit), Description: "edit comment"},
 				components.HelpItem{Key: km.Keys(ActNew), Description: "new comment"},
+				components.HelpItem{Key: km.Keys(ActReplyComment), Description: "reply"},
 			)
 		default:
 			items = append(items,

--- a/pkg/tui/keymap.go
+++ b/pkg/tui/keymap.go
@@ -46,6 +46,10 @@ const (
 	ActCreateSubtask  Action = "createSubtask"
 	ActDuplicateIssue Action = "duplicateIssue"
 	ActShowParent     Action = "showParent"
+	// ActReplyComment opens a comment popup quoting the selected comment.
+	// Not bound to plain "r": that is refresh, and Match is global rather
+	// than per-context.
+	ActReplyComment Action = "replyComment"
 
 	ActNavDown     Action = "navDown"
 	ActNavUp       Action = "navUp"
@@ -99,6 +103,7 @@ func DefaultKeymap() Keymap {
 		ActDuplicateIssue: {"ctrl+n"},
 		ActCreateSubtask:  {"S"},
 		ActShowParent:     {"backspace"},
+		ActReplyComment:   {"ctrl+r"},
 
 		ActNavDown:     {"j", "down", "ctrl+j"},
 		ActNavUp:       {"k", "up", "ctrl+k"},
@@ -157,6 +162,7 @@ func KeymapFromConfig(kcfg config.KeybindingConfig) Keymap {
 	set(ActDetailScrollUp, kcfg.Detail.ScrollUp)
 	set(ActDetailHalfDown, kcfg.Detail.HalfPageDown)
 	set(ActDetailHalfUp, kcfg.Detail.HalfPageUp)
+	set(ActReplyComment, kcfg.Detail.ReplyComment)
 	// Navigation
 	set(ActNavDown, kcfg.Navigation.Down)
 	set(ActNavUp, kcfg.Navigation.Up)

--- a/pkg/tui/keymap_test.go
+++ b/pkg/tui/keymap_test.go
@@ -39,3 +39,29 @@ func TestKeymap_MatchUnknownReturnsEmpty(t *testing.T) {
 	testkit.AssertEqual(t, "unknown key", keymap.Match("this-key-is-unbound"), Action(""))
 	testkit.AssertEqual(t, "unknown nav key", keymap.MatchNav("this-key-is-unbound"), components.NavNone)
 }
+
+// TestDefaultKeymapHasNoDuplicateKeys guards a silent failure mode: Keymap.Match
+// iterates a map, so a key bound to two actions resolves to a random one of
+// them, differently on each run.
+func TestDefaultKeymapHasNoDuplicateKeys(t *testing.T) {
+	t.Parallel()
+	owners := map[string][]Action{}
+	for action, keys := range DefaultKeymap() {
+		for _, key := range keys {
+			owners[key] = append(owners[key], action)
+		}
+	}
+	for key, actions := range owners {
+		if len(actions) > 1 {
+			t.Errorf("key %q is bound to %v; Match would pick one at random", key, actions)
+		}
+	}
+}
+
+func TestKeymapFromConfigOverridesReplyComment(t *testing.T) {
+	t.Parallel()
+	km := KeymapFromConfig(config.KeybindingConfig{Detail: config.DetailKeys{ReplyComment: "A"}})
+	if got := km.Keys(ActReplyComment); got != "A" {
+		t.Errorf("replyComment = %q, want A", got)
+	}
+}


### PR DESCRIPTION
## Summary
- Adds a multi-line popup for writing comments instead of a single-line prompt.
- Adds a key to reply to the selected comment, prefilled with a quoted excerpt and a mention of its author.
- The popup can hand off to $EDITOR for longer comments.

## Test plan
- `make check` passes.
- Added unit tests for the new comment popup, reply prefill, and mention resolution for multi-word names.

Closes #123