### PR TITLE
Add a kanban board for each agile board of the project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Added
+
+- Kanban boards. They fill the detail panel whenever no task is open: selecting a project shows one, `enter` on a card opens that task, and `esc` brings the board back. A project's agile boards each appear with their own columns and their own issues, as configured in Jira -- including columns that collect several statuses -- and `[`/`]` switches between them. A project with no agile board falls back to one column per project status. The board mirrors what the issue list is showing, so a narrower tab such as Assigned or a `/` filter narrows the board with it. `f` filters by assignee on top of that, with the current user and an unassigned bucket pinned on top; the choice is remembered per project
+
 ## [2.19.2] - 2026-07-08
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ make build-demo
 
 - **JQL search** with autocomplete, syntax highlighting, and persistent history
 - **4-panel layout** - issues, projects, detail, status - with vim-style navigation
+- **Kanban boards** - every agile board of the project with its own columns, switchable with `[`/`]` and filterable by assignee
 - **Inline editing** - transitions, priority, assignee, labels, comments, description (`$EDITOR`)
 - **Configurable** - custom keybindings (including navigation keys), JQL tabs, issue columns, custom fields
 - **Themes** - default ANSI palette plus all four Catppuccin flavors (Latte, Frappé, Macchiato, Mocha)
@@ -200,6 +201,7 @@ Press `?` inside the app for all keybindings.
 - [x] Searchable keybindings help popup
 - [x] Scroll detail panel without switching focus
 - [x] Create subtasks from TUI
+- [x] Kanban board per agile board, with assignee filter
 - [ ] Link issues (add/remove issue links)
 - [ ] CLI mode (non-interactive commands for scripting and automation)
 - [ ] Robust issue type changer (handle subtask/parent unlinking, field validation)

--- a/docs/Config.md
+++ b/docs/Config.md
@@ -393,6 +393,7 @@ keybinding:
     transition: "t"
     browser: "o"
     createBranch: "b"
+    filterAssignees: "f"
 ```
 
 Only include keys you want to change. Missing keys keep their defaults.

--- a/docs/Keybindings.md
+++ b/docs/Keybindings.md
@@ -42,6 +42,33 @@ Detail scroll keys (`J`/`K`/`ctrl+f`/`ctrl+b`) can be remapped via `keybinding.d
 | `s` | JQL search |
 | `x` | Close JQL tab |
 
+## Kanban board
+
+The board of the active project fills the detail panel whenever no task is
+open. Selecting a project shows it, `enter` on a card opens that task, and
+`esc` brings the board back.
+
+A project can have several agile boards. Each is shown with its own columns
+and its own issues, exactly as configured in Jira, and they appear as tabs in
+the panel title with the active one in brackets. A project with no agile board
+falls back to one column per project status, filled from the active issue tab.
+
+The board mirrors whatever the issue list is showing: switching to a narrower
+tab such as **Assigned**, or typing a `/` filter, narrows the board with it. A
+board card the list is not showing drops off the board.
+
+| Key | Action |
+| --- | --- |
+| `[` / `]` | Previous / next board of the project |
+| `h` `j` `k` `l` | Move between cards and columns |
+| `enter` / `space` | Open the highlighted task |
+| `f` | Filter the board by assignee (works from any panel while the board is up) |
+| `esc` | Back to the left panels |
+
+In the assignee filter, `enter` applies the highlighted person; `space` ticks
+several before confirming. The first row, **(Everyone)**, clears the filter.
+The choice is remembered per project.
+
 ## Help popup
 
 | Key | Action |

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -166,6 +166,8 @@ type IssueKeys struct {
 	CreateBranch  string `yaml:"createBranch"`
 	CreateIssue   string `yaml:"createIssue"`
 	CreateSubtask string `yaml:"createSubtask"`
+	// FilterAssignees filters the project board by assignee.
+	FilterAssignees string `yaml:"filterAssignees"`
 }
 
 type ProjectKeys struct {

--- a/pkg/jira/client.go
+++ b/pkg/jira/client.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"sort"
 	"strings"
 	"time"
 )
@@ -24,11 +25,17 @@ type ClientInterface interface {
 	AssignIssue(ctx context.Context, issueKey, accountID string) error
 	GetProjects(ctx context.Context) ([]Project, error)
 	GetBoards(ctx context.Context) ([]Board, error)
+	GetBoardConfiguration(ctx context.Context, boardID int) (*BoardConfiguration, error)
 	GetBoardIssues(ctx context.Context, boardID int, jql string) ([]Issue, error)
 	GetChildren(ctx context.Context, parentKey string) ([]Issue, error)
 	UpdateIssue(ctx context.Context, issueKey string, fields map[string]any) error
 	RemoveIssueParent(ctx context.Context, issueKey string) error
 	GetPriorities(ctx context.Context) ([]Priority, error)
+	GetProjectStatuses(ctx context.Context, projectKey string) ([]Status, error)
+	GetIssueLinkTypes(ctx context.Context) ([]IssueLinkType, error)
+	CreateIssueLink(ctx context.Context, typeName, inwardKey, outwardKey string) error
+	DeleteIssueLink(ctx context.Context, linkID string) error
+	DeleteIssue(ctx context.Context, issueKey string, deleteSubtasks bool) error
 	CreateIssue(ctx context.Context, fields map[string]any) (*Issue, error)
 	GetCreateMeta(ctx context.Context, projectKey, issueTypeID string) ([]CreateMetaField, error)
 	GetComments(ctx context.Context, issueKey string) ([]Comment, error)
@@ -298,7 +305,7 @@ func (c *Client) fillSprintFromCustomField(issue *Issue, raw map[string]json.Raw
 
 func (c *Client) SearchIssues(ctx context.Context, jql string, startAt, maxResults int) (*SearchResult, error) {
 	sprintField := c.SprintFieldID()
-	fields := "summary,description,status,priority,assignee,reporter,labels,components," + sprintField + ",issuetype,created,updated,subtasks,issuelinks,parent"
+	fields := "summary,description,status,priority,assignee,reporter,labels,components," + sprintField + ",issuetype,created,updated,subtasks,issuelinks,parent,timetracking"
 	// Default sprint custom-field ids: 10020 (Cloud), 10010 (older Server/DC).
 	if sprintField == sprintFieldAlias {
 		fields += ",customfield_10010,customfield_10020"
@@ -479,6 +486,38 @@ func (c *Client) GetBoards(ctx context.Context) ([]Board, error) {
 	return boards, nil
 }
 
+// GetBoardConfiguration returns the column layout of a board. Columns that map
+// to no status are dropped: they can hold no card.
+func (c *Client) GetBoardConfiguration(ctx context.Context, boardID int) (*BoardConfiguration, error) {
+	var raw struct {
+		ColumnConfig struct {
+			Columns []struct {
+				Name     string `json:"name"`
+				Statuses []struct {
+					ID string `json:"id"`
+				} `json:"statuses"`
+			} `json:"columns"`
+		} `json:"columnConfig"`
+	}
+	path := fmt.Sprintf("/board/%d/configuration", boardID)
+	if err := c.doAgile(ctx, path, &raw); err != nil {
+		return nil, fmt.Errorf("get board %d configuration: %w", boardID, err)
+	}
+
+	config := &BoardConfiguration{BoardID: boardID}
+	for _, col := range raw.ColumnConfig.Columns {
+		if len(col.Statuses) == 0 {
+			continue
+		}
+		ids := make([]string, 0, len(col.Statuses))
+		for _, s := range col.Statuses {
+			ids = append(ids, s.ID)
+		}
+		config.Columns = append(config.Columns, BoardColumn{Name: col.Name, StatusIDs: ids})
+	}
+	return config, nil
+}
+
 func (c *Client) GetBoardIssues(ctx context.Context, boardID int, jql string) ([]Issue, error) {
 	const batchSize = 50
 	const maxPages = 50
@@ -542,6 +581,96 @@ func (c *Client) GetPriorities(ctx context.Context) ([]Priority, error) {
 		return nil, fmt.Errorf("get priorities: %w", err)
 	}
 	return raw, nil
+}
+
+// GetProjectStatuses returns the statuses reachable in a project, deduplicated
+// across issue types and ordered To Do → In Progress → Done. These are the
+// board columns: unlike GetTransitions they do not depend on a current issue.
+func (c *Client) GetProjectStatuses(ctx context.Context, projectKey string) ([]Status, error) {
+	var raw []struct {
+		Statuses []statusResponse `json:"statuses"`
+	}
+	if err := c.do(ctx, http.MethodGet, "/project/"+projectKey+"/statuses", nil, &raw); err != nil {
+		return nil, fmt.Errorf("get statuses of project %s: %w", projectKey, err)
+	}
+
+	seen := make(map[string]bool)
+	var out []Status
+	for _, byType := range raw {
+		for i := range byType.Statuses {
+			s := byType.Statuses[i].toStatus()
+			if s == nil || seen[s.ID] {
+				continue
+			}
+			seen[s.ID] = true
+			out = append(out, *s)
+		}
+	}
+	SortStatuses(out)
+	return out, nil
+}
+
+// SortStatuses orders statuses by workflow category, keeping the server order
+// within each category.
+func SortStatuses(statuses []Status) {
+	sort.SliceStable(statuses, func(i, j int) bool {
+		return statusCategoryRank(statuses[i].CategoryKey) < statusCategoryRank(statuses[j].CategoryKey)
+	})
+}
+
+// statusCategoryRank maps a Jira status category key to a column position.
+// Unknown categories sort with "in progress" so they stay visible in the middle.
+func statusCategoryRank(key string) int {
+	switch key {
+	case "new":
+		return 0
+	case "done":
+		return 2
+	default:
+		return 1
+	}
+}
+
+func (c *Client) GetIssueLinkTypes(ctx context.Context) ([]IssueLinkType, error) {
+	var raw struct {
+		IssueLinkTypes []IssueLinkType `json:"issueLinkTypes"`
+	}
+	if err := c.do(ctx, http.MethodGet, "/issueLinkType", nil, &raw); err != nil {
+		return nil, fmt.Errorf("get issue link types: %w", err)
+	}
+	return raw.IssueLinkTypes, nil
+}
+
+// CreateIssueLink links two issues. The direction is carried by the argument
+// order: inwardKey is the issue the link points at ("is blocked by" side),
+// outwardKey the one it points from ("blocks" side).
+func (c *Client) CreateIssueLink(ctx context.Context, typeName, inwardKey, outwardKey string) error {
+	body := map[string]any{
+		"type":         map[string]string{"name": typeName},
+		"inwardIssue":  map[string]string{"key": inwardKey},
+		"outwardIssue": map[string]string{"key": outwardKey},
+	}
+	if err := c.do(ctx, http.MethodPost, "/issueLink", body, nil); err != nil {
+		return fmt.Errorf("create %s link %s -> %s: %w", typeName, outwardKey, inwardKey, err)
+	}
+	return nil
+}
+
+func (c *Client) DeleteIssueLink(ctx context.Context, linkID string) error {
+	if err := c.do(ctx, http.MethodDelete, "/issueLink/"+linkID, nil, nil); err != nil {
+		return fmt.Errorf("delete issue link %s: %w", linkID, err)
+	}
+	return nil
+}
+
+// DeleteIssue removes an issue. Jira rejects the call with 400 when the issue
+// has subtasks and deleteSubtasks is false, so callers can retry after asking.
+func (c *Client) DeleteIssue(ctx context.Context, issueKey string, deleteSubtasks bool) error {
+	path := fmt.Sprintf("/issue/%s?deleteSubtasks=%t", issueKey, deleteSubtasks)
+	if err := c.do(ctx, http.MethodDelete, path, nil, nil); err != nil {
+		return fmt.Errorf("delete issue %s: %w", issueKey, err)
+	}
+	return nil
 }
 
 func (c *Client) CreateIssue(ctx context.Context, fields map[string]any) (*Issue, error) {
@@ -861,22 +990,23 @@ type issueResponse struct {
 }
 
 type issueFieldsResponse struct {
-	Summary     string                     `json:"summary"`
-	Description any                        `json:"description"`
-	Status      *statusResponse            `json:"status"`
-	Priority    *Priority                  `json:"priority"`
-	Assignee    *userResponse              `json:"assignee"`
-	Reporter    *userResponse              `json:"reporter"`
-	Labels      []string                   `json:"labels"`
-	Components  []Component                `json:"components"`
-	Sprint      *Sprint                    `json:"sprint"`
-	IssueType   *IssueType                 `json:"issuetype"`
-	Parent      *issueResponse             `json:"parent"`
-	Created     JiraTime                   `json:"created"`
-	Updated     JiraTime                   `json:"updated"`
-	Subtasks    []issueResponse            `json:"subtasks"`
-	IssueLinks  []issueLinkResponse        `json:"issuelinks"`
-	RawExtra    map[string]json.RawMessage `json:"-"`
+	Summary      string                     `json:"summary"`
+	Description  any                        `json:"description"`
+	Status       *statusResponse            `json:"status"`
+	Priority     *Priority                  `json:"priority"`
+	Assignee     *userResponse              `json:"assignee"`
+	Reporter     *userResponse              `json:"reporter"`
+	Labels       []string                   `json:"labels"`
+	Components   []Component                `json:"components"`
+	Sprint       *Sprint                    `json:"sprint"`
+	IssueType    *IssueType                 `json:"issuetype"`
+	Parent       *issueResponse             `json:"parent"`
+	Created      JiraTime                   `json:"created"`
+	Updated      JiraTime                   `json:"updated"`
+	Subtasks     []issueResponse            `json:"subtasks"`
+	IssueLinks   []issueLinkResponse        `json:"issuelinks"`
+	TimeTracking *TimeTracking              `json:"timetracking"`
+	RawExtra     map[string]json.RawMessage `json:"-"`
 }
 
 func (f *issueFieldsResponse) UnmarshalJSON(data []byte) error {
@@ -928,6 +1058,11 @@ func (r *issueResponse) toIssue() Issue {
 		IssueType:  r.Fields.IssueType,
 		Created:    r.Fields.Created.Time,
 		Updated:    r.Fields.Updated.Time,
+	}
+
+	if !r.Fields.TimeTracking.IsZero() {
+		tt := *r.Fields.TimeTracking
+		issue.TimeTracking = &tt
 	}
 
 	if r.Fields.Status != nil {

--- a/pkg/jira/client_board_test.go
+++ b/pkg/jira/client_board_test.go
@@ -1,0 +1,208 @@
+package jira
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/textfuel/lazyjira/v2/pkg/internal/testkit"
+)
+
+const projectStatusesBody = `[
+  {"name":"Task","statuses":[
+    {"id":"3","name":"In Progress","statusCategory":{"key":"indeterminate"}},
+    {"id":"1","name":"To Do","statusCategory":{"key":"new"}}
+  ]},
+  {"name":"Bug","statuses":[
+    {"id":"5","name":"Done","statusCategory":{"key":"done"}},
+    {"id":"1","name":"To Do","statusCategory":{"key":"new"}}
+  ]}
+]`
+
+func TestGetProjectStatusesDeduplicatesAndOrdersByCategory(t *testing.T) {
+	t.Parallel()
+	client, recorded := newRecordingClient(t, cloudOpts(), testkit.StubResponse{
+		Status: http.StatusOK, Body: projectStatusesBody,
+	})
+
+	statuses, err := client.GetProjectStatuses(context.Background(), "PLAT")
+	if err != nil {
+		t.Fatalf("GetProjectStatuses: %v", err)
+	}
+
+	if recorded.Path != "/rest/api/3/project/PLAT/statuses" {
+		t.Errorf("path = %q", recorded.Path)
+	}
+
+	names := make([]string, 0, len(statuses))
+	for _, s := range statuses {
+		names = append(names, s.Name)
+	}
+	want := []string{"To Do", "In Progress", "Done"}
+	if len(names) != len(want) {
+		t.Fatalf("statuses = %v, want %v", names, want)
+	}
+	for i := range want {
+		if names[i] != want[i] {
+			t.Errorf("statuses = %v, want %v", names, want)
+			break
+		}
+	}
+	if statuses[0].CategoryKey != "new" {
+		t.Errorf("CategoryKey = %q, want new", statuses[0].CategoryKey)
+	}
+}
+
+func TestGetProjectStatusesWrapsAPIError(t *testing.T) {
+	t.Parallel()
+	client, _ := newRecordingClient(t, cloudOpts(), testkit.StubResponse{
+		Status: http.StatusNotFound, Body: `{"errorMessages":["No project could be found"]}`,
+	})
+
+	if _, err := client.GetProjectStatuses(context.Background(), errorTestProjectKey); err == nil {
+		t.Fatal("expected error for missing project")
+	} else if !strings.Contains(err.Error(), errorTestProjectKey) {
+		t.Errorf("error %q does not name the project", err)
+	}
+}
+
+func TestGetIssueLinkTypes(t *testing.T) {
+	t.Parallel()
+	client, recorded := newRecordingClient(t, cloudOpts(), testkit.StubResponse{
+		Status: http.StatusOK,
+		Body:   `{"issueLinkTypes":[{"id":"10000","name":"Blocks","inward":"is blocked by","outward":"blocks"}]}`,
+	})
+
+	types, err := client.GetIssueLinkTypes(context.Background())
+	if err != nil {
+		t.Fatalf("GetIssueLinkTypes: %v", err)
+	}
+	if recorded.Path != "/rest/api/3/issueLinkType" {
+		t.Errorf("path = %q", recorded.Path)
+	}
+	if len(types) != 1 || types[0].Name != "Blocks" || types[0].Outward != "blocks" {
+		t.Errorf("types = %+v", types)
+	}
+}
+
+func TestCreateIssueLinkSendsDirectionalPayload(t *testing.T) {
+	t.Parallel()
+	client, recorded := newRecordingClient(t, cloudOpts(), testkit.StubResponse{Status: http.StatusCreated})
+
+	if err := client.CreateIssueLink(context.Background(), "Blocks", "PLAT-2", "PLAT-1"); err != nil {
+		t.Fatalf("CreateIssueLink: %v", err)
+	}
+
+	if recorded.Method != http.MethodPost || recorded.Path != "/rest/api/3/issueLink" {
+		t.Errorf("%s %s", recorded.Method, recorded.Path)
+	}
+
+	var body struct {
+		Type         struct{ Name string } `json:"type"`
+		InwardIssue  struct{ Key string }  `json:"inwardIssue"`
+		OutwardIssue struct{ Key string }  `json:"outwardIssue"`
+	}
+	if err := json.Unmarshal(recorded.Body, &body); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if body.Type.Name != "Blocks" {
+		t.Errorf("type = %q", body.Type.Name)
+	}
+	if body.InwardIssue.Key != "PLAT-2" || body.OutwardIssue.Key != "PLAT-1" {
+		t.Errorf("inward = %q, outward = %q", body.InwardIssue.Key, body.OutwardIssue.Key)
+	}
+}
+
+func TestDeleteIssueLink(t *testing.T) {
+	t.Parallel()
+	client, recorded := newRecordingClient(t, cloudOpts(), testkit.StubResponse{Status: http.StatusNoContent})
+
+	if err := client.DeleteIssueLink(context.Background(), "10042"); err != nil {
+		t.Fatalf("DeleteIssueLink: %v", err)
+	}
+	if recorded.Method != http.MethodDelete || recorded.Path != "/rest/api/3/issueLink/10042" {
+		t.Errorf("%s %s", recorded.Method, recorded.Path)
+	}
+}
+
+func TestDeleteIssuePassesDeleteSubtasks(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name     string
+		subtasks bool
+		want     string
+	}{
+		{"without subtasks", false, "false"},
+		{"with subtasks", true, "true"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			client, recorded := newRecordingClient(t, cloudOpts(), testkit.StubResponse{Status: http.StatusNoContent})
+
+			if err := client.DeleteIssue(context.Background(), errorTestIssueKey, tc.subtasks); err != nil {
+				t.Fatalf("DeleteIssue: %v", err)
+			}
+			if recorded.Method != http.MethodDelete {
+				t.Errorf("method = %s", recorded.Method)
+			}
+			if recorded.Path != "/rest/api/3/issue/"+errorTestIssueKey {
+				t.Errorf("path = %q", recorded.Path)
+			}
+			if got := recorded.Query.Get("deleteSubtasks"); got != tc.want {
+				t.Errorf("deleteSubtasks = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestGetIssueParsesTimeTracking(t *testing.T) {
+	t.Parallel()
+	client, _ := newRecordingClient(t, cloudOpts(), testkit.StubResponse{
+		Status: http.StatusOK,
+		Body: `{"id":"1","key":"PLAT-1","fields":{"summary":"s","timetracking":
+		  {"originalEstimate":"2d","remainingEstimate":"4h","timeSpent":"1d 4h"}}}`,
+	})
+
+	issue, err := client.GetIssue(context.Background(), "PLAT-1")
+	if err != nil {
+		t.Fatalf("GetIssue: %v", err)
+	}
+	if issue.TimeTracking == nil {
+		t.Fatal("TimeTracking is nil")
+	}
+	if issue.TimeTracking.OriginalEstimate != "2d" || issue.TimeTracking.TimeSpent != "1d 4h" {
+		t.Errorf("TimeTracking = %+v", issue.TimeTracking)
+	}
+}
+
+func TestGetIssueLeavesTimeTrackingNilWhenEmpty(t *testing.T) {
+	t.Parallel()
+	client, _ := newRecordingClient(t, cloudOpts(), testkit.StubResponse{
+		Status: http.StatusOK,
+		Body:   `{"id":"1","key":"PLAT-1","fields":{"summary":"s","timetracking":{}}}`,
+	})
+
+	issue, err := client.GetIssue(context.Background(), "PLAT-1")
+	if err != nil {
+		t.Fatalf("GetIssue: %v", err)
+	}
+	if issue.TimeTracking != nil {
+		t.Errorf("TimeTracking = %+v, want nil for an empty object", issue.TimeTracking)
+	}
+}
+
+func TestSearchIssuesRequestsTimeTrackingField(t *testing.T) {
+	t.Parallel()
+	client, recorded := newRecordingClient(t, cloudOpts(), testkit.StubResponse{
+		Status: http.StatusOK, Body: `{"issues":[],"total":0,"maxResults":50,"startAt":0}`,
+	})
+
+	if _, err := client.SearchIssues(context.Background(), "project = PLAT", 0, 50); err != nil {
+		t.Fatalf("SearchIssues: %v", err)
+	}
+	if !strings.Contains(recorded.Query.Get("fields"), "timetracking") {
+		t.Errorf("fields = %q, want it to include timetracking", recorded.Query.Get("fields"))
+	}
+}

--- a/pkg/jira/demo.go
+++ b/pkg/jira/demo.go
@@ -333,12 +333,72 @@ func (d *DemoClient) UpdateComment(_ context.Context, issueKey, commentID string
 }
 func (d *DemoClient) AssignIssue(_ context.Context, _ string, _ string) error { return nil }
 func (d *DemoClient) GetBoards(_ context.Context) ([]Board, error) {
+	d.logRequest("GET", "/board")
+	// SHOP has two boards with different layouts, PLAT one, MOBI none: the
+	// project without a board exercises the status-derived fallback.
 	return []Board{
-		{ID: 1, Name: "SHOP Board", Type: "scrum", ProjectKey: "SHOP"},
+		{ID: 1, Name: "Delivery", Type: "scrum", ProjectKey: "SHOP"},
+		{ID: 2, Name: "Bugs", Type: "kanban", ProjectKey: "SHOP"},
+		{ID: 3, Name: "Platform", Type: "kanban", ProjectKey: "PLAT"},
 	}, nil
 }
-func (d *DemoClient) GetBoardIssues(_ context.Context, _ int, _ string) ([]Issue, error) {
-	return nil, nil
+
+// GetBoardConfiguration gives each demo board its own columns. Board 1 merges
+// In Progress and In Review into one column, which is the case a project's
+// status list cannot express.
+func (d *DemoClient) GetBoardConfiguration(_ context.Context, boardID int) (*BoardConfiguration, error) {
+	d.logRequest("GET", fmt.Sprintf("/board/%d/configuration", boardID))
+	switch boardID {
+	case 1:
+		return &BoardConfiguration{BoardID: 1, Columns: []BoardColumn{
+			{Name: "Backlog", StatusIDs: []string{"1"}},
+			{Name: "Doing", StatusIDs: []string{"3", "4"}},
+			{Name: "Shipped", StatusIDs: []string{"5"}},
+		}}, nil
+	case 2:
+		return &BoardConfiguration{BoardID: 2, Columns: []BoardColumn{
+			{Name: "Triage", StatusIDs: []string{"1"}},
+			{Name: "Fixing", StatusIDs: []string{"3"}},
+			{Name: "Verifying", StatusIDs: []string{"4"}},
+			{Name: "Closed", StatusIDs: []string{"5"}},
+		}}, nil
+	case 3:
+		return &BoardConfiguration{BoardID: 3, Columns: []BoardColumn{
+			{Name: "To Do", StatusIDs: []string{"1"}},
+			{Name: "In Progress", StatusIDs: []string{"3"}},
+			{Name: "In Review", StatusIDs: []string{"4"}},
+			{Name: "Done", StatusIDs: []string{"5"}},
+		}}, nil
+	}
+	return nil, fmt.Errorf("board %d not found", boardID)
+}
+
+// demoBoardProject maps a demo board to the project whose issues it carries.
+func demoBoardProject(boardID int) (projectKey string, bugsOnly bool) {
+	switch boardID {
+	case 1:
+		return "SHOP", false
+	case 2:
+		return "SHOP", true
+	case 3:
+		return "PLAT", false
+	}
+	return "", false
+}
+func (d *DemoClient) GetBoardIssues(_ context.Context, boardID int, _ string) ([]Issue, error) {
+	d.logRequest("GET", fmt.Sprintf("/board/%d/issue", boardID))
+	projectKey, bugsOnly := demoBoardProject(boardID)
+	if projectKey == "" {
+		return nil, fmt.Errorf("board %d not found", boardID)
+	}
+	var out []Issue
+	for _, iss := range d.issues[projectKey] {
+		if bugsOnly && (iss.IssueType == nil || iss.IssueType.Name != "Bug") {
+			continue
+		}
+		out = append(out, *iss)
+	}
+	return out, nil
 }
 func (d *DemoClient) UpdateIssue(_ context.Context, issueKey string, fields map[string]any) error {
 	d.logRequest("PUT", "/issue/"+issueKey)
@@ -414,6 +474,20 @@ func (d *DemoClient) UpdateIssue(_ context.Context, issueKey string, fields map[
 	}
 	if _, ok := fields["sprint"]; ok {
 		iss.Sprint = nil
+	}
+	if tt, ok := fields["timetracking"].(map[string]string); ok {
+		if iss.TimeTracking == nil {
+			iss.TimeTracking = &TimeTracking{}
+		}
+		if v, set := tt["originalEstimate"]; set {
+			iss.TimeTracking.OriginalEstimate = v
+		}
+		if v, set := tt["remainingEstimate"]; set {
+			iss.TimeTracking.RemainingEstimate = v
+		}
+		if iss.TimeTracking.IsZero() {
+			iss.TimeTracking = nil
+		}
 	}
 	if p, ok := fields["parent"].(map[string]string); ok {
 		if parent, found := d.issueIndex[p["key"]]; found {
@@ -575,6 +649,133 @@ func (d *DemoClient) GetPriorities(_ context.Context) ([]Priority, error) {
 		{ID: "4", Name: "Low"},
 	}, nil
 }
+
+// demoStatuses are the board columns of every demo project, matching the
+// statuses transitionsForStatus can reach.
+func demoStatuses() []Status {
+	return []Status{
+		{ID: "1", Name: "To Do", Description: "Not started yet", CategoryKey: "new"},
+		{ID: "3", Name: "In Progress", Description: "Work has begun on this issue", CategoryKey: "indeterminate"},
+		{ID: "4", Name: "In Review", Description: "Code is ready for peer review", CategoryKey: "indeterminate"},
+		{ID: "5", Name: "Done", Description: "Issue is resolved and verified", CategoryKey: "done"},
+	}
+}
+
+func (d *DemoClient) GetProjectStatuses(_ context.Context, projectKey string) ([]Status, error) {
+	d.logRequest("GET", "/project/"+projectKey+"/statuses")
+	return demoStatuses(), nil
+}
+
+func (d *DemoClient) GetIssueLinkTypes(_ context.Context) ([]IssueLinkType, error) {
+	d.logRequest("GET", "/issueLinkType")
+	return []IssueLinkType{
+		{ID: "10000", Name: "Blocks", Inward: "is blocked by", Outward: "blocks"},
+		{ID: "10001", Name: "Relates", Inward: "relates to", Outward: "relates to"},
+		{ID: "10002", Name: "Duplicate", Inward: "is duplicated by", Outward: "duplicates"},
+	}, nil
+}
+
+func (d *DemoClient) CreateIssueLink(ctx context.Context, typeName, inwardKey, outwardKey string) error {
+	d.logRequest("POST", "/issueLink")
+	inward, ok := d.issueIndex[inwardKey]
+	if !ok {
+		return fmt.Errorf("issue %s not found", inwardKey)
+	}
+	outward, ok := d.issueIndex[outwardKey]
+	if !ok {
+		return fmt.Errorf("issue %s not found", outwardKey)
+	}
+	types, _ := d.GetIssueLinkTypes(ctx)
+	var linkType *IssueLinkType
+	for i := range types {
+		if strings.EqualFold(types[i].Name, typeName) {
+			linkType = &types[i]
+			break
+		}
+	}
+	if linkType == nil {
+		return fmt.Errorf("unknown link type %q", typeName)
+	}
+
+	id := strconv.Itoa(d.nextLinkID())
+	// Both endpoints carry the same link, each pointing at the other. The side
+	// an issue stores decides how it is phrased: the outward end reads
+	// "blocks X", the inward end "is blocked by Y".
+	outward.IssueLinks = append(outward.IssueLinks, IssueLink{
+		ID: id, Type: linkType, OutwardIssue: &Issue{Key: inward.Key, Summary: inward.Summary, Status: inward.Status},
+	})
+	inward.IssueLinks = append(inward.IssueLinks, IssueLink{
+		ID: id, Type: linkType, InwardIssue: &Issue{Key: outward.Key, Summary: outward.Summary, Status: outward.Status},
+	})
+	return nil
+}
+
+func (d *DemoClient) nextLinkID() int {
+	maxID := 20000
+	for _, iss := range d.issueIndex {
+		for _, l := range iss.IssueLinks {
+			if n, err := strconv.Atoi(l.ID); err == nil && n >= maxID {
+				maxID = n + 1
+			}
+		}
+	}
+	return maxID
+}
+
+func (d *DemoClient) DeleteIssueLink(_ context.Context, linkID string) error {
+	d.logRequest("DELETE", "/issueLink/"+linkID)
+	found := false
+	for _, iss := range d.issueIndex {
+		kept := iss.IssueLinks[:0]
+		for _, l := range iss.IssueLinks {
+			if l.ID == linkID {
+				found = true
+				continue
+			}
+			kept = append(kept, l)
+		}
+		iss.IssueLinks = kept
+	}
+	if !found {
+		return fmt.Errorf("issue link %s not found", linkID)
+	}
+	return nil
+}
+
+func (d *DemoClient) DeleteIssue(_ context.Context, issueKey string, deleteSubtasks bool) error {
+	d.logRequest("DELETE", "/issue/"+issueKey)
+	iss, ok := d.issueIndex[issueKey]
+	if !ok {
+		return fmt.Errorf("issue %s not found", issueKey)
+	}
+	if len(iss.Subtasks) > 0 && !deleteSubtasks {
+		return fmt.Errorf("issue %s has subtasks: pass deleteSubtasks to remove them too", issueKey)
+	}
+
+	remove := []string{issueKey}
+	if deleteSubtasks {
+		for _, sub := range iss.Subtasks {
+			remove = append(remove, sub.Key)
+		}
+	}
+	for _, key := range remove {
+		delete(d.issueIndex, key)
+		delete(d.comments, key)
+		delete(d.changelog, key)
+		for projectKey, list := range d.issues {
+			kept := list[:0]
+			for _, candidate := range list {
+				if candidate.Key == key {
+					continue
+				}
+				kept = append(kept, candidate)
+			}
+			d.issues[projectKey] = kept
+		}
+	}
+	return nil
+}
+
 func (d *DemoClient) GetSprints(_ context.Context, _ int) ([]Sprint, error) {
 	d.logRequest("GET", "/board/1/sprint")
 	return []Sprint{
@@ -681,7 +882,8 @@ func (d *DemoClient) initDemoData() {
 			Status:      inProgress, Priority: high, Assignee: demo, Reporter: alice,
 			IssueType: story, Sprint: sprint1,
 			Labels: []string{"frontend", "ux"}, Components: []Component{{ID: "c1", Name: "Cart"}},
-			Created: now.Add(-10 * day), Updated: now.Add(-1 * day),
+			TimeTracking: &TimeTracking{OriginalEstimate: "3d", RemainingEstimate: "1d", TimeSpent: "2d"},
+			Created:      now.Add(-10 * day), Updated: now.Add(-1 * day),
 		},
 		{
 			ID: "102", Key: "SHOP-2", Summary: "Fix checkout total not updating on quantity change",
@@ -689,7 +891,8 @@ func (d *DemoClient) initDemoData() {
 			Status:      inReview, Priority: critical, Assignee: bob, Reporter: dave,
 			IssueType: bug, Sprint: sprint1,
 			Labels: []string{"bug", "checkout"}, Components: []Component{{ID: "c2", Name: "Checkout"}},
-			Created: now.Add(-5 * day), Updated: now.Add(-6 * time.Hour),
+			TimeTracking: &TimeTracking{OriginalEstimate: "4h", RemainingEstimate: "1h", TimeSpent: "3h"},
+			Created:      now.Add(-5 * day), Updated: now.Add(-6 * time.Hour),
 		},
 		{
 			ID: "103", Key: "SHOP-3", Summary: "Add product search with Elasticsearch",
@@ -952,6 +1155,12 @@ func (d *DemoClient) initDemoData() {
 	for _, iss := range mobiIssues {
 		d.addIssue("MOBI", iss)
 	}
+
+	// Issue links, so the Lnk tab has something to show.
+	ctx := context.Background()
+	_ = d.CreateIssueLink(ctx, "Blocks", "SHOP-2", "SHOP-1")
+	_ = d.CreateIssueLink(ctx, "Relates", "SHOP-3", "SHOP-1")
+	_ = d.CreateIssueLink(ctx, "Blocks", "SHOP-9", "SHOP-2")
 
 	// Comments
 	d.comments["SHOP-1"] = []Comment{

--- a/pkg/jira/demoserver.go
+++ b/pkg/jira/demoserver.go
@@ -87,13 +87,33 @@ func (s *DemoServer) handle(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodPost {
 			s.handleCreateIssue(w, r)
 		}
-	case strings.HasPrefix(path, "/issue/"):
-		key := strings.TrimPrefix(path, "/issue/")
-		if r.Method == http.MethodPut {
-			s.handleUpdateIssue(w, r, key)
+	case path == "/issueLink":
+		if r.Method == http.MethodPost {
+			s.handleCreateIssueLink(w, r)
 		} else {
+			http.NotFound(w, r)
+		}
+	case strings.HasPrefix(path, "/issueLink/"):
+		if r.Method == http.MethodDelete {
+			s.handleDeleteIssueLink(w, strings.TrimPrefix(path, "/issueLink/"))
+		} else {
+			http.NotFound(w, r)
+		}
+	case path == "/issueLinkType":
+		s.handleIssueLinkTypes(w)
+	case strings.HasPrefix(path, "/issue/"):
+		key, _, _ := strings.Cut(strings.TrimPrefix(path, "/issue/"), "?")
+		switch r.Method {
+		case http.MethodPut:
+			s.handleUpdateIssue(w, r, key)
+		case http.MethodDelete:
+			s.handleDeleteIssue(w, r, key)
+		default:
 			s.handleIssue(w, key)
 		}
+	case strings.HasSuffix(path, "/statuses") && strings.HasPrefix(path, "/project/"):
+		key := strings.TrimSuffix(strings.TrimPrefix(path, "/project/"), "/statuses")
+		s.handleProjectStatuses(w, key)
 	case path == "/priority":
 		s.handlePriorities(w)
 	case strings.HasPrefix(path, "/user/assignable/search"):
@@ -354,6 +374,61 @@ func (s *DemoServer) handleAddComment(w http.ResponseWriter, r *http.Request, ke
 	writeJSON(w, commentToJSON(comment))
 }
 
+// handleProjectStatuses mirrors GET /project/{key}/statuses: the real API
+// groups statuses per issue type, so the demo emits a single group.
+func (s *DemoServer) handleProjectStatuses(w http.ResponseWriter, key string) {
+	statuses, err := s.data.GetProjectStatuses(context.Background(), key)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusNotFound)
+		return
+	}
+	encoded := make([]any, len(statuses))
+	for i := range statuses {
+		encoded[i] = statusToJSON(&statuses[i])
+	}
+	writeJSON(w, []any{map[string]any{"name": "Task", "statuses": encoded}})
+}
+
+func (s *DemoServer) handleIssueLinkTypes(w http.ResponseWriter) {
+	types, _ := s.data.GetIssueLinkTypes(context.Background())
+	writeJSON(w, map[string]any{"issueLinkTypes": types})
+}
+
+func (s *DemoServer) handleCreateIssueLink(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		Type         struct{ Name string } `json:"type"`
+		InwardIssue  struct{ Key string }  `json:"inwardIssue"`
+		OutwardIssue struct{ Key string }  `json:"outwardIssue"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(w, "bad request", http.StatusBadRequest)
+		return
+	}
+	err := s.data.CreateIssueLink(context.Background(), body.Type.Name, body.InwardIssue.Key, body.OutwardIssue.Key)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	w.WriteHeader(http.StatusCreated)
+}
+
+func (s *DemoServer) handleDeleteIssueLink(w http.ResponseWriter, linkID string) {
+	if err := s.data.DeleteIssueLink(context.Background(), linkID); err != nil {
+		http.Error(w, err.Error(), http.StatusNotFound)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (s *DemoServer) handleDeleteIssue(w http.ResponseWriter, r *http.Request, key string) {
+	deleteSubtasks := r.URL.Query().Get("deleteSubtasks") == "true"
+	if err := s.data.DeleteIssue(context.Background(), key, deleteSubtasks); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
 func (s *DemoServer) handlePriorities(w http.ResponseWriter) {
 	priorities, _ := s.data.GetPriorities(context.Background())
 	result := make([]any, len(priorities))
@@ -565,6 +640,34 @@ func (s *DemoServer) handleAgile(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 		writeJSON(w, map[string]any{"values": result})
+	case strings.HasSuffix(path, "/configuration"):
+		id, _ := strconv.Atoi(strings.TrimSuffix(strings.TrimPrefix(path, "/board/"), "/configuration"))
+		config, err := s.data.GetBoardConfiguration(context.Background(), id)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusNotFound)
+			return
+		}
+		columns := make([]any, 0, len(config.Columns))
+		for _, col := range config.Columns {
+			statuses := make([]any, 0, len(col.StatusIDs))
+			for _, statusID := range col.StatusIDs {
+				statuses = append(statuses, map[string]any{"id": statusID})
+			}
+			columns = append(columns, map[string]any{"name": col.Name, "statuses": statuses})
+		}
+		writeJSON(w, map[string]any{"columnConfig": map[string]any{"columns": columns}})
+	case strings.HasPrefix(path, "/board/") && strings.HasSuffix(path, "/issue"):
+		id, _ := strconv.Atoi(strings.TrimSuffix(strings.TrimPrefix(path, "/board/"), "/issue"))
+		issues, err := s.data.GetBoardIssues(context.Background(), id, "")
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusNotFound)
+			return
+		}
+		encoded := make([]any, 0, len(issues))
+		for i := range issues {
+			encoded = append(encoded, issueToJSON(&issues[i]))
+		}
+		writeJSON(w, map[string]any{"issues": encoded, "total": len(encoded), "maxResults": 50, "startAt": 0})
 	case strings.HasSuffix(path, "/sprint"):
 		sprints, _ := s.data.GetSprints(context.Background(), 0)
 		result := make([]any, len(sprints))
@@ -638,6 +741,13 @@ func issueToJSON(iss *Issue) map[string]any {
 		fields["issuetype"] = map[string]any{
 			"id": iss.IssueType.ID, "name": iss.IssueType.Name,
 			"iconUrl": iss.IssueType.IconURL, "subtask": iss.IssueType.Subtask,
+		}
+	}
+	if !iss.TimeTracking.IsZero() {
+		fields["timetracking"] = map[string]any{
+			"originalEstimate":  iss.TimeTracking.OriginalEstimate,
+			"remainingEstimate": iss.TimeTracking.RemainingEstimate,
+			"timeSpent":         iss.TimeTracking.TimeSpent,
 		}
 	}
 

--- a/pkg/jira/jiratest/fake.go
+++ b/pkg/jira/jiratest/fake.go
@@ -30,6 +30,34 @@ type GetTransitionsCall struct {
 	Key string
 }
 
+type GetBoardConfigurationCall struct {
+	Ctx     context.Context
+	BoardID int
+}
+
+type GetProjectStatusesCall struct {
+	Ctx        context.Context
+	ProjectKey string
+}
+
+type CreateIssueLinkCall struct {
+	Ctx        context.Context
+	TypeName   string
+	InwardKey  string
+	OutwardKey string
+}
+
+type DeleteIssueLinkCall struct {
+	Ctx    context.Context
+	LinkID string
+}
+
+type DeleteIssueCall struct {
+	Ctx            context.Context
+	Key            string
+	DeleteSubtasks bool
+}
+
 type DoTransitionCall struct {
 	Ctx          context.Context
 	Key          string
@@ -156,11 +184,17 @@ type FakeClient struct {
 	AssignIssueFunc                   func(ctx context.Context, key, accountID string) error
 	GetProjectsFunc                   func(ctx context.Context) ([]jira.Project, error)
 	GetBoardsFunc                     func(ctx context.Context) ([]jira.Board, error)
+	GetBoardConfigurationFunc         func(ctx context.Context, boardID int) (*jira.BoardConfiguration, error)
 	GetBoardIssuesFunc                func(ctx context.Context, boardID int, jql string) ([]jira.Issue, error)
 	GetChildrenFunc                   func(ctx context.Context, parentKey string) ([]jira.Issue, error)
 	UpdateIssueFunc                   func(ctx context.Context, key string, fields map[string]any) error
 	RemoveIssueParentFunc             func(ctx context.Context, key string) error
 	GetPrioritiesFunc                 func(ctx context.Context) ([]jira.Priority, error)
+	GetProjectStatusesFunc            func(ctx context.Context, projectKey string) ([]jira.Status, error)
+	GetIssueLinkTypesFunc             func(ctx context.Context) ([]jira.IssueLinkType, error)
+	CreateIssueLinkFunc               func(ctx context.Context, typeName, inwardKey, outwardKey string) error
+	DeleteIssueLinkFunc               func(ctx context.Context, linkID string) error
+	DeleteIssueFunc                   func(ctx context.Context, key string, deleteSubtasks bool) error
 	CreateIssueFunc                   func(ctx context.Context, fields map[string]any) (*jira.Issue, error)
 	GetCreateMetaFunc                 func(ctx context.Context, projectKey, issueTypeID string) ([]jira.CreateMetaField, error)
 	GetCommentsFunc                   func(ctx context.Context, key string) ([]jira.Comment, error)
@@ -190,11 +224,17 @@ type FakeClient struct {
 	AssignIssueCalls                   []AssignIssueCall
 	GetProjectsCalls                   []context.Context
 	GetBoardsCalls                     []context.Context
+	GetBoardConfigurationCalls         []GetBoardConfigurationCall
 	GetBoardIssuesCalls                []GetBoardIssuesCall
 	GetChildrenCalls                   []GetChildrenCall
 	UpdateIssueCalls                   []UpdateIssueCall
 	RemoveIssueParentCalls             []RemoveIssueParentCall
 	GetPrioritiesCalls                 []context.Context
+	GetProjectStatusesCalls            []GetProjectStatusesCall
+	GetIssueLinkTypesCalls             []context.Context
+	CreateIssueLinkCalls               []CreateIssueLinkCall
+	DeleteIssueLinkCalls               []DeleteIssueLinkCall
+	DeleteIssueCalls                   []DeleteIssueCall
 	CreateIssueCalls                   []CreateIssueCall
 	GetCreateMetaCalls                 []GetCreateMetaCall
 	GetCommentsCalls                   []GetCommentsCall
@@ -354,6 +394,62 @@ func (f *FakeClient) GetPriorities(ctx context.Context) ([]jira.Priority, error)
 		return nil, nil
 	}
 	return f.GetPrioritiesFunc(ctx)
+}
+
+func (f *FakeClient) GetBoardConfiguration(ctx context.Context, boardID int) (*jira.BoardConfiguration, error) {
+	f.GetBoardConfigurationCalls = append(f.GetBoardConfigurationCalls, GetBoardConfigurationCall{Ctx: ctx, BoardID: boardID})
+	if f.GetBoardConfigurationFunc == nil {
+		f.fatal("GetBoardConfiguration")
+		return nil, nil
+	}
+	return f.GetBoardConfigurationFunc(ctx, boardID)
+}
+
+func (f *FakeClient) GetProjectStatuses(ctx context.Context, projectKey string) ([]jira.Status, error) {
+	f.GetProjectStatusesCalls = append(f.GetProjectStatusesCalls, GetProjectStatusesCall{Ctx: ctx, ProjectKey: projectKey})
+	if f.GetProjectStatusesFunc == nil {
+		f.fatal("GetProjectStatuses")
+		return nil, nil
+	}
+	return f.GetProjectStatusesFunc(ctx, projectKey)
+}
+
+func (f *FakeClient) GetIssueLinkTypes(ctx context.Context) ([]jira.IssueLinkType, error) {
+	f.GetIssueLinkTypesCalls = append(f.GetIssueLinkTypesCalls, ctx)
+	if f.GetIssueLinkTypesFunc == nil {
+		f.fatal("GetIssueLinkTypes")
+		return nil, nil
+	}
+	return f.GetIssueLinkTypesFunc(ctx)
+}
+
+func (f *FakeClient) CreateIssueLink(ctx context.Context, typeName, inwardKey, outwardKey string) error {
+	f.CreateIssueLinkCalls = append(f.CreateIssueLinkCalls, CreateIssueLinkCall{
+		Ctx: ctx, TypeName: typeName, InwardKey: inwardKey, OutwardKey: outwardKey,
+	})
+	if f.CreateIssueLinkFunc == nil {
+		f.fatal("CreateIssueLink")
+		return nil
+	}
+	return f.CreateIssueLinkFunc(ctx, typeName, inwardKey, outwardKey)
+}
+
+func (f *FakeClient) DeleteIssueLink(ctx context.Context, linkID string) error {
+	f.DeleteIssueLinkCalls = append(f.DeleteIssueLinkCalls, DeleteIssueLinkCall{Ctx: ctx, LinkID: linkID})
+	if f.DeleteIssueLinkFunc == nil {
+		f.fatal("DeleteIssueLink")
+		return nil
+	}
+	return f.DeleteIssueLinkFunc(ctx, linkID)
+}
+
+func (f *FakeClient) DeleteIssue(ctx context.Context, key string, deleteSubtasks bool) error {
+	f.DeleteIssueCalls = append(f.DeleteIssueCalls, DeleteIssueCall{Ctx: ctx, Key: key, DeleteSubtasks: deleteSubtasks})
+	if f.DeleteIssueFunc == nil {
+		f.fatal("DeleteIssue")
+		return nil
+	}
+	return f.DeleteIssueFunc(ctx, key, deleteSubtasks)
 }
 
 func (f *FakeClient) CreateIssue(ctx context.Context, fields map[string]any) (*jira.Issue, error) {

--- a/pkg/jira/models.go
+++ b/pkg/jira/models.go
@@ -63,7 +63,25 @@ type Issue struct {
 	Comments       []Comment        `json:"-"`
 	Changelog      []ChangelogEntry `json:"-"`
 	Transitions    []Transition     `json:"-"`
+	TimeTracking   *TimeTracking    `json:"-"`
 	CustomFields   map[string]any   `json:"-"`
+}
+
+// TimeTracking holds the Jira timetracking field. Values are Jira duration
+// strings ("2w 3d 4h"), not durations: the unit lengths are per-instance
+// config (a "day" may be 8h), so they are never parsed into time.Duration.
+type TimeTracking struct {
+	OriginalEstimate  string `json:"originalEstimate"`
+	RemainingEstimate string `json:"remainingEstimate"`
+	TimeSpent         string `json:"timeSpent"`
+}
+
+// IsZero reports whether no estimate or spent time is recorded.
+func (t *TimeTracking) IsZero() bool {
+	if t == nil {
+		return true
+	}
+	return t.OriginalEstimate == "" && t.RemainingEstimate == "" && t.TimeSpent == ""
 }
 
 // ChangelogEntry represents a single change in issue history
@@ -117,6 +135,20 @@ type Board struct {
 	ProjectKey string `json:"-"`
 }
 
+// BoardColumn is one column of an agile board. A column can collect several
+// statuses, which is why a board's layout cannot be derived from the project
+// status list alone.
+type BoardColumn struct {
+	Name      string
+	StatusIDs []string
+}
+
+// BoardConfiguration is the column layout of a board.
+type BoardConfiguration struct {
+	BoardID int
+	Columns []BoardColumn
+}
+
 type Project struct {
 	ID        string `json:"id"`
 	Key       string `json:"key"`
@@ -148,6 +180,7 @@ type IssueLink struct {
 }
 
 type IssueLinkType struct {
+	ID      string `json:"id"`
 	Name    string `json:"name"`
 	Inward  string `json:"inward"`
 	Outward string `json:"outward"`

--- a/pkg/tui/app.go
+++ b/pkg/tui/app.go
@@ -62,6 +62,7 @@ const (
 	editBranch
 	editCreateField
 	editCreateDesc
+	editBoardFilter
 )
 
 type editCtx struct {
@@ -84,7 +85,7 @@ type createCtx struct {
 }
 
 type onSelectFunc func(components.ModalItem) tea.Cmd
-type onChecklistFunc func([]components.ModalItem) tea.Cmd
+type onChecklistFunc func(components.ChecklistConfirmedMsg) tea.Cmd
 
 type issuesLoadedMsg struct {
 	issues []jira.Issue
@@ -185,6 +186,23 @@ type App struct {
 	issueCache      map[string]*jira.Issue
 	childrenCache   map[string][]jira.Issue
 	createMetaCache map[string][]jira.CreateMetaField
+	// projectStatuses caches the workflow statuses per project key. They lay
+	// the board out when the project has no agile board.
+	projectStatuses map[string][]jira.Status
+	// activeBoard is the index into the active project's boards of the one on
+	// screen; -1 means the status-derived board.
+	activeBoard int
+	// boardColumns and boardIssues cache what each agile board reported.
+	boardColumns map[int][]jira.BoardColumn
+	boardIssues  map[int][]jira.Issue
+	// boardFilters holds the board assignee filter per project key, so it
+	// survives tab switches and revisits. Empty means "everyone".
+	boardFilters      map[string]map[string]bool
+	boardFilterLabels map[string]string
+	// taskOpen is true once a task has been opened with enter. While it is
+	// false the right panel belongs to the project board, and list navigation
+	// must not push issues into it.
+	taskOpen bool
 	// previewKey identifies the issue displayed in the right-side views.
 	// Empty means nothing is displayed.
 	previewKey string
@@ -354,7 +372,14 @@ func NewAppWithAuth(cfg *config.Config, client jira.ClientInterface, authMethod 
 		issueCache:      make(map[string]*jira.Issue),
 		childrenCache:   make(map[string][]jira.Issue),
 		createMetaCache: make(map[string][]jira.CreateMetaField),
-		converter:       BuiltinConverter{},
+		projectStatuses: make(map[string][]jira.Status),
+		activeBoard:     -1,
+		boardColumns:    make(map[int][]jira.BoardColumn),
+		boardIssues:     make(map[int][]jira.Issue),
+
+		boardFilters:      make(map[string]map[string]bool),
+		boardFilterLabels: make(map[string]string),
+		converter:         BuiltinConverter{},
 	}
 	// cfg.Converter is validated at config-load time; "" and "builtin"
 	// both fall through to the BuiltinConverter set above.
@@ -434,6 +459,11 @@ func (a *App) Init() tea.Cmd {
 		}),
 	}
 	if cmd := a.fetchActiveTab(); cmd != nil {
+		cmds = append(cmds, cmd)
+	}
+	// A project restored from config is already selected, but never went
+	// through selectProject: put its board up here.
+	if cmd := a.showBoard(); cmd != nil {
 		cmds = append(cmds, cmd)
 	}
 	return tea.Batch(cmds...)
@@ -536,42 +566,6 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case commentUpdatedMsg:
 		return a, fetchIssueDetail(a.client, msg.issueKey)
 
-	case components.CreateFormTypeSelectedMsg:
-		return a.handleCreateFormTypeSelected(msg)
-	case components.CreateFormEditTextMsg:
-		return a.handleCreateFormEditText(msg)
-	case components.CreateFormEditExternalMsg:
-		return a.handleCreateFormEditExternal(msg)
-	case components.CreateFormPickerMsg:
-		return a.handleCreateFormPicker(msg)
-	case components.CreateFormChecklistMsg:
-		return a.handleCreateFormChecklist(msg)
-	case components.CreateFormSubmitMsg:
-		return a.handleCreateFormSubmit(msg)
-	case components.CreateFormCancelMsg:
-		a.createCtx = createCtx{}
-		return a, nil
-
-	case components.ModalSelectedMsg:
-		return a.handleModalSelected(msg)
-	case components.ChecklistConfirmedMsg:
-		return a.handleChecklistConfirmed(msg)
-	case components.ModalCancelledMsg:
-		return a.handleModalCancelled()
-
-	case editorFinishedMsg:
-		return a.handleEditorFinished(msg)
-	case customCommandFinishedMsg:
-		return a.handleCustomCommandFinished(msg)
-	case components.DiffConfirmedMsg:
-		return a.handleDiffConfirmed(msg)
-	case components.DiffCancelledMsg:
-		return a.handleDiffCancelled()
-	case components.InputConfirmedMsg:
-		return a.handleInputConfirmed(msg)
-	case components.InputCancelledMsg:
-		return a.handleInputCancelled()
-
 	case components.JQLSubmitMsg:
 		return a.handleJQLSubmit(msg)
 	case jqlSearchResultMsg:
@@ -619,29 +613,11 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			a.infoPanel.SetIssue(msg.Issue)
 		}
 		_, previewCmd := a.Update(views.PreviewRequestMsg{Key: msg.Issue.Key})
-		return a, tea.Batch(previewCmd, a.prefetchRelated(msg.Issue), a.infoPanel.MaybeChildrenRequest())
+		return a, tea.Batch(previewCmd, a.prefetchRelated(msg.Issue),
+			a.infoPanel.MaybeChildrenRequest())
 
 	case views.PreviewRequestMsg:
-		a.previewKey = msg.Key
-		a.previewEpoch++
-		sel := a.issuesList.SelectedIssue()
-		mainListMatches := sel != nil && sel.Key == msg.Key
-		if cached, ok := a.issueCache[msg.Key]; ok && cached != nil {
-			a.detailView.UpdateIssueData(cached)
-			if mainListMatches {
-				a.infoPanel.SetIssue(cached)
-			}
-			return a, nil
-		}
-		if mainListMatches {
-			a.detailView.SetIssue(sel)
-			a.infoPanel.SetIssue(sel)
-		}
-		epoch := a.previewEpoch
-		key := msg.Key
-		return a, tea.Tick(150*time.Millisecond, func(_ time.Time) tea.Msg {
-			return previewDebounceMsg{key: key, epoch: epoch}
-		})
+		return a.handlePreviewRequest(msg)
 
 	case previewDebounceMsg:
 		if msg.epoch != a.previewEpoch {
@@ -693,14 +669,28 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		a.statusPanel.SetOnline(true)
 		a.issueCache[msg.issue.Key] = msg.issue
 		// DetailView only: InfoPanel belongs to the main list issue.
-		a.detailView.UpdateIssueData(msg.issue)
+		if !a.boardVisible() {
+			a.detailView.UpdateIssueData(msg.issue)
+		}
 		a.issuesList.PatchIssue(msg.issue)
+		a.refreshBoard()
 		return a, nil
+	case projectStatusesLoadedMsg:
+		return a.handleProjectStatusesLoaded(msg)
+
+	case boardDataLoadedMsg:
+		return a.handleBoardDataLoaded(msg)
+
 	case views.ProjectHoveredMsg:
 		if msg.Project != nil {
 			a.detailView.SetProject(msg.Project)
 		}
 		return a, nil
+
+	default:
+		if m, cmd, ok := a.handleOverlayMsg(msg); ok {
+			return m, cmd
+		}
 	}
 
 	return a, a.routeToPanel(msg)
@@ -804,9 +794,9 @@ func (a *App) editInfoField(sel *jira.Issue) (tea.Model, tea.Cmd) {
 		issueKey := sel.Key
 		switch field.FieldID {
 		case fldLabels:
-			a.onChecklist = func(selected []components.ModalItem) tea.Cmd {
-				labels := make([]string, 0, len(selected))
-				for _, item := range selected {
+			a.onChecklist = func(confirmed components.ChecklistConfirmedMsg) tea.Cmd {
+				labels := make([]string, 0, len(confirmed.Selected))
+				for _, item := range confirmed.Selected {
 					labels = append(labels, item.ID)
 				}
 				a.optimisticFieldUpdate(issueKey, fldLabels, labels)
@@ -814,9 +804,9 @@ func (a *App) editInfoField(sel *jira.Issue) (tea.Model, tea.Cmd) {
 			}
 			return a, fetchLabels(a.client)
 		case fldComponents:
-			a.onChecklist = func(selected []components.ModalItem) tea.Cmd {
-				comps := make([]map[string]string, 0, len(selected))
-				for _, item := range selected {
+			a.onChecklist = func(confirmed components.ChecklistConfirmedMsg) tea.Cmd {
+				comps := make([]map[string]string, 0, len(confirmed.Selected))
+				for _, item := range confirmed.Selected {
 					comps = append(comps, map[string]string{"id": item.ID})
 				}
 				a.optimisticFieldUpdate(issueKey, fldComponents, comps)
@@ -1051,9 +1041,9 @@ func (a *App) handleCustomFieldOptions(msg customFieldOptionsMsg) (tea.Model, te
 
 	switch msg.fieldType {
 	case views.FieldMultiSelect:
-		a.onChecklist = func(selected []components.ModalItem) tea.Cmd {
-			vals := make([]map[string]string, 0, len(selected))
-			for _, item := range selected {
+		a.onChecklist = func(confirmed components.ChecklistConfirmedMsg) tea.Cmd {
+			vals := make([]map[string]string, 0, len(confirmed.Selected))
+			for _, item := range confirmed.Selected {
 				vals = append(vals, map[string]string{"id": item.ID})
 			}
 			a.optimisticFieldUpdate(msg.issueKey, msg.fieldID, vals)

--- a/pkg/tui/app_edit_flows_test.go
+++ b/pkg/tui/app_edit_flows_test.go
@@ -228,7 +228,7 @@ func TestEditInfoField_LabelsChecklistCallbackUpdatesIssue(t *testing.T) {
 	app.issueCache[testKey] = issue
 
 	_, _ = app.editInfoField(issue)
-	cmd := app.onChecklist([]components.ModalItem{{ID: "backend"}, {ID: "infra"}})
+	cmd := app.onChecklist(components.ChecklistConfirmedMsg{Selected: []components.ModalItem{{ID: "backend"}, {ID: "infra"}}})
 	cmd()
 
 	if len(fake.UpdateIssueCalls) != 1 {
@@ -252,7 +252,7 @@ func TestEditInfoField_ComponentsChecklistCallbackUpdatesIssue(t *testing.T) {
 	issue := selectInfoField(t, app, &jira.Issue{Key: testKey, IssueType: &jira.IssueType{ID: "10001"}, Components: []jira.Component{{ID: "9", Name: "Old"}}}, config.FieldConfig{ID: "components"})
 
 	_, _ = app.editInfoField(issue)
-	cmd := app.onChecklist([]components.ModalItem{{ID: "10"}})
+	cmd := app.onChecklist(components.ChecklistConfirmedMsg{Selected: []components.ModalItem{{ID: "10"}}})
 	cmd()
 
 	if len(fake.UpdateIssueCalls) != 1 {
@@ -639,7 +639,7 @@ func TestHandleCustomFieldOptions_MoreBranches(t *testing.T) {
 		if !app.modal.IsVisible() || !app.modal.IsChecklist() {
 			t.Fatal("checklist modal should be visible")
 		}
-		cmd := app.onChecklist([]components.ModalItem{{ID: "2"}})
+		cmd := app.onChecklist(components.ChecklistConfirmedMsg{Selected: []components.ModalItem{{ID: "2"}}})
 		cmd()
 		vals, ok := fake.UpdateIssueCalls[0].Fields["customfield_1"].([]map[string]string)
 		if !ok || len(vals) != 1 || vals[0]["id"] != "2" {

--- a/pkg/tui/app_update_routing_test.go
+++ b/pkg/tui/app_update_routing_test.go
@@ -466,7 +466,7 @@ func TestUpdate_RoutesCreateAndEditMessages(t *testing.T) {
 		{
 			name: "checklist confirmed dispatches callback",
 			setup: func(app *App, fake *jiratest.FakeClient) {
-				app.onChecklist = func([]components.ModalItem) tea.Cmd { return func() tea.Msg { return nil } }
+				app.onChecklist = func(components.ChecklistConfirmedMsg) tea.Cmd { return func() tea.Msg { return nil } }
 			},
 			msg:     components.ChecklistConfirmedMsg{},
 			wantCmd: true,

--- a/pkg/tui/commands.go
+++ b/pkg/tui/commands.go
@@ -232,6 +232,14 @@ type issueUpdatedMsg struct {
 type commentAddedMsg struct{ issueKey string }
 type commentUpdatedMsg struct{ issueKey string }
 type prioritiesLoadedMsg struct{ priorities []jira.Priority }
+
+// projectStatusesLoadedMsg carries the board columns of a project. An empty
+// slice means the lookup failed; the board then derives its columns from the
+// issues it already has, so this is never reported as an error.
+type projectStatusesLoadedMsg struct {
+	projectKey string
+	statuses   []jira.Status
+}
 type usersLoadedMsg struct {
 	users    []jira.User
 	issueKey string
@@ -353,6 +361,48 @@ func fetchPriorities(client jira.ClientInterface) tea.Cmd {
 			return errorMsg{err: err}
 		}
 		return prioritiesLoadedMsg{priorities: priorities}
+	}
+}
+
+// boardDataLoadedMsg carries one agile board's own layout and cards. A failed
+// piece is left nil: the board falls back to the project statuses, or to the
+// issues of the active list tab.
+type boardDataLoadedMsg struct {
+	boardID int
+	columns []jira.BoardColumn
+	issues  []jira.Issue
+	err     error
+}
+
+// fetchBoardData pulls a board's column configuration and its issues together:
+// neither is useful without the other.
+func fetchBoardData(client jira.ClientInterface, boardID int) tea.Cmd {
+	return func() tea.Msg {
+		msg := boardDataLoadedMsg{boardID: boardID}
+		config, err := client.GetBoardConfiguration(context.Background(), boardID)
+		if err != nil {
+			msg.err = err
+		} else if config != nil {
+			msg.columns = config.Columns
+		}
+		issues, err := client.GetBoardIssues(context.Background(), boardID, "")
+		if err != nil {
+			msg.err = err
+			return msg
+		}
+		msg.issues = issues
+		return msg
+	}
+}
+
+func fetchProjectStatuses(client jira.ClientInterface, projectKey string) tea.Cmd {
+	return func() tea.Msg {
+		statuses, err := client.GetProjectStatuses(context.Background(), projectKey)
+		if err != nil {
+			// Not fatal: the board falls back to the statuses of the issues.
+			return projectStatusesLoadedMsg{projectKey: projectKey}
+		}
+		return projectStatusesLoadedMsg{projectKey: projectKey, statuses: statuses}
 	}
 }
 

--- a/pkg/tui/components/modal.go
+++ b/pkg/tui/components/modal.go
@@ -31,6 +31,10 @@ type ModalCancelledMsg struct{}
 // ChecklistConfirmedMsg is sent when user confirms a checklist selection
 type ChecklistConfirmedMsg struct {
 	Selected []ModalItem
+	// Cursor is the row that was highlighted on confirm. Callers for which an
+	// empty Selected is ambiguous -- a filter, where "nothing ticked" and
+	// "just this row" look the same to the user -- can fall back to it.
+	Cursor ModalItem
 }
 
 // Modal is a centered popup list for picking an option
@@ -231,6 +235,12 @@ func (m *Modal) IsVisible() bool   { return m.visible }
 func (m *Modal) IsSearching() bool { return m.searching }
 func (m *Modal) IsChecklist() bool { return m.checklist }
 
+// Title is the heading currently displayed.
+func (m *Modal) Title() string { return m.title }
+
+// Items are the rows currently offered, in display order.
+func (m *Modal) Items() []ModalItem { return m.items }
+
 // SearchView renders the modal search bar for external use
 func (m *Modal) SearchView(_ int) string {
 	return RenderFilterBarInput(&m.filterInput)
@@ -348,8 +358,12 @@ func (m *Modal) handleEnter() (Modal, tea.Cmd) {
 				result = append(result, item)
 			}
 		}
+		var cursor ModalItem
+		if m.cursor >= 0 && m.cursor < len(m.items) && !m.items[m.cursor].Separator {
+			cursor = m.items[m.cursor]
+		}
 		m.visible = false
-		return *m, func() tea.Msg { return ChecklistConfirmedMsg{Selected: result} }
+		return *m, func() tea.Msg { return ChecklistConfirmedMsg{Selected: result, Cursor: cursor} }
 	}
 	if m.cursor >= 0 && m.cursor < len(m.items) && !m.items[m.cursor].Separator {
 		selected := m.items[m.cursor]

--- a/pkg/tui/custom_commands.go
+++ b/pkg/tui/custom_commands.go
@@ -93,6 +93,9 @@ func (a *App) activeContexts() []config.Context {
 			out = append(out, config.CtxDetail)
 		case views.ModeProject:
 			out = append(out, config.CtxProjects)
+		case views.ModeKanban:
+			// The board shows a project, so project commands apply.
+			out = append(out, config.CtxProjects)
 		case views.ModeSplash:
 			// no custom command contexts on splash
 		}

--- a/pkg/tui/handlers.go
+++ b/pkg/tui/handlers.go
@@ -26,6 +26,7 @@ func (a *App) handleSearchChanged(msg components.SearchChangedMsg) (tea.Model, t
 	switch {
 	case a.side == sideLeft && a.leftFocus == focusIssues:
 		a.issuesList.SetFilter(msg.Query)
+		a.refreshBoard()
 	case a.side == sideLeft && a.leftFocus == focusInfo:
 		a.infoPanel.SetFilter(msg.Query)
 	case a.side == sideLeft && a.leftFocus == focusProjects:
@@ -41,6 +42,7 @@ func (a *App) handleSearchConfirmed() (tea.Model, tea.Cmd) {
 	case a.side == sideLeft && a.leftFocus == focusIssues:
 		selectedIssue := a.issuesList.SelectedIssue()
 		a.issuesList.ClearFilter()
+		a.refreshBoard()
 		if selectedIssue != nil {
 			if _, cmd := a.Update(views.IssueSelectedMsg{Issue: selectedIssue}); cmd != nil {
 				cmds = append(cmds, cmd)
@@ -65,6 +67,7 @@ func (a *App) handleSearchCancelled() (tea.Model, tea.Cmd) {
 	a.issuesList.SetFilter("")
 	a.infoPanel.SetFilter("")
 	a.projectList.SetFilter("")
+	a.refreshBoard()
 	return a, nil
 }
 
@@ -91,14 +94,18 @@ func (a *App) selectProject(p *jira.Project) tea.Cmd {
 	a.createMetaCache = make(map[string][]jira.CreateMetaField)
 	a.invalidateInFlight()
 	a.infoPanel.SetIssue(nil)
+	// A different project means a different set of boards.
+	a.activeBoard = -1
 	a.resolveBoardID()
 	if !a.demoMode {
 		go saveLastProject(p.Key)
 	}
+	// Picking a project replaces whatever task was open with its board.
+	cmds := []tea.Cmd{a.showBoard()}
 	if _, ok := a.usersCache[p.Key]; !ok {
-		return prefetchUsers(p.Key)
+		cmds = append(cmds, prefetchUsers(p.Key))
 	}
-	return nil
+	return tea.Batch(cmds...)
 }
 
 // routeToPanel forwards input to the focused panel.

--- a/pkg/tui/handlers_data.go
+++ b/pkg/tui/handlers_data.go
@@ -24,6 +24,7 @@ func (a *App) handleIssuesLoaded(msg issuesLoadedMsg) (tea.Model, tea.Cmd) {
 	var cmds []tea.Cmd
 	if msg.tab == a.issuesList.GetTabIndex() {
 		a.issuesList.SetIssues(msg.issues)
+		a.refreshBoard()
 		for _, issue := range msg.issues {
 			cmds = append(cmds, prefetchIssue(a.client, issue.Key))
 		}
@@ -71,13 +72,14 @@ func (a *App) handleIssueDetailLoaded(msg issueDetailLoadedMsg) (tea.Model, tea.
 	*a.logFlag = false
 	a.statusPanel.SetOnline(true)
 	a.issueCache[msg.issue.Key] = msg.issue
-	if a.previewKey == "" || a.previewKey == msg.issue.Key {
+	if !a.boardVisible() && (a.previewKey == "" || a.previewKey == msg.issue.Key) {
 		a.detailView.UpdateIssueData(msg.issue)
 	}
 	if sel := a.issuesList.SelectedIssue(); sel != nil && sel.Key == msg.issue.Key {
 		a.infoPanel.SetIssue(msg.issue)
 	}
 	a.issuesList.PatchIssue(msg.issue)
+	a.refreshBoard()
 
 	return a, a.prefetchRelated(msg.issue)
 }
@@ -89,7 +91,7 @@ func (a *App) handleIssuePrefetched(msg issuePrefetchedMsg) (tea.Model, tea.Cmd)
 	}
 	a.issueCache[msg.issue.Key] = msg.issue
 	if sel := a.issuesList.SelectedIssue(); sel != nil && sel.Key == msg.issue.Key {
-		if a.detailView.IssueKey() == "" || a.detailView.IssueKey() == msg.issue.Key {
+		if !a.boardVisible() && (a.detailView.IssueKey() == "" || a.detailView.IssueKey() == msg.issue.Key) {
 			a.detailView.UpdateIssueData(msg.issue)
 		}
 		if a.infoPanel.IssueKey() == "" || a.infoPanel.IssueKey() == msg.issue.Key {
@@ -164,6 +166,10 @@ func (a *App) handleUsersLoaded(msg usersLoadedMsg) (tea.Model, tea.Cmd) {
 	if msg.issueKey == "" {
 		return a, nil
 	}
+	if msg.issueKey == boardFilterSentinel {
+		a.showBoardFilterModal(msg.users)
+		return a, nil
+	}
 	if msg.issueKey == createUsersSentinel {
 		if a.onChecklist != nil {
 			a.modal.ShowChecklist("Select users", a.buildUserItems(msg.users), nil)
@@ -219,6 +225,11 @@ func (a *App) handleUsersLoaded(msg usersLoadedMsg) (tea.Model, tea.Cmd) {
 func (a *App) handleBoardsLoaded(msg boardsLoadedMsg) (tea.Model, tea.Cmd) {
 	a.boards = msg.boards
 	a.resolveBoardID()
+	// Boards land after the board panel is already up, so it has to be laid
+	// out again now that the project's agile boards are known.
+	if a.boardVisible() {
+		return a, a.showBoard()
+	}
 	return a, nil
 }
 
@@ -376,7 +387,9 @@ func (a *App) handleProjectsLoaded(msg projectsLoadedMsg) (tea.Model, tea.Cmd) {
 		a.statusPanel.SetProject(a.projectKey)
 		a.projectList.SetActiveKey(a.projectKey)
 		a.resolveBoardID()
-		return a, a.fetchActiveTab()
+		// The project is picked here rather than through selectProject, so the
+		// board has to be raised explicitly: at Init there was no project yet.
+		return a, tea.Batch(a.fetchActiveTab(), a.showBoard())
 	}
 	return a, nil
 }

--- a/pkg/tui/handlers_data_more_test.go
+++ b/pkg/tui/handlers_data_more_test.go
@@ -488,7 +488,7 @@ func TestHandleUsersLoaded_CreateSentinel(t *testing.T) {
 		t.Parallel()
 		app := newAppWithFake(t, &jiratest.FakeClient{T: t})
 		app.usersCache = map[string][]jira.User{}
-		app.onChecklist = func([]components.ModalItem) tea.Cmd { return nil }
+		app.onChecklist = func(components.ChecklistConfirmedMsg) tea.Cmd { return nil }
 
 		_, _ = app.handleUsersLoaded(usersLoadedMsg{
 			users:    []jira.User{{AccountID: "u1", DisplayName: "Ann"}},

--- a/pkg/tui/handlers_keys.go
+++ b/pkg/tui/handlers_keys.go
@@ -12,6 +12,9 @@ import (
 	"github.com/textfuel/lazyjira/v2/pkg/tui/views"
 )
 
+// keyEsc is the escape key as the runtime spells it.
+const keyEsc = "esc"
+
 // handleKeyMsg dispatches keyboard actions.
 // Returns (nil, nil) if the key was not handled and should be forwarded to the focused panel
 func (a *App) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
@@ -28,6 +31,20 @@ func (a *App) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	}
 
 	action := a.keymap.Match(msg.String())
+
+	// The board owns the right panel while no task is open.
+	if a.side == sideRight && a.boardVisible() {
+		if m, cmd, ok := a.handleBoardKeys(action, msg.String()); ok {
+			return m, cmd
+		}
+	}
+
+	// Filtering the board works from anywhere it is on screen: the cursor is
+	// usually still in the issues list when the user reaches for it.
+	if action == ActFilterAssignees && a.boardVisible() {
+		m, cmd, _ := a.openBoardFilter()
+		return m, cmd
+	}
 
 	// In the hierarchy tab, ActFocusLeft pops a NavFrame instead of
 	// shifting focus.
@@ -117,7 +134,7 @@ func (a *App) handleHelpKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		a.helpSearch.SetWidth(a.width - 5)
 		return a, nil
 	}
-	if key == "esc" || key == "q" || key == "?" {
+	if key == keyEsc || key == "q" || key == "?" {
 		a.showHelp = false
 		a.helpFilter = ""
 		a.helpSearching = false
@@ -272,9 +289,15 @@ func (a *App) handleFocusAction(action Action) (tea.Model, tea.Cmd, bool) {
 			return a, nil, true
 		}
 		if a.side == sideRight {
+			// Closing a task hands the panel back to the project board.
+			var cmd tea.Cmd
+			if a.taskOpen {
+				a.detailView.CloseIssue()
+				cmd = a.showBoard()
+			}
 			a.side = sideLeft
 			a.updateFocusState()
-			return a, nil, true
+			return a, cmd, true
 		}
 
 	case ActFocusDetail:
@@ -322,6 +345,7 @@ func (a *App) handleTabAction(action Action) (tea.Model, tea.Cmd, bool) {
 			a.detailView.PrevTab()
 		case a.side == sideLeft && a.leftFocus == focusIssues:
 			a.issuesList.PrevTab()
+			a.refreshBoard()
 			if !a.issuesList.HasCachedTab() {
 				return a, a.fetchActiveTab(), true
 			}
@@ -338,6 +362,7 @@ func (a *App) handleTabAction(action Action) (tea.Model, tea.Cmd, bool) {
 			a.detailView.NextTab()
 		case a.side == sideLeft && a.leftFocus == focusIssues:
 			a.issuesList.NextTab()
+			a.refreshBoard()
 			if !a.issuesList.HasCachedTab() {
 				return a, a.fetchActiveTab(), true
 			}
@@ -628,6 +653,8 @@ func (a *App) handleActionOpen() (tea.Model, tea.Cmd) {
 func (a *App) openIssueDetail() (tea.Model, tea.Cmd) {
 	if sel := a.issuesList.SelectedIssue(); sel != nil {
 		a.side = sideRight
+		a.taskOpen = true
+		a.detailView.SetIssue(sel)
 		a.updateFocusState()
 		return a, fetchIssueDetail(a.client, sel.Key)
 	}

--- a/pkg/tui/handlers_modal.go
+++ b/pkg/tui/handlers_modal.go
@@ -50,7 +50,7 @@ func (a *App) handleChecklistConfirmed(msg components.ChecklistConfirmedMsg) (te
 	a.createForm.Resume()
 	if fn := a.onChecklist; fn != nil {
 		a.onChecklist = nil
-		return a, fn(msg.Selected)
+		return a, fn(msg)
 	}
 	return a, nil
 }
@@ -313,9 +313,9 @@ func (a *App) handleCreateFormChecklist(msg components.CreateFormChecklistMsg) (
 	if len(items) == 0 {
 		switch field.FieldID {
 		case fldLabels:
-			a.onChecklist = func(selected []components.ModalItem) tea.Cmd {
-				labels := make([]string, 0, len(selected))
-				for _, item := range selected {
+			a.onChecklist = func(confirmed components.ChecklistConfirmedMsg) tea.Cmd {
+				labels := make([]string, 0, len(confirmed.Selected))
+				for _, item := range confirmed.Selected {
 					labels = append(labels, item.ID)
 				}
 				a.createForm.SetFieldValue(idx, labels, strings.Join(labels, ", "))
@@ -323,10 +323,10 @@ func (a *App) handleCreateFormChecklist(msg components.CreateFormChecklistMsg) (
 			}
 			return a, fetchLabels(a.client)
 		case fldComponents:
-			a.onChecklist = func(selected []components.ModalItem) tea.Cmd {
-				comps := make([]map[string]string, 0, len(selected))
-				names := make([]string, 0, len(selected))
-				for _, item := range selected {
+			a.onChecklist = func(confirmed components.ChecklistConfirmedMsg) tea.Cmd {
+				comps := make([]map[string]string, 0, len(confirmed.Selected))
+				names := make([]string, 0, len(confirmed.Selected))
+				for _, item := range confirmed.Selected {
 					comps = append(comps, map[string]string{"id": item.ID})
 					names = append(names, item.Label)
 				}
@@ -345,10 +345,10 @@ func (a *App) handleCreateFormChecklist(msg components.CreateFormChecklistMsg) (
 		}
 	}
 
-	a.onChecklist = func(selected []components.ModalItem) tea.Cmd {
-		names := make([]string, 0, len(selected))
-		ids := make([]map[string]string, 0, len(selected))
-		for _, item := range selected {
+	a.onChecklist = func(confirmed components.ChecklistConfirmedMsg) tea.Cmd {
+		names := make([]string, 0, len(confirmed.Selected))
+		ids := make([]map[string]string, 0, len(confirmed.Selected))
+		for _, item := range confirmed.Selected {
 			names = append(names, item.Label)
 			ids = append(ids, map[string]string{"id": item.ID})
 		}
@@ -385,10 +385,10 @@ func (a *App) handleCreateFormUserChecklist(field *components.CreateFormField, i
 	if a.isCloud {
 		key = fldAccountID
 	}
-	a.onChecklist = func(selected []components.ModalItem) tea.Cmd {
-		users := make([]map[string]string, 0, len(selected))
-		names := make([]string, 0, len(selected))
-		for _, item := range selected {
+	a.onChecklist = func(confirmed components.ChecklistConfirmedMsg) tea.Cmd {
+		users := make([]map[string]string, 0, len(confirmed.Selected))
+		names := make([]string, 0, len(confirmed.Selected))
+		for _, item := range confirmed.Selected {
 			users = append(users, map[string]string{key: item.ID})
 			names = append(names, item.Label)
 		}
@@ -423,4 +423,76 @@ func (a *App) handleExpandBlock(msg views.ExpandBlockMsg) (tea.Model, tea.Cmd) {
 	a.modal.SetSize(a.width, a.height-1)
 	a.modal.ShowReadOnly(msg.Title, items)
 	return a, nil
+}
+
+// handleOverlayMsg routes the results of the editor and of the overlay
+// widgets. It lives apart from Update's main switch, which is already at the
+// limit of what one function should branch on.
+func (a *App) handleOverlayMsg(msg tea.Msg) (tea.Model, tea.Cmd, bool) {
+	if m, cmd, ok := a.handleCreateFormMsg(msg); ok {
+		return m, cmd, true
+	}
+
+	switch msg := msg.(type) {
+	case components.ModalSelectedMsg:
+		m, cmd := a.handleModalSelected(msg)
+		return m, cmd, true
+	case components.ChecklistConfirmedMsg:
+		m, cmd := a.handleChecklistConfirmed(msg)
+		return m, cmd, true
+	case components.ModalCancelledMsg:
+		m, cmd := a.handleModalCancelled()
+		return m, cmd, true
+
+	case editorFinishedMsg:
+		m, cmd := a.handleEditorFinished(msg)
+		return m, cmd, true
+	case customCommandFinishedMsg:
+		m, cmd := a.handleCustomCommandFinished(msg)
+		return m, cmd, true
+
+	case components.DiffConfirmedMsg:
+		m, cmd := a.handleDiffConfirmed(msg)
+		return m, cmd, true
+	case components.DiffCancelledMsg:
+		m, cmd := a.handleDiffCancelled()
+		return m, cmd, true
+
+	case components.InputConfirmedMsg:
+		m, cmd := a.handleInputConfirmed(msg)
+		return m, cmd, true
+	case components.InputCancelledMsg:
+		m, cmd := a.handleInputCancelled()
+		return m, cmd, true
+
+	}
+	return nil, nil, false
+}
+
+// handleCreateFormMsg routes the create-form overlay's own messages.
+func (a *App) handleCreateFormMsg(msg tea.Msg) (tea.Model, tea.Cmd, bool) {
+	switch msg := msg.(type) {
+	case components.CreateFormTypeSelectedMsg:
+		m, cmd := a.handleCreateFormTypeSelected(msg)
+		return m, cmd, true
+	case components.CreateFormEditTextMsg:
+		m, cmd := a.handleCreateFormEditText(msg)
+		return m, cmd, true
+	case components.CreateFormEditExternalMsg:
+		m, cmd := a.handleCreateFormEditExternal(msg)
+		return m, cmd, true
+	case components.CreateFormPickerMsg:
+		m, cmd := a.handleCreateFormPicker(msg)
+		return m, cmd, true
+	case components.CreateFormChecklistMsg:
+		m, cmd := a.handleCreateFormChecklist(msg)
+		return m, cmd, true
+	case components.CreateFormSubmitMsg:
+		m, cmd := a.handleCreateFormSubmit(msg)
+		return m, cmd, true
+	case components.CreateFormCancelMsg:
+		a.createCtx = createCtx{}
+		return a, nil, true
+	}
+	return nil, nil, false
 }

--- a/pkg/tui/handlers_modal_test.go
+++ b/pkg/tui/handlers_modal_test.go
@@ -71,7 +71,7 @@ func TestHandleChecklistConfirmed(t *testing.T) {
 		t.Parallel()
 		app := newAppWithFake(t, &jiratest.FakeClient{T: t})
 		called := false
-		app.onChecklist = func([]components.ModalItem) tea.Cmd {
+		app.onChecklist = func(components.ChecklistConfirmedMsg) tea.Cmd {
 			called = true
 			return nil
 		}
@@ -100,7 +100,7 @@ func TestHandleModalCancelled_ClearsCallbacks(t *testing.T) {
 	t.Parallel()
 	app := newAppWithFake(t, &jiratest.FakeClient{T: t})
 	app.onSelect = func(components.ModalItem) tea.Cmd { return nil }
-	app.onChecklist = func([]components.ModalItem) tea.Cmd { return nil }
+	app.onChecklist = func(components.ChecklistConfirmedMsg) tea.Cmd { return nil }
 	app.createCtx = createCtx{projectKey: testProject}
 
 	_, _ = app.handleModalCancelled()

--- a/pkg/tui/kanban.go
+++ b/pkg/tui/kanban.go
@@ -1,0 +1,345 @@
+package tui
+
+import (
+	"strconv"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/textfuel/lazyjira/v2/pkg/jira"
+	"github.com/textfuel/lazyjira/v2/pkg/tui/components"
+	"github.com/textfuel/lazyjira/v2/pkg/tui/views"
+)
+
+// meLabel prefixes the current user in the board filter so it is pickable
+// without knowing one's own display name by heart.
+const meLabel = "(Me) "
+
+// boardFilterSentinel marks a user fetch whose result feeds the board filter
+// rather than the assignee picker.
+const boardFilterSentinel = "__board_filter__"
+
+// everyoneFilterID is the row that clears the board filter. Without it the
+// only way back to "show everything" would be to untick every name.
+const everyoneFilterID = "__everyone__"
+
+// boardVisible reports whether the right panel is showing the project board.
+// While it is, list navigation must not push issues into the detail panel:
+// the board owns it until a task is opened with enter.
+func (a *App) boardVisible() bool {
+	return !a.taskOpen && a.detailView.Mode() == views.ModeKanban
+}
+
+// projectBoards are the agile boards of the active project, in the order the
+// Agile API reported them.
+func (a *App) projectBoards() []jira.Board {
+	var out []jira.Board
+	for _, b := range a.boards {
+		if b.ProjectKey == a.projectKey {
+			out = append(out, b)
+		}
+	}
+	return out
+}
+
+// showBoard puts the active project's board on the right panel. A project can
+// have several agile boards, each with its own columns and its own issues; one
+// with none falls back to a board laid out from the project statuses.
+func (a *App) showBoard() tea.Cmd {
+	if a.projectKey == "" {
+		return nil
+	}
+	a.taskOpen = false
+	a.detailView.ShowKanban(a.projectKey)
+
+	boards := a.projectBoards()
+	if a.activeBoard >= len(boards) {
+		a.activeBoard = len(boards) - 1
+	}
+	if a.activeBoard < 0 && len(boards) > 0 {
+		a.activeBoard = 0
+	}
+
+	view := a.detailView.Kanban()
+	view.SetAssigneeFilter(a.boardFilters[a.projectKey], a.boardFilterLabels[a.projectKey])
+	view.SetBoardTabs(boardNames(boards), a.activeBoard)
+
+	cmds := []tea.Cmd{}
+	if _, ok := a.projectStatuses[a.projectKey]; !ok {
+		cmds = append(cmds, fetchProjectStatuses(a.client, a.projectKey))
+	}
+	if cmd := a.applyBoardLayout(); cmd != nil {
+		cmds = append(cmds, cmd)
+	}
+	if sel := a.issuesList.SelectedIssue(); sel != nil {
+		view.SelectByKey(sel.Key)
+	}
+	return tea.Batch(cmds...)
+}
+
+// boardScope is the set of issue keys the issue list is currently showing, so
+// that narrowing the list -- by tab or by the search filter -- narrows the
+// board with it. Returns nil while the list has nothing loaded, which would
+// otherwise blank the board before its first fetch lands.
+func (a *App) boardScope() map[string]bool {
+	visible := a.issuesList.VisibleIssues()
+	if len(visible) == 0 && len(a.issuesList.CurrentIssues()) == 0 {
+		return nil
+	}
+	keys := make(map[string]bool, len(visible))
+	for _, issue := range visible {
+		keys[issue.Key] = true
+	}
+	return keys
+}
+
+// applyBoardLayout feeds the view from the active agile board, falling back to
+// the project statuses and the active list tab while the board is unknown or
+// when the project has no board at all. Returns a fetch when the board's data
+// is not cached yet.
+func (a *App) applyBoardLayout() tea.Cmd {
+	view := a.detailView.Kanban()
+	boards := a.projectBoards()
+	view.SetScope(a.boardScope())
+
+	if a.activeBoard < 0 || a.activeBoard >= len(boards) {
+		view.SetData(a.projectStatuses[a.projectKey], a.issuesList.CurrentIssues())
+		return nil
+	}
+
+	boardID := boards[a.activeBoard].ID
+	issues, haveIssues := a.boardIssues[boardID]
+	columns, haveColumns := a.boardColumns[boardID]
+	if !haveIssues {
+		// Show the list issues under the project statuses until the board
+		// answers, rather than blanking the panel.
+		view.SetData(a.projectStatuses[a.projectKey], a.issuesList.CurrentIssues())
+		return fetchBoardData(a.client, boardID)
+	}
+
+	view.SetIssues(issues)
+	if haveColumns && len(columns) > 0 {
+		view.SetBoardLayout(columns, a.projectStatuses[a.projectKey])
+	} else {
+		view.SetStatuses(a.projectStatuses[a.projectKey])
+	}
+	return nil
+}
+
+func boardNames(boards []jira.Board) []string {
+	if len(boards) < 2 {
+		// A single board adds nothing to the title.
+		return nil
+	}
+	names := make([]string, 0, len(boards))
+	for _, b := range boards {
+		names = append(names, b.Name)
+	}
+	return names
+}
+
+// cycleBoard moves to the next or previous board of the project.
+func (a *App) cycleBoard(delta int) tea.Cmd {
+	boards := a.projectBoards()
+	if len(boards) < 2 {
+		return nil
+	}
+	a.activeBoard = (a.activeBoard + delta + len(boards)) % len(boards)
+	a.detailView.Kanban().SetBoardTabs(boardNames(boards), a.activeBoard)
+	return a.applyBoardLayout()
+}
+
+// handleBoardDataLoaded caches an agile board's layout and cards.
+func (a *App) handleBoardDataLoaded(msg boardDataLoadedMsg) (tea.Model, tea.Cmd) {
+	if msg.err != nil {
+		// Not fatal: the board keeps the status-derived layout it is showing.
+		a.statusPanel.SetError("board " + strconv.Itoa(msg.boardID) + ": " + msg.err.Error())
+		return a, nil
+	}
+	a.boardColumns[msg.boardID] = msg.columns
+	a.boardIssues[msg.boardID] = msg.issues
+
+	if a.boardVisible() {
+		if boards := a.projectBoards(); a.activeBoard >= 0 && a.activeBoard < len(boards) &&
+			boards[a.activeBoard].ID == msg.boardID {
+			return a, a.applyBoardLayout()
+		}
+	}
+	return a, nil
+}
+
+// refreshBoard re-feeds the board from whatever source it is using. It is a
+// no-op unless the board is the visible panel.
+func (a *App) refreshBoard() {
+	if !a.boardVisible() {
+		return
+	}
+	a.applyBoardLayout()
+}
+
+// handleProjectStatusesLoaded caches a project's workflow statuses. A failed
+// request is not surfaced as an error: the board falls back to the statuses
+// present in the loaded issues, which is a usable board.
+func (a *App) handleProjectStatusesLoaded(msg projectStatusesLoadedMsg) (tea.Model, tea.Cmd) {
+	if len(msg.statuses) == 0 {
+		return a, nil
+	}
+	a.projectStatuses[msg.projectKey] = msg.statuses
+	if a.boardVisible() && msg.projectKey == a.projectKey {
+		a.applyBoardLayout()
+	}
+	return a, nil
+}
+
+// handleBoardKeys drives the board while the right panel has focus. It returns
+// handled=false for anything it does not own, so the global bindings keep
+// working.
+//
+// key is needed because the same action covers both "move a column left" and
+// "leave the panel": h and left steer the board, esc backs out of it.
+func (a *App) handleBoardKeys(action Action, key string) (tea.Model, tea.Cmd, bool) {
+	board := a.detailView.Kanban()
+
+	switch action { //nolint:exhaustive
+	case ActNavUp, ActDetailScrollUp:
+		board.Move(0, -1)
+	case ActNavDown, ActDetailScrollDown:
+		board.Move(0, 1)
+	case ActFocusLeft:
+		if key == keyEsc {
+			return a, nil, false
+		}
+		board.Move(-1, 0)
+	case ActFocusRight:
+		board.Move(1, 0)
+	case ActOpen, ActSelect:
+		return a.openBoardCard()
+	case ActFilterAssignees:
+		return a.openBoardFilter()
+	case ActPrevTab, ActNextTab:
+		// Only claim the tab keys when there is more than one board to move
+		// between; otherwise they keep switching the issue list's tabs.
+		if len(a.projectBoards()) < 2 {
+			return a, nil, false
+		}
+		delta := 1
+		if action == ActPrevTab {
+			delta = -1
+		}
+		return a, a.cycleBoard(delta), true
+	default:
+		return a, nil, false
+	}
+
+	// Keep the list cursor on the card the board highlights, so leaving the
+	// board lands on the same issue.
+	if sel := board.SelectedIssue(); sel != nil {
+		a.issuesList.SelectByKey(sel.Key)
+		a.infoPanel.SetIssue(sel)
+	}
+	return a, nil, true
+}
+
+// openBoardCard opens the highlighted card as a regular task view.
+func (a *App) openBoardCard() (tea.Model, tea.Cmd, bool) {
+	sel := a.detailView.Kanban().SelectedIssue()
+	if sel == nil {
+		return a, nil, true
+	}
+	a.taskOpen = true
+	a.issuesList.SelectByKey(sel.Key)
+	a.infoPanel.SetIssue(sel)
+	a.showCachedIssue(sel.Key)
+	if a.detailView.Mode() == views.ModeKanban {
+		// Nothing cached yet: show what the board knows until the fetch lands.
+		a.detailView.SetIssue(sel)
+	}
+	return a, fetchIssueDetail(a.client, sel.Key), true
+}
+
+// openBoardFilter asks for the set of assignees the board should show. The
+// user list is fetched (and cached) exactly like the assignee picker does.
+func (a *App) openBoardFilter() (tea.Model, tea.Cmd, bool) {
+	a.editContext = editCtx{kind: editBoardFilter}
+	a.onChecklist = a.applyBoardFilter
+
+	if users, ok := a.usersCache[a.projectKey]; ok {
+		a.showBoardFilterModal(users)
+		return a, nil, true
+	}
+	*a.logFlag = true
+	return a, fetchUsers(a.client, a.projectKey, boardFilterSentinel), true
+}
+
+// showBoardFilterModal lists the assignable users, with the current user and
+// the unassigned bucket pinned on top, preselecting the active filter.
+func (a *App) showBoardFilterModal(users []jira.User) {
+	selected := a.boardFilters[a.projectKey]
+
+	items := []components.ModalItem{
+		{ID: everyoneFilterID, Label: "(Everyone — clear the filter)"},
+		{ID: views.UnassignedFilterID, Label: "(Unassigned)"},
+	}
+	if a.currentUser != nil {
+		items = append(items, components.ModalItem{
+			ID:    a.currentUser.AccountID,
+			Label: meLabel + a.currentUser.DisplayName,
+		})
+	}
+	for _, u := range users {
+		if a.currentUser != nil && u.AccountID == a.currentUser.AccountID {
+			continue
+		}
+		items = append(items, components.ModalItem{ID: u.AccountID, Label: u.DisplayName})
+	}
+
+	a.modal.ShowChecklist("Show issues assigned to", items, selected)
+}
+
+// applyBoardFilter stores the chosen assignees for the active project.
+//
+// Confirming without ticking anything falls back to the highlighted row:
+// people reach for enter on the person they want, and an empty selection
+// silently meaning "everyone" reads as a filter that does nothing. Clearing
+// is done explicitly through the "everyone" row.
+func (a *App) applyBoardFilter(confirmed components.ChecklistConfirmedMsg) tea.Cmd {
+	items := confirmed.Selected
+	switch {
+	case confirmed.Cursor.ID == everyoneFilterID:
+		// Landing on that row is an explicit "show everything", and it has to
+		// beat the ticks left over from the filter being replaced.
+		items = nil
+	case len(items) == 0 && confirmed.Cursor.ID != "":
+		items = []components.ModalItem{confirmed.Cursor}
+	}
+
+	ids := make(map[string]bool, len(items))
+	names := make([]string, 0, len(items))
+	for _, item := range items {
+		if item.ID == everyoneFilterID {
+			ids, names = make(map[string]bool), nil
+			break
+		}
+		ids[item.ID] = true
+		names = append(names, strings.TrimPrefix(item.Label, meLabel))
+	}
+
+	label := boardFilterLabel(names)
+	a.boardFilters[a.projectKey] = ids
+	a.boardFilterLabels[a.projectKey] = label
+	a.detailView.Kanban().SetAssigneeFilter(ids, label)
+	return nil
+}
+
+// boardFilterLabel keeps the panel title short: names while they fit, a count
+// beyond that.
+func boardFilterLabel(names []string) string {
+	switch {
+	case len(names) == 0:
+		return ""
+	case len(names) <= 2:
+		return strings.Join(names, ", ")
+	default:
+		return strconv.Itoa(len(names)) + " assignees"
+	}
+}

--- a/pkg/tui/kanban_test.go
+++ b/pkg/tui/kanban_test.go
@@ -1,0 +1,860 @@
+package tui
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/textfuel/lazyjira/v2/pkg/jira"
+	"github.com/textfuel/lazyjira/v2/pkg/jira/jiratest"
+	"github.com/textfuel/lazyjira/v2/pkg/tui/components"
+	"github.com/textfuel/lazyjira/v2/pkg/tui/views"
+)
+
+var errBoardTest = errors.New("board unavailable")
+
+const (
+	boardKey1 = testProject + "-1"
+	boardKey2 = testProject + "-2"
+	aliceName = "Alice"
+)
+
+var (
+	kbStatusTodo = jira.Status{ID: "1", Name: "To Do", CategoryKey: "new"}
+	kbStatusDone = jira.Status{ID: "5", Name: "Done", CategoryKey: "done"}
+	kbUserAlice  = &jira.User{AccountID: "u1", DisplayName: aliceName}
+	kbUserBob    = &jira.User{AccountID: "u2", DisplayName: "Bob"}
+)
+
+func kbBoardIssues() []jira.Issue {
+	todo, done := kbStatusTodo, kbStatusDone
+	return []jira.Issue{
+		{Key: boardKey1, Summary: "First", Status: &todo, Assignee: kbUserAlice},
+		{Key: boardKey2, Summary: "Second", Status: &done, Assignee: kbUserBob},
+	}
+}
+
+// newBoardApp returns an app with a project selected and issues loaded, which
+// is the state in which the board is meant to be visible.
+func newBoardApp(t *testing.T) *App {
+	t.Helper()
+	app := newTestApp()
+	app.client = &jiratest.FakeClient{T: t}
+	app.infoPanel = views.NewInfoPanel()
+	app.statusPanel = views.NewStatusPanel(testProject, "", "")
+	app.logPanel = views.NewLogPanel()
+	app.keymap = DefaultKeymap()
+	logFlag := false
+	app.logFlag = &logFlag
+	app.projectStatuses = map[string][]jira.Status{testProject: {kbStatusTodo, kbStatusDone}}
+	app.activeBoard = -1
+	app.boardColumns = map[int][]jira.BoardColumn{}
+	app.boardIssues = map[int][]jira.Issue{}
+	app.boardFilters = map[string]map[string]bool{}
+	app.boardFilterLabels = map[string]string{}
+	app.usersCache = map[string][]jira.User{}
+	app.issueCache = map[string]*jira.Issue{}
+	app.projectKey = testProject
+	app.issuesList.SetIssues(kbBoardIssues())
+	app.detailView.SetSize(100, 20)
+	app.showBoard()
+	return app
+}
+
+func TestShowBoardPutsKanbanOnTheDetailPanel(t *testing.T) {
+	t.Parallel()
+	app := newBoardApp(t)
+
+	if app.detailView.Mode() != views.ModeKanban {
+		t.Fatalf("mode = %v, want ModeKanban", app.detailView.Mode())
+	}
+	if !app.boardVisible() {
+		t.Error("boardVisible = false right after showBoard")
+	}
+	if got := len(app.detailView.Kanban().Columns()); got != 2 {
+		t.Errorf("columns = %d, want 2", got)
+	}
+}
+
+func TestShowBoardIsNoOpWithoutProject(t *testing.T) {
+	t.Parallel()
+	app := newBoardApp(t)
+	app.projectKey = ""
+	app.detailView.SetIssue(&jira.Issue{Key: testKey})
+
+	if cmd := app.showBoard(); cmd != nil {
+		t.Error("showBoard fetched statuses with no project selected")
+	}
+	if app.detailView.Mode() != views.ModeIssue {
+		t.Errorf("mode = %v, want the panel left untouched", app.detailView.Mode())
+	}
+}
+
+func TestShowBoardFetchesStatusesOnlyWhenNotCached(t *testing.T) {
+	t.Parallel()
+	app := newBoardApp(t)
+	if cmd := app.showBoard(); cmd != nil {
+		t.Error("showBoard refetched statuses that were already cached")
+	}
+
+	delete(app.projectStatuses, testProject)
+	if cmd := app.showBoard(); cmd == nil {
+		t.Error("showBoard did not fetch the missing statuses")
+	}
+}
+
+func TestProjectStatusesLoadedFallsBackOnFailure(t *testing.T) {
+	t.Parallel()
+	app := newBoardApp(t)
+	delete(app.projectStatuses, testProject)
+	app.showBoard() // rebuilds the board with statuses derived from the issues
+
+	app.handleProjectStatusesLoaded(projectStatusesLoadedMsg{projectKey: testProject})
+
+	if _, cached := app.projectStatuses[testProject]; cached {
+		t.Error("an empty response should not be cached as the status list")
+	}
+	if got := len(app.detailView.Kanban().Columns()); got != 2 {
+		t.Errorf("columns = %d, want 2 derived from the loaded issues", got)
+	}
+}
+
+func TestProjectStatusesLoadedUpdatesVisibleBoard(t *testing.T) {
+	t.Parallel()
+	app := newBoardApp(t)
+	extra := jira.Status{ID: "3", Name: "In Progress", CategoryKey: "indeterminate"}
+
+	app.handleProjectStatusesLoaded(projectStatusesLoadedMsg{
+		projectKey: testProject,
+		statuses:   []jira.Status{kbStatusTodo, extra, kbStatusDone},
+	})
+
+	if got := len(app.detailView.Kanban().Columns()); got != 3 {
+		t.Errorf("columns = %d, want the refreshed status list", got)
+	}
+}
+
+func TestOpenIssueDetailClosesTheBoard(t *testing.T) {
+	t.Parallel()
+	app := newBoardApp(t)
+	app.issuesList.SelectByKey(boardKey1)
+
+	app.openIssueDetail()
+
+	if !app.taskOpen {
+		t.Error("taskOpen = false after opening a task")
+	}
+	if app.detailView.Mode() != views.ModeIssue {
+		t.Errorf("mode = %v, want ModeIssue", app.detailView.Mode())
+	}
+	if app.boardVisible() {
+		t.Error("board is still considered visible with a task open")
+	}
+}
+
+func TestEscFromTaskReturnsToTheBoard(t *testing.T) {
+	t.Parallel()
+	app := newBoardApp(t)
+	app.issuesList.SelectByKey(boardKey1)
+	app.openIssueDetail()
+
+	_, _, handled := app.handleFocusAction(ActFocusLeft)
+
+	if !handled {
+		t.Fatal("ActFocusLeft was not handled from the right panel")
+	}
+	if app.taskOpen {
+		t.Error("taskOpen is still true after closing the task")
+	}
+	if app.detailView.Mode() != views.ModeKanban {
+		t.Errorf("mode = %v, want the board back", app.detailView.Mode())
+	}
+	if app.side != sideLeft {
+		t.Error("focus did not return to the left column")
+	}
+}
+
+func TestBoardSurvivesListNavigation(t *testing.T) {
+	t.Parallel()
+	app := newBoardApp(t)
+	app.issueCache[boardKey2] = &jira.Issue{Key: boardKey2, Summary: "Second"}
+
+	app.Update(views.PreviewRequestMsg{Key: boardKey2})
+
+	if app.detailView.Mode() != views.ModeKanban {
+		t.Errorf("mode = %v; moving the list cursor must not replace the board", app.detailView.Mode())
+	}
+	if got := app.detailView.Kanban().SelectedIssue(); got == nil || got.Key != boardKey2 {
+		t.Errorf("board cursor = %v, want it to follow the list selection", got)
+	}
+}
+
+func TestPreviewDetailLoadedDoesNotReplaceTheBoard(t *testing.T) {
+	t.Parallel()
+	app := newBoardApp(t)
+	app.previewEpoch = 7
+
+	app.Update(previewDetailLoadedMsg{
+		issue: &jira.Issue{Key: boardKey1, Summary: "First", Description: "body"},
+		epoch: 7,
+	})
+
+	if app.detailView.Mode() != views.ModeKanban {
+		t.Errorf("mode = %v; a background fetch must not replace the board", app.detailView.Mode())
+	}
+	if _, cached := app.issueCache[boardKey1]; !cached {
+		t.Error("the fetched issue was not cached")
+	}
+}
+
+func TestBoardKeysMoveTheCursor(t *testing.T) {
+	t.Parallel()
+	app := newBoardApp(t)
+	app.side = sideRight
+
+	if got := app.detailView.Kanban().SelectedIssue(); got.Key != boardKey1 {
+		t.Fatalf("initial card = %s", got.Key)
+	}
+
+	_, _, handled := app.handleBoardKeys(ActFocusRight, "l")
+	if !handled {
+		t.Fatal("ActFocusRight was not handled by the board")
+	}
+	if got := app.detailView.Kanban().SelectedIssue(); got.Key != boardKey2 {
+		t.Errorf("card after moving right = %s, want PLAT-2", got.Key)
+	}
+	if got := app.issuesList.SelectedIssue(); got == nil || got.Key != boardKey2 {
+		t.Errorf("list selection = %v, want it to follow the board cursor", got)
+	}
+}
+
+func TestBoardLetsEscThrough(t *testing.T) {
+	t.Parallel()
+	app := newBoardApp(t)
+	app.side = sideRight
+
+	if _, _, handled := app.handleBoardKeys(ActFocusLeft, "esc"); handled {
+		t.Error("the board swallowed esc; it must fall through to the focus handler")
+	}
+	if _, _, handled := app.handleBoardKeys(ActFocusLeft, "h"); !handled {
+		t.Error("h should steer the board columns")
+	}
+}
+
+func TestBoardIgnoresUnrelatedActions(t *testing.T) {
+	t.Parallel()
+	app := newBoardApp(t)
+	app.side = sideRight
+
+	if _, _, handled := app.handleBoardKeys(ActRefresh, "r"); handled {
+		t.Error("the board claimed an action it does not own")
+	}
+}
+
+func TestOpenBoardCardOpensTheTask(t *testing.T) {
+	t.Parallel()
+	app := newBoardApp(t)
+	app.side = sideRight
+	app.handleBoardKeys(ActFocusRight, "l") // move to PLAT-2
+
+	_, cmd, handled := app.handleBoardKeys(ActOpen, "enter")
+
+	if !handled || cmd == nil {
+		t.Fatal("enter did not open the highlighted card")
+	}
+	if !app.taskOpen {
+		t.Error("taskOpen = false after opening a card")
+	}
+	if app.detailView.Mode() != views.ModeKanban && app.detailView.IssueKey() != boardKey2 {
+		t.Errorf("detail shows %q, want PLAT-2", app.detailView.IssueKey())
+	}
+}
+
+func TestBoardFilterUsesCachedUsers(t *testing.T) {
+	t.Parallel()
+	app := newBoardApp(t)
+	app.usersCache[testProject] = []jira.User{*kbUserAlice, *kbUserBob}
+
+	_, cmd, handled := app.openBoardFilter()
+
+	if !handled {
+		t.Fatal("the filter action was not handled")
+	}
+	if cmd != nil {
+		t.Error("the filter refetched users that were already cached")
+	}
+	if !app.modal.IsVisible() {
+		t.Error("the assignee checklist was not shown")
+	}
+}
+
+func TestBoardFilterFetchesUsersWhenMissing(t *testing.T) {
+	t.Parallel()
+	app := newBoardApp(t)
+
+	_, cmd, _ := app.openBoardFilter()
+	if cmd == nil {
+		t.Fatal("the filter did not fetch the user list")
+	}
+
+	app.handleUsersLoaded(usersLoadedMsg{users: []jira.User{*kbUserAlice}, issueKey: boardFilterSentinel})
+
+	if !app.modal.IsVisible() {
+		t.Error("the checklist was not shown once the users arrived")
+	}
+}
+
+func TestApplyBoardFilterHidesOtherAssignees(t *testing.T) {
+	t.Parallel()
+	app := newBoardApp(t)
+
+	app.applyBoardFilter(components.ChecklistConfirmedMsg{Selected: []components.ModalItem{{ID: "u1", Label: meLabel + aliceName}}})
+
+	board := app.detailView.Kanban()
+	if got := len(board.Columns()[0].Issues); got != 1 {
+		t.Errorf("To Do column = %d issues, want Alice's only", got)
+	}
+	if got := len(board.Columns()[1].Issues); got != 0 {
+		t.Errorf("Done column = %d issues, want Bob's hidden", got)
+	}
+	if got := board.FilterLabel(); got != aliceName {
+		t.Errorf("filter label = %q, want the (Me) prefix stripped", got)
+	}
+}
+
+func TestBoardFilterPersistsPerProject(t *testing.T) {
+	t.Parallel()
+	app := newBoardApp(t)
+	app.applyBoardFilter(components.ChecklistConfirmedMsg{Selected: []components.ModalItem{{ID: "u1", Label: "Alice"}}})
+
+	app.showBoard() // as happens when coming back to the project
+
+	if got := app.detailView.Kanban().FilterLabel(); got != aliceName {
+		t.Errorf("filter label = %q, want the stored filter reapplied", got)
+	}
+}
+
+func TestBoardFilterLabel(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		names []string
+		want  string
+	}{
+		{nil, ""},
+		{[]string{"Alice"}, "Alice"},
+		{[]string{"Alice", "Bob"}, "Alice, Bob"},
+		{[]string{"Alice", "Bob", "Carol"}, "3 assignees"},
+	}
+	for _, tc := range cases {
+		if got := boardFilterLabel(tc.names); got != tc.want {
+			t.Errorf("boardFilterLabel(%v) = %q, want %q", tc.names, got, tc.want)
+		}
+	}
+}
+
+func TestIssuesLoadedRefreshesTheBoard(t *testing.T) {
+	t.Parallel()
+	app := newBoardApp(t)
+	app.statusPanel = views.NewStatusPanel(testProject, "", "")
+	flag := false
+	app.logFlag = &flag
+
+	extra := kbStatusTodo
+	app.handleIssuesLoaded(issuesLoadedMsg{
+		tab: app.issuesList.GetTabIndex(),
+		issues: append(kbBoardIssues(), jira.Issue{
+			Key: testProject + "-3", Summary: "Third", Status: &extra, Assignee: kbUserAlice,
+		}),
+	})
+
+	if got := len(app.detailView.Kanban().Columns()[0].Issues); got != 2 {
+		t.Errorf("To Do column = %d issues, want the newly loaded one included", got)
+	}
+}
+
+// keyMsg builds a key press the way the runtime delivers it.
+func keyMsg(s string) tea.KeyMsg {
+	if len(s) == 1 {
+		return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(s)}
+	}
+	switch s {
+	case "enter":
+		return tea.KeyMsg{Type: tea.KeyEnter}
+	case "esc":
+		return tea.KeyMsg{Type: tea.KeyEsc}
+	case "ctrl+r":
+		return tea.KeyMsg{Type: tea.KeyCtrlR}
+	case "ctrl+d":
+		return tea.KeyMsg{Type: tea.KeyCtrlD}
+	}
+	return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(s)}
+}
+
+func TestBoardKeysRoutedFromHandleKeyMsg(t *testing.T) {
+	t.Parallel()
+	app := newBoardApp(t)
+	app.side = sideRight
+	app.keymap = DefaultKeymap()
+	app.helpBar = components.HelpBar{}
+
+	app.handleKeyMsg(keyMsg("l"))
+
+	if got := app.detailView.Kanban().SelectedIssue(); got == nil || got.Key != boardKey2 {
+		t.Errorf("board cursor = %v; the key was not routed to the board", got)
+	}
+}
+
+func TestBoardHasItsOwnHelpContext(t *testing.T) {
+	t.Parallel()
+	app := newBoardApp(t)
+	app.side = sideRight
+
+	var help strings.Builder
+	for _, b := range app.ContextBindings() {
+		help.WriteString(b.Key + " " + b.Description + "\n")
+	}
+	joined := help.String()
+	for _, want := range []string{"move between cards", "filter by assignee", "open the highlighted task"} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("board help is missing %q:\n%s", want, joined)
+		}
+	}
+
+	var barBuf strings.Builder
+	for _, item := range app.helpBarItems() {
+		barBuf.WriteString(item.Key + ":" + item.Description + " ")
+	}
+	bar := barBuf.String()
+	if !strings.Contains(bar, "filter") {
+		t.Errorf("board help bar = %q", bar)
+	}
+}
+
+// The project is often chosen by handleProjectsLoaded rather than by
+// selectProject: at Init there is no project yet, so the board has to be
+// raised there too or it never appears on startup.
+func TestProjectsLoadedRaisesTheBoard(t *testing.T) {
+	t.Parallel()
+	app := newBoardApp(t)
+	app.projectKey = ""
+	app.projectID = ""
+	app.taskOpen = true
+	app.detailView.SetIssue(&jira.Issue{Key: boardKey1})
+	// Nothing known about this project yet, as on a cold start.
+	delete(app.projectStatuses, testProject)
+
+	_, cmd := app.handleProjectsLoaded(projectsLoadedMsg{
+		projects: []jira.Project{{ID: "1", Key: testProject, Name: "Platform"}},
+	})
+
+	if app.detailView.Mode() != views.ModeKanban {
+		t.Errorf("mode = %v, want the board up once the project is known", app.detailView.Mode())
+	}
+	if !app.boardVisible() {
+		t.Error("boardVisible = false after the project loaded")
+	}
+	if cmd == nil {
+		t.Fatal("the board columns were never fetched")
+	}
+}
+
+// The board sits on the right, but the cursor is usually still in the issues
+// list when the user reaches for the filter.
+func TestFilterOpensFromTheLeftPanelToo(t *testing.T) {
+	t.Parallel()
+	app := newBoardApp(t)
+	app.usersCache[testProject] = []jira.User{*kbUserAlice, *kbUserBob}
+	app.side = sideLeft
+	app.leftFocus = focusIssues
+
+	app.handleKeyMsg(keyMsg("f"))
+
+	if !app.modal.IsVisible() {
+		t.Error("f did nothing with the board on screen and the focus on the left")
+	}
+}
+
+func TestFilterIgnoredWhenNoBoardIsShown(t *testing.T) {
+	t.Parallel()
+	app := newBoardApp(t)
+	app.usersCache[testProject] = []jira.User{*kbUserAlice}
+	app.taskOpen = true
+	app.detailView.SetIssue(&jira.Issue{Key: boardKey1})
+	app.side = sideLeft
+	app.leftFocus = focusIssues
+
+	app.handleKeyMsg(keyMsg("f"))
+
+	if app.modal.IsVisible() {
+		t.Error("the board filter opened with a task on screen")
+	}
+}
+
+// End-to-end through the real messages: the checklist result has to reach the
+// board, not just the callback.
+func TestChecklistConfirmFiltersTheBoard(t *testing.T) {
+	t.Parallel()
+	app := newBoardApp(t)
+	app.usersCache[testProject] = []jira.User{*kbUserAlice, *kbUserBob}
+	app.side = sideRight
+
+	total := func() int {
+		n := 0
+		for _, c := range app.detailView.Kanban().Columns() {
+			n += len(c.Issues)
+		}
+		return n
+	}
+	if total() != 2 {
+		t.Fatalf("cards = %d, want 2 before filtering", total())
+	}
+
+	app.handleKeyMsg(keyMsg("f"))
+	app.Update(components.ChecklistConfirmedMsg{
+		Selected: []components.ModalItem{{ID: kbUserAlice.AccountID, Label: kbUserAlice.DisplayName}},
+	})
+
+	if got := total(); got != 1 {
+		t.Errorf("cards = %d, want only Alice's after confirming the checklist", got)
+	}
+	if got := app.detailView.Kanban().FilterLabel(); got != aliceName {
+		t.Errorf("filter label = %q", got)
+	}
+}
+
+// A checklist needs space to tick a row, but people press enter on the person
+// they want. An empty selection then meant "everyone", so the filter appeared
+// to do nothing at all.
+func TestFilterAppliesTheHighlightedRowWhenNothingIsTicked(t *testing.T) {
+	t.Parallel()
+	app := newBoardApp(t)
+
+	app.applyBoardFilter(components.ChecklistConfirmedMsg{
+		Cursor: components.ModalItem{ID: kbUserAlice.AccountID, Label: kbUserAlice.DisplayName},
+	})
+
+	board := app.detailView.Kanban()
+	if got := len(board.Columns()[0].Issues); got != 1 {
+		t.Errorf("To Do column = %d issues, want only Alice's", got)
+	}
+	if got := len(board.Columns()[1].Issues); got != 0 {
+		t.Errorf("Done column = %d issues, want Bob's hidden", got)
+	}
+	if got := board.FilterLabel(); got != aliceName {
+		t.Errorf("filter label = %q", got)
+	}
+}
+
+// Ticked rows still win: the cursor is only a fallback.
+func TestTickedRowsBeatTheCursor(t *testing.T) {
+	t.Parallel()
+	app := newBoardApp(t)
+
+	app.applyBoardFilter(components.ChecklistConfirmedMsg{
+		Selected: []components.ModalItem{{ID: kbUserBob.AccountID, Label: kbUserBob.DisplayName}},
+		Cursor:   components.ModalItem{ID: kbUserAlice.AccountID, Label: kbUserAlice.DisplayName},
+	})
+
+	if got := app.detailView.Kanban().FilterLabel(); got != "Bob" {
+		t.Errorf("filter label = %q, want the ticked row", got)
+	}
+}
+
+func TestEveryoneRowClearsTheFilter(t *testing.T) {
+	t.Parallel()
+	app := newBoardApp(t)
+	app.applyBoardFilter(components.ChecklistConfirmedMsg{
+		Selected: []components.ModalItem{{ID: kbUserAlice.AccountID, Label: kbUserAlice.DisplayName}},
+	})
+
+	app.applyBoardFilter(components.ChecklistConfirmedMsg{
+		Cursor: components.ModalItem{ID: everyoneFilterID, Label: "(Everyone — clear the filter)"},
+	})
+
+	total := 0
+	for _, c := range app.detailView.Kanban().Columns() {
+		total += len(c.Issues)
+	}
+	if total != 2 {
+		t.Errorf("cards = %d, want every card back", total)
+	}
+	if got := app.detailView.Kanban().FilterLabel(); got != "" {
+		t.Errorf("filter label = %q, want it cleared", got)
+	}
+}
+
+func TestFilterModalOffersTheClearRowFirst(t *testing.T) {
+	t.Parallel()
+	app := newBoardApp(t)
+
+	app.showBoardFilterModal([]jira.User{*kbUserAlice})
+
+	items := app.modal.Items()
+	if len(items) == 0 || items[0].ID != everyoneFilterID {
+		t.Fatalf("first row = %+v, want the clear-the-filter row", items)
+	}
+}
+
+// Reopening the filter shows the active one already ticked, so choosing the
+// clear row has to win over those leftovers.
+func TestEveryoneRowBeatsLeftoverTicks(t *testing.T) {
+	t.Parallel()
+	app := newBoardApp(t)
+
+	app.applyBoardFilter(components.ChecklistConfirmedMsg{
+		Selected: []components.ModalItem{{ID: kbUserAlice.AccountID, Label: kbUserAlice.DisplayName}},
+		Cursor:   components.ModalItem{ID: everyoneFilterID, Label: "(Everyone — clear the filter)"},
+	})
+
+	total := 0
+	for _, c := range app.detailView.Kanban().Columns() {
+		total += len(c.Issues)
+	}
+	if total != 2 {
+		t.Errorf("cards = %d, want the filter cleared despite the ticked row", total)
+	}
+}
+
+func kbBoards() []jira.Board {
+	return []jira.Board{
+		{ID: 1, Name: "Delivery", Type: "scrum", ProjectKey: testProject},
+		{ID: 2, Name: "Bugs", Type: "kanban", ProjectKey: testProject},
+		{ID: 9, Name: "Other project", Type: "kanban", ProjectKey: "OTHER"},
+	}
+}
+
+func TestProjectBoardsExcludesOtherProjects(t *testing.T) {
+	t.Parallel()
+	app := newBoardApp(t)
+	app.boards = kbBoards()
+
+	got := app.projectBoards()
+
+	if len(got) != 2 || got[0].ID != 1 || got[1].ID != 2 {
+		t.Errorf("boards = %+v, want only this project's", got)
+	}
+}
+
+func TestBoardFetchesItsOwnColumnsAndCards(t *testing.T) {
+	t.Parallel()
+	app := newBoardApp(t)
+	app.boards = kbBoards()
+
+	cmd := app.showBoard()
+	if cmd == nil {
+		t.Fatal("the active board's data was never fetched")
+	}
+
+	app.handleBoardDataLoaded(boardDataLoadedMsg{
+		boardID: 1,
+		columns: []jira.BoardColumn{{Name: "Doing", StatusIDs: []string{"1", "5"}}},
+		issues:  kbBoardIssues(),
+	})
+
+	cols := app.detailView.Kanban().Columns()
+	if len(cols) != 1 || cols[0].Name != "Doing" {
+		t.Fatalf("columns = %+v, want the board's own layout", cols)
+	}
+	if len(cols[0].Issues) != 2 {
+		t.Errorf("cards = %d, want both statuses collected in the column", len(cols[0].Issues))
+	}
+}
+
+func TestCycleBoardSwitchesToTheNextOne(t *testing.T) {
+	t.Parallel()
+	app := newBoardApp(t)
+	app.boards = kbBoards()
+	app.showBoard()
+	app.handleBoardDataLoaded(boardDataLoadedMsg{boardID: 1, issues: kbBoardIssues()})
+
+	cmd := app.cycleBoard(1)
+
+	if app.activeBoard != 1 {
+		t.Fatalf("activeBoard = %d, want the second board", app.activeBoard)
+	}
+	if cmd == nil {
+		t.Error("the second board's data was not fetched")
+	}
+	if got := app.detailView.Kanban().Title(); !strings.Contains(got, "[Bugs]") {
+		t.Errorf("title = %q, want the second board marked active", got)
+	}
+}
+
+func TestCycleBoardWrapsAround(t *testing.T) {
+	t.Parallel()
+	app := newBoardApp(t)
+	app.boards = kbBoards()
+	app.showBoard()
+
+	app.cycleBoard(-1)
+
+	if app.activeBoard != 1 {
+		t.Errorf("activeBoard = %d, want it to wrap to the last board", app.activeBoard)
+	}
+}
+
+func TestCycleBoardIsNoOpWithASingleBoard(t *testing.T) {
+	t.Parallel()
+	app := newBoardApp(t)
+	app.boards = []jira.Board{{ID: 1, Name: "Only", ProjectKey: testProject}}
+	app.showBoard()
+
+	if cmd := app.cycleBoard(1); cmd != nil {
+		t.Error("cycling did something with a single board")
+	}
+	if app.activeBoard != 0 {
+		t.Errorf("activeBoard = %d", app.activeBoard)
+	}
+}
+
+// A project with no agile board still gets a usable board, laid out from its
+// statuses and filled from the active list tab.
+func TestProjectWithoutBoardsFallsBackToStatuses(t *testing.T) {
+	t.Parallel()
+	app := newBoardApp(t)
+	app.boards = []jira.Board{{ID: 9, Name: "Elsewhere", ProjectKey: "OTHER"}}
+
+	app.showBoard()
+
+	if app.activeBoard != -1 {
+		t.Errorf("activeBoard = %d, want none selected", app.activeBoard)
+	}
+	cols := app.detailView.Kanban().Columns()
+	if len(cols) != 2 || cols[0].Name != "To Do" {
+		t.Fatalf("columns = %+v, want the project statuses", cols)
+	}
+	if got := app.detailView.Kanban().Title(); strings.Contains(got, "[") && strings.Contains(got, "]") &&
+		!strings.HasPrefix(got, "[0] Kanban") {
+		t.Errorf("title = %q, want no board tabs", got)
+	}
+}
+
+func TestSwitchingProjectResetsTheActiveBoard(t *testing.T) {
+	t.Parallel()
+	app := newBoardApp(t)
+	app.boards = kbBoards()
+	app.showBoard()
+	app.cycleBoard(1)
+
+	app.selectProject(&jira.Project{Key: "OTHER", ID: "9"})
+
+	if app.activeBoard == 1 {
+		t.Error("the previous project's board index carried over")
+	}
+}
+
+func TestBoardDataErrorKeepsTheBoardUsable(t *testing.T) {
+	t.Parallel()
+	app := newBoardApp(t)
+	app.boards = kbBoards()
+	app.showBoard()
+
+	app.handleBoardDataLoaded(boardDataLoadedMsg{boardID: 1, err: errBoardTest})
+
+	if got := len(app.detailView.Kanban().Columns()); got != 2 {
+		t.Errorf("columns = %d, want the status fallback still standing", got)
+	}
+}
+
+func TestBoardTabKeysCycleBoards(t *testing.T) {
+	t.Parallel()
+	app := newBoardApp(t)
+	app.boards = kbBoards()
+	app.showBoard()
+	app.side = sideRight
+
+	app.handleBoardKeys(ActNextTab, "]")
+
+	if app.activeBoard != 1 {
+		t.Errorf("activeBoard = %d, want ] to move to the next board", app.activeBoard)
+	}
+}
+
+// With a single board the tab keys belong to the issue list, as before.
+func TestTabKeysFallThroughWithASingleBoard(t *testing.T) {
+	t.Parallel()
+	app := newBoardApp(t)
+	app.boards = []jira.Board{{ID: 1, Name: "Only", ProjectKey: testProject}}
+	app.showBoard()
+	app.side = sideRight
+
+	if _, _, handled := app.handleBoardKeys(ActNextTab, "]"); handled {
+		t.Error("the board swallowed ] with nothing to cycle between")
+	}
+}
+
+// The board mirrors what the issue list is showing, so switching to a
+// narrower tab or typing a filter narrows the board too.
+func TestBoardFollowsTheVisibleList(t *testing.T) {
+	t.Parallel()
+	app := newBoardApp(t)
+	app.boards = kbBoards()
+	app.showBoard()
+	app.handleBoardDataLoaded(boardDataLoadedMsg{
+		boardID: 1,
+		issues:  kbBoardIssues(),
+	})
+
+	cards := func() int {
+		n := 0
+		for _, c := range app.detailView.Kanban().Columns() {
+			n += len(c.Issues)
+		}
+		return n
+	}
+	if cards() != 2 {
+		t.Fatalf("cards = %d, want the whole board", cards())
+	}
+
+	app.issuesList.SetFilter(aliceName)
+	app.refreshBoard()
+
+	if got := cards(); got != 1 {
+		t.Errorf("cards = %d, want the board narrowed with the list", got)
+	}
+}
+
+// A board card the list is not showing drops off the board, which is the
+// trade-off of mirroring the list.
+func TestBoardDropsCardsMissingFromTheList(t *testing.T) {
+	t.Parallel()
+	app := newBoardApp(t)
+	app.boards = kbBoards()
+	app.showBoard()
+
+	extra := kbStatusTodo
+	app.handleBoardDataLoaded(boardDataLoadedMsg{
+		boardID: 1,
+		issues: append(kbBoardIssues(), jira.Issue{
+			Key: testProject + "-99", Summary: "Only on the board", Status: &extra,
+		}),
+	})
+
+	for _, c := range app.detailView.Kanban().Columns() {
+		for _, iss := range c.Issues {
+			if iss.Key == testProject+"-99" {
+				t.Error("a card absent from the list stayed on the board")
+			}
+		}
+	}
+}
+
+// Before the list has loaded anything the scope must not blank the board.
+func TestEmptyListDoesNotBlankTheBoard(t *testing.T) {
+	t.Parallel()
+	app := newBoardApp(t)
+	app.issuesList.SetIssues(nil)
+	app.boards = kbBoards()
+	app.showBoard()
+	app.handleBoardDataLoaded(boardDataLoadedMsg{boardID: 1, issues: kbBoardIssues()})
+
+	total := 0
+	for _, c := range app.detailView.Kanban().Columns() {
+		total += len(c.Issues)
+	}
+	if total != 2 {
+		t.Errorf("cards = %d, want the board intact while the list is empty", total)
+	}
+}

--- a/pkg/tui/keybindings.go
+++ b/pkg/tui/keybindings.go
@@ -107,6 +107,18 @@ func (a *App) ContextBindings() []Binding {
 			a.bind(ActFocusRight, "switch to detail panel"),
 		)
 
+	case a.side == sideRight && a.boardVisible():
+		bindings := slices.Concat(global, []Binding{
+			{"hjkl", "move between cards"},
+			a.bind(ActOpen, "open the highlighted task"),
+			a.bind(ActFilterAssignees, "filter by assignee"),
+			a.bind(ActFocusLeft, "back to left panel"),
+		})
+		if len(a.projectBoards()) > 1 {
+			bindings = append(bindings, Binding{"[]", "previous/next board"})
+		}
+		return bindings
+
 	case a.side == sideRight:
 		bindings := slices.Concat(global, a.navBindings())
 		bindings = append(bindings,
@@ -238,6 +250,7 @@ func (a *App) helpBarItems() []components.HelpItem {
 			components.HelpItem{Key: km.Keys(ActPriority), Description: "priority"},
 			components.HelpItem{Key: km.Keys(ActAssignee), Description: "assignee"},
 		)
+
 		items = append(items, a.customCommandHelpItems(config.CtxInfo)...)
 		items = append(items, components.HelpItem{Key: km.Keys(ActHelp), Description: "help"})
 		return items
@@ -255,6 +268,17 @@ func (a *App) helpBarItems() []components.HelpItem {
 			{Key: km.Keys(ActSwitchPanel) + "/" + km.Keys(ActFocusRight), Description: "detail"},
 			{Key: km.Keys(ActHelp), Description: "help"},
 		}
+	case a.side == sideRight && a.boardVisible():
+		items := []components.HelpItem{
+			{Key: "hjkl", Description: "move"},
+			{Key: km.Keys(ActOpen), Description: "open"},
+			{Key: km.Keys(ActFilterAssignees), Description: "filter"},
+			{Key: km.Keys(ActFocusLeft), Description: "back"},
+		}
+		if len(a.projectBoards()) > 1 {
+			items = append(items, components.HelpItem{Key: "[]", Description: "board"})
+		}
+		return append(items, components.HelpItem{Key: km.Keys(ActHelp), Description: "help"})
 	case a.side == sideRight:
 		items := []components.HelpItem{
 			{Key: "[]", Description: "tabs"},

--- a/pkg/tui/keymap.go
+++ b/pkg/tui/keymap.go
@@ -46,6 +46,8 @@ const (
 	ActCreateSubtask  Action = "createSubtask"
 	ActDuplicateIssue Action = "duplicateIssue"
 	ActShowParent     Action = "showParent"
+	// ActFilterAssignees filters the project board by assignee.
+	ActFilterAssignees Action = "filterAssignees"
 
 	ActNavDown     Action = "navDown"
 	ActNavUp       Action = "navUp"
@@ -100,6 +102,8 @@ func DefaultKeymap() Keymap {
 		ActCreateSubtask:  {"S"},
 		ActShowParent:     {"backspace"},
 
+		ActFilterAssignees: {"f"},
+
 		ActNavDown:     {"j", "down", "ctrl+j"},
 		ActNavUp:       {"k", "up", "ctrl+k"},
 		ActNavTop:      {"g", "home"},
@@ -150,6 +154,7 @@ func KeymapFromConfig(kcfg config.KeybindingConfig) Keymap {
 	set(ActCreateBranch, kcfg.Issues.CreateBranch)
 	set(ActCreateIssue, kcfg.Issues.CreateIssue)
 	set(ActCreateSubtask, kcfg.Issues.CreateSubtask)
+	set(ActFilterAssignees, kcfg.Issues.FilterAssignees)
 	// Detail
 	set(ActFocusLeft, kcfg.Detail.FocusLeft)
 	set(ActInfoTab, kcfg.Detail.InfoTab)

--- a/pkg/tui/keymap_test.go
+++ b/pkg/tui/keymap_test.go
@@ -39,3 +39,29 @@ func TestKeymap_MatchUnknownReturnsEmpty(t *testing.T) {
 	testkit.AssertEqual(t, "unknown key", keymap.Match("this-key-is-unbound"), Action(""))
 	testkit.AssertEqual(t, "unknown nav key", keymap.MatchNav("this-key-is-unbound"), components.NavNone)
 }
+
+// TestDefaultKeymapHasNoDuplicateKeys guards a silent failure mode: Keymap.Match
+// iterates a map, so a key bound to two actions resolves to a random one of
+// them, differently on each run.
+func TestDefaultKeymapHasNoDuplicateKeys(t *testing.T) {
+	t.Parallel()
+	owners := map[string][]Action{}
+	for action, keys := range DefaultKeymap() {
+		for _, key := range keys {
+			owners[key] = append(owners[key], action)
+		}
+	}
+	for key, actions := range owners {
+		if len(actions) > 1 {
+			t.Errorf("key %q is bound to %v; Match would pick one at random", key, actions)
+		}
+	}
+}
+
+func TestKeymapFromConfigOverridesFilterAssignees(t *testing.T) {
+	t.Parallel()
+	km := KeymapFromConfig(config.KeybindingConfig{Issues: config.IssueKeys{FilterAssignees: "F"}})
+	if got := km.Keys(ActFilterAssignees); got != "F" {
+		t.Errorf("filterAssignees = %q, want F", got)
+	}
+}

--- a/pkg/tui/navigation.go
+++ b/pkg/tui/navigation.go
@@ -41,7 +41,9 @@ func (a *App) showCachedIssue(key string) {
 	if !ok {
 		return
 	}
-	a.detailView.SetIssue(cached)
+	if !a.boardVisible() {
+		a.detailView.SetIssue(cached)
+	}
 	if sel := a.issuesList.SelectedIssue(); sel != nil && sel.Key == key {
 		a.infoPanel.SetIssue(cached)
 	}
@@ -53,13 +55,17 @@ func (a *App) previewSelectedIssue() tea.Cmd {
 		return nil
 	}
 	a.previewKey = sel.Key
-	if cached, ok := a.issueCache[sel.Key]; ok {
-		a.detailView.SetIssue(cached)
-		a.infoPanel.SetIssue(cached)
-	} else {
-		a.detailView.SetIssue(sel)
-		a.infoPanel.SetIssue(sel)
+	// While the board owns the right panel it only tracks the cursor; the
+	// InfoPanel still follows the selection.
+	board := a.boardVisible()
+	if board {
+		a.detailView.Kanban().SelectByKey(sel.Key)
 	}
+	issue := sel
+	if cached, ok := a.issueCache[sel.Key]; ok {
+		issue = cached
+	}
+	a.showPreviewIssue(issue, board, true, true)
 	return tea.Batch(a.prefetchRelated(sel), a.infoPanel.MaybeChildrenRequest())
 }
 
@@ -183,4 +189,55 @@ func copyToClipboard(text string) {
 func openBrowser(url string) {
 	name, args := platformCommand("open", url)
 	runExternalCommand("", false, name, args...)
+}
+
+// previewDebounce is how long a cursor must rest on an issue before its detail
+// is fetched, so scrolling a list does not fire a request per row.
+const previewDebounce = 150 * time.Millisecond
+
+// handlePreviewRequest points the right-hand views at an issue. A cached issue
+// is shown at once; otherwise a debounced fetch is scheduled, tagged with the
+// current epoch so a later request supersedes it.
+//
+// While the board owns the panel the detail view is left alone: only the board
+// cursor and the InfoPanel follow the selection.
+func (a *App) handlePreviewRequest(msg views.PreviewRequestMsg) (tea.Model, tea.Cmd) {
+	a.previewKey = msg.Key
+	a.previewEpoch++
+
+	sel := a.issuesList.SelectedIssue()
+	mainListMatches := sel != nil && sel.Key == msg.Key
+
+	board := a.boardVisible()
+	if board {
+		a.detailView.Kanban().SelectByKey(msg.Key)
+	}
+
+	if cached, ok := a.issueCache[msg.Key]; ok && cached != nil {
+		a.showPreviewIssue(cached, board, mainListMatches, false)
+		return a, nil
+	}
+	if mainListMatches {
+		a.showPreviewIssue(sel, board, true, true)
+	}
+
+	epoch, key := a.previewEpoch, msg.Key
+	return a, tea.Tick(previewDebounce, func(_ time.Time) tea.Msg {
+		return previewDebounceMsg{key: key, epoch: epoch}
+	})
+}
+
+// showPreviewIssue routes an issue to the detail and info panels. reset picks
+// SetIssue over UpdateIssueData, which also rewinds the tab and scroll.
+func (a *App) showPreviewIssue(issue *jira.Issue, board, updateInfo, reset bool) {
+	if !board {
+		if reset {
+			a.detailView.SetIssue(issue)
+		} else {
+			a.detailView.UpdateIssueData(issue)
+		}
+	}
+	if updateInfo {
+		a.infoPanel.SetIssue(issue)
+	}
 }

--- a/pkg/tui/views/detail.go
+++ b/pkg/tui/views/detail.go
@@ -31,6 +31,9 @@ const (
 	ModeIssue MainMode = iota
 	ModeSplash
 	ModeProject
+	// ModeKanban shows the board of the active project. It is what the panel
+	// falls back to while no issue is open.
+	ModeKanban
 )
 
 // SplashInfo holds data for the splash/status screen
@@ -71,6 +74,7 @@ type DetailView struct {
 	blocks     [][]string
 	blockKeys  []string
 	dblClick   components.DblClickDetector
+	kanban     *KanbanView
 	width      int
 	height     int
 	focused    bool
@@ -81,7 +85,7 @@ type DetailView struct {
 
 // NewDetailView constructs a DetailView with the given ADF renderer.
 func NewDetailView(renderer ADFRenderer) *DetailView {
-	return &DetailView{theme: theme.Default, mode: ModeIssue, renderer: renderer}
+	return &DetailView{theme: theme.Default, mode: ModeIssue, renderer: renderer, kanban: NewKanbanView()}
 }
 
 func (d *DetailView) Mode() MainMode { return d.mode }
@@ -133,7 +137,37 @@ func (d *DetailView) SetSplash(info SplashInfo) {
 	d.scrollY = 0
 }
 
-func (d *DetailView) SetSize(w, h int) { d.width = w; d.height = h }
+// Kanban exposes the board so the app can feed it data and move its cursor.
+func (d *DetailView) Kanban() *KanbanView { return d.kanban }
+
+// ShowKanban switches the panel to the board of the given project.
+func (d *DetailView) ShowKanban(projectKey string) {
+	d.kanban.SetProjectKey(projectKey)
+	d.mode = ModeKanban
+	d.issue = nil
+	d.scrollY = 0
+	d.listCursor = 0
+}
+
+// CloseIssue drops the open issue and returns to the board, or to the splash
+// screen when no project is active.
+func (d *DetailView) CloseIssue() {
+	if d.kanban.ProjectKey() != "" {
+		d.ShowKanban(d.kanban.ProjectKey())
+		return
+	}
+	d.issue = nil
+	d.mode = ModeIssue
+	d.scrollY = 0
+	d.listCursor = 0
+}
+
+func (d *DetailView) SetSize(w, h int) {
+	d.width = w
+	d.height = h
+	contentWidth, innerH := components.PanelDimensions(w, h)
+	d.kanban.SetSize(contentWidth, innerH)
+}
 func (d *DetailView) SetFocused(focused bool) {
 	if d.focused && !focused {
 		// Actually losing focus — reset list cursor.
@@ -466,6 +500,10 @@ func (d *DetailView) View() string {
 	}
 	if d.mode == ModeProject && d.project != nil {
 		return d.renderProjectView(contentWidth, innerH)
+	}
+	if d.mode == ModeKanban {
+		d.kanban.SetSize(contentWidth, innerH)
+		return components.RenderPanel(d.kanban.Title(), d.kanban.View(), d.width, innerH, d.focused)
 	}
 
 	visible := d.VisibleRows()

--- a/pkg/tui/views/issues.go
+++ b/pkg/tui/views/issues.go
@@ -245,6 +245,10 @@ func (m *IssuesList) GetTabIndex() int { return m.tab }
 
 func (m *IssuesList) CurrentIssues() []jira.Issue { return m.allIssues }
 
+// VisibleIssues are the rows on screen: the active tab narrowed by the search
+// filter, which is what CurrentIssues deliberately ignores.
+func (m *IssuesList) VisibleIssues() []jira.Issue { return m.issues }
+
 // SetTabIndex switches to the given tab and loads from cache if available
 func (m *IssuesList) SetTabIndex(idx int) {
 	if idx < 0 || idx >= len(m.tabs) {

--- a/pkg/tui/views/kanban.go
+++ b/pkg/tui/views/kanban.go
@@ -1,0 +1,418 @@
+package views
+
+import (
+	"slices"
+	"strconv"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/textfuel/lazyjira/v2/pkg/jira"
+	"github.com/textfuel/lazyjira/v2/pkg/tui/components"
+	"github.com/textfuel/lazyjira/v2/pkg/tui/theme"
+)
+
+// UnassignedFilterID is the pseudo account id that matches issues with no
+// assignee in the board filter.
+const UnassignedFilterID = "__unassigned__"
+
+const (
+	minColumnWidth  = 18
+	cardInnerMargin = 1 // one blank column between cards
+)
+
+// KanbanColumn is one rendered board column. A column can collect several
+// statuses, which is how agile boards are actually configured.
+type KanbanColumn struct {
+	Name        string
+	StatusIDs   []string
+	CategoryKey string
+	Issues      []*jira.Issue
+}
+
+// holds reports whether statusID belongs in this column.
+func (c KanbanColumn) holds(statusID string) bool {
+	return slices.Contains(c.StatusIDs, statusID)
+}
+
+// KanbanView renders a set of issues laid out in columns.
+//
+// The layout comes either from an agile board's own configuration or, when the
+// project has no board, from its statuses. Filtering is client-side over the
+// issues it was given.
+type KanbanView struct {
+	layout    []KanbanColumn // columns without their issues
+	allIssues []jira.Issue
+	columns   []KanbanColumn
+
+	boardNames  []string
+	activeBoard int
+
+	col, row int   // cursor: column index, card index within the column
+	scroll   []int // first visible card per column
+	hOffset  int   // first visible column
+
+	assignees   map[string]bool // empty means "everyone"
+	filterLabel string
+
+	// scope restricts the board to a set of issue keys, mirroring what the
+	// issue list is showing. nil means no restriction; an empty non-nil set
+	// legitimately means "the list shows nothing".
+	scope map[string]bool
+
+	projectKey    string
+	width, height int
+}
+
+func NewKanbanView() *KanbanView {
+	return &KanbanView{assignees: map[string]bool{}}
+}
+
+func (k *KanbanView) SetProjectKey(key string) { k.projectKey = key }
+func (k *KanbanView) ProjectKey() string       { return k.projectKey }
+
+func (k *KanbanView) SetSize(width, height int) {
+	k.width, k.height = width, height
+}
+
+// SetData lays the board out one column per status and replaces the issues.
+// Passing nil statuses derives the columns from the issues themselves, which
+// is what happens for a project with no reachable status list.
+func (k *KanbanView) SetData(statuses []jira.Status, issues []jira.Issue) {
+	k.allIssues = issues
+	k.SetStatuses(statuses)
+}
+
+// SetStatuses replaces the layout with one column per status, keeping the
+// issues already loaded.
+func (k *KanbanView) SetStatuses(statuses []jira.Status) {
+	if len(statuses) == 0 {
+		statuses = statusesFromIssues(k.allIssues)
+	}
+	layout := make([]KanbanColumn, 0, len(statuses))
+	for _, s := range statuses {
+		layout = append(layout, KanbanColumn{
+			Name: s.Name, StatusIDs: []string{s.ID}, CategoryKey: s.CategoryKey,
+		})
+	}
+	k.layout = layout
+	k.rebuild()
+}
+
+// SetBoardLayout lays the board out with an agile board's own columns. The
+// statuses are only consulted to colour each header by workflow category.
+func (k *KanbanView) SetBoardLayout(columns []jira.BoardColumn, statuses []jira.Status) {
+	category := make(map[string]string, len(statuses))
+	for _, s := range statuses {
+		category[s.ID] = s.CategoryKey
+	}
+	for i := range k.allIssues {
+		if s := k.allIssues[i].Status; s != nil {
+			if _, known := category[s.ID]; !known {
+				category[s.ID] = s.CategoryKey
+			}
+		}
+	}
+
+	layout := make([]KanbanColumn, 0, len(columns))
+	for _, col := range columns {
+		rendered := KanbanColumn{Name: col.Name, StatusIDs: col.StatusIDs}
+		for _, id := range col.StatusIDs {
+			if key, ok := category[id]; ok && key != "" {
+				rendered.CategoryKey = key
+				break
+			}
+		}
+		layout = append(layout, rendered)
+	}
+	k.layout = layout
+	k.rebuild()
+}
+
+// SetIssues replaces the cards, keeping the current layout.
+func (k *KanbanView) SetIssues(issues []jira.Issue) {
+	k.allIssues = issues
+	k.rebuild()
+}
+
+// SetScope restricts the board to the given issue keys, so that narrowing the
+// issue list narrows the board with it. Pass nil to lift the restriction.
+func (k *KanbanView) SetScope(keys map[string]bool) {
+	k.scope = keys
+	k.rebuild()
+}
+
+// SetBoardTabs names the boards of the project and which one is on screen, so
+// the panel title can show them.
+func (k *KanbanView) SetBoardTabs(names []string, active int) {
+	k.boardNames = names
+	k.activeBoard = active
+}
+
+// SetAssigneeFilter restricts the board to the given account ids. An empty set
+// clears the filter. label is what the panel title shows.
+func (k *KanbanView) SetAssigneeFilter(ids map[string]bool, label string) {
+	k.assignees = ids
+	if ids == nil {
+		k.assignees = map[string]bool{}
+	}
+	k.filterLabel = label
+	k.rebuild()
+}
+
+func (k *KanbanView) AssigneeFilter() map[string]bool { return k.assignees }
+func (k *KanbanView) FilterLabel() string             { return k.filterLabel }
+func (k *KanbanView) Columns() []KanbanColumn         { return k.columns }
+
+// statusesFromIssues derives board columns from the issues at hand, preserving
+// first-seen order within each workflow category.
+func statusesFromIssues(issues []jira.Issue) []jira.Status {
+	seen := make(map[string]bool)
+	var out []jira.Status
+	for i := range issues {
+		s := issues[i].Status
+		if s == nil || seen[s.ID] {
+			continue
+		}
+		seen[s.ID] = true
+		out = append(out, *s)
+	}
+	jira.SortStatuses(out)
+	return out
+}
+
+func (k *KanbanView) rebuild() {
+	k.columns = make([]KanbanColumn, len(k.layout))
+	copy(k.columns, k.layout)
+	for i := range k.columns {
+		k.columns[i].Issues = nil
+	}
+
+	for i := range k.allIssues {
+		issue := &k.allIssues[i]
+		if issue.Status == nil || !k.matches(issue) {
+			continue
+		}
+		for c := range k.columns {
+			if k.columns[c].holds(issue.Status.ID) {
+				k.columns[c].Issues = append(k.columns[c].Issues, issue)
+				break
+			}
+		}
+	}
+
+	k.scroll = make([]int, len(k.columns))
+	k.clampCursor()
+}
+
+func (k *KanbanView) matches(issue *jira.Issue) bool {
+	if k.scope != nil && !k.scope[issue.Key] {
+		return false
+	}
+	if len(k.assignees) == 0 {
+		return true
+	}
+	if issue.Assignee == nil {
+		return k.assignees[UnassignedFilterID]
+	}
+	return k.assignees[issue.Assignee.AccountID]
+}
+
+// clampCursor keeps the cursor on an existing card, preferring to stay in the
+// current column and falling back to the first column that has any.
+func (k *KanbanView) clampCursor() {
+	if len(k.columns) == 0 {
+		k.col, k.row = 0, 0
+		return
+	}
+	k.col = min(max(k.col, 0), len(k.columns)-1)
+	if len(k.columns[k.col].Issues) == 0 {
+		for i, column := range k.columns {
+			if len(column.Issues) > 0 {
+				k.col = i
+				break
+			}
+		}
+	}
+	k.row = min(max(k.row, 0), max(len(k.columns[k.col].Issues)-1, 0))
+}
+
+// Move walks the cursor by whole cards (dy) or columns (dx). Changing column
+// keeps the vertical position when the target column is long enough.
+func (k *KanbanView) Move(dx, dy int) {
+	if len(k.columns) == 0 {
+		return
+	}
+	if dx != 0 {
+		k.col = min(max(k.col+dx, 0), len(k.columns)-1)
+		k.row = min(k.row, max(len(k.columns[k.col].Issues)-1, 0))
+	}
+	if dy != 0 {
+		k.row = min(max(k.row+dy, 0), max(len(k.columns[k.col].Issues)-1, 0))
+	}
+}
+
+// SelectByKey moves the cursor to the card holding issueKey, if it is visible
+// under the current filter.
+func (k *KanbanView) SelectByKey(issueKey string) bool {
+	for c, column := range k.columns {
+		for r, issue := range column.Issues {
+			if issue.Key == issueKey {
+				k.col, k.row = c, r
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func (k *KanbanView) SelectedIssue() *jira.Issue {
+	if k.col < 0 || k.col >= len(k.columns) {
+		return nil
+	}
+	column := k.columns[k.col]
+	if k.row < 0 || k.row >= len(column.Issues) {
+		return nil
+	}
+	return column.Issues[k.row]
+}
+
+// Title is the panel heading: the project, its boards as tabs, and the active
+// filter.
+func (k *KanbanView) Title() string {
+	title := "[0] Kanban"
+	if k.projectKey != "" {
+		title += ": " + k.projectKey
+	}
+	if len(k.boardNames) > 0 {
+		marked := make([]string, 0, len(k.boardNames))
+		for i, name := range k.boardNames {
+			if i == k.activeBoard {
+				name = "[" + name + "]"
+			}
+			marked = append(marked, name)
+		}
+		title += " " + strings.Join(marked, " ")
+	}
+	if k.filterLabel != "" {
+		title += " — " + k.filterLabel
+	}
+	return title
+}
+
+// visibleColumnCount is how many columns fit side by side at the current width.
+func (k *KanbanView) visibleColumnCount() int {
+	if k.width <= 0 || len(k.columns) == 0 {
+		return 0
+	}
+	fit := k.width / (minColumnWidth + cardInnerMargin)
+	return min(max(fit, 1), len(k.columns))
+}
+
+func (k *KanbanView) View() string {
+	if len(k.columns) == 0 {
+		return theme.Default.Subtitle.Render("No statuses to show for this project")
+	}
+
+	visible := k.visibleColumnCount()
+	k.hOffset = min(max(k.hOffset, 0), max(len(k.columns)-visible, 0))
+	if k.col < k.hOffset {
+		k.hOffset = k.col
+	} else if k.col >= k.hOffset+visible {
+		k.hOffset = k.col - visible + 1
+	}
+
+	colWidth := max((k.width-(visible-1)*cardInnerMargin)/max(visible, 1), minColumnWidth)
+	cardHeight := max(k.height-1, 1) // one line goes to the column header
+
+	rendered := make([]string, 0, visible)
+	for i := k.hOffset; i < k.hOffset+visible && i < len(k.columns); i++ {
+		rendered = append(rendered, k.renderColumn(i, colWidth, cardHeight))
+	}
+
+	board := lipgloss.JoinHorizontal(lipgloss.Top, rendered...)
+	if len(k.columns) > visible {
+		board += "\n" + theme.Default.Subtitle.Render(
+			"columns "+strconv.Itoa(k.hOffset+1)+"-"+strconv.Itoa(k.hOffset+visible)+" of "+strconv.Itoa(len(k.columns)))
+	}
+	return board
+}
+
+func (k *KanbanView) renderColumn(index, width, height int) string {
+	column := k.columns[index]
+	inner := max(width-cardInnerMargin, 1)
+
+	header := components.TruncateEnd(column.Name, max(inner-6, 4))
+	header += " (" + strconv.Itoa(len(column.Issues)) + ")"
+	headerStyle := theme.StatusColor(column.CategoryKey)
+	if index == k.col {
+		headerStyle = headerStyle.Bold(true)
+	}
+
+	lines := []string{headerStyle.Render(components.TruncateEnd(header, inner))}
+
+	if len(column.Issues) == 0 {
+		lines = append(lines, theme.Default.Subtitle.Render(components.TruncateEnd("—", inner)))
+	}
+
+	// Three lines of content plus a blank separator; scroll by whole cards so
+	// none is cut in half.
+	const cardLines = 4
+	perScreen := max(height/cardLines, 1)
+	if index < len(k.scroll) {
+		if index == k.col {
+			if k.row < k.scroll[index] {
+				k.scroll[index] = k.row
+			} else if k.row >= k.scroll[index]+perScreen {
+				k.scroll[index] = k.row - perScreen + 1
+			}
+		}
+		start := min(k.scroll[index], max(len(column.Issues)-1, 0))
+		for row := start; row < len(column.Issues) && row < start+perScreen; row++ {
+			selected := index == k.col && row == k.row
+			lines = append(lines, k.renderCard(column.Issues[row], inner, selected)...)
+		}
+	}
+
+	body := strings.Join(lines, "\n")
+	return lipgloss.NewStyle().Width(width).MaxHeight(height + 1).Render(body)
+}
+
+// renderCard draws one issue as exactly three lines: key + priority, summary,
+// assignee. The selected card is marked with a leading bar because a
+// background highlight is unreadable over the per-status colors.
+func (k *KanbanView) renderCard(issue *jira.Issue, width int, selected bool) []string {
+	marker, textWidth := "  ", width-2
+	if selected {
+		marker = theme.Default.Title.Render("▌") + " "
+	}
+
+	key := issue.Key
+	if selected {
+		key = theme.Default.Title.Render(key)
+	} else {
+		key = theme.Default.KeyStyle.Render(key)
+	}
+	head := key
+	if issue.Priority != nil {
+		head += " " + theme.PriorityStyled(components.TruncateEnd(issue.Priority.Name, 8))
+	}
+
+	summary := components.TruncateEnd(issue.Summary, textWidth)
+	if !selected {
+		summary = theme.Default.Subtitle.Render(summary)
+	}
+
+	who := "unassigned"
+	if issue.Assignee != nil {
+		who = issue.Assignee.DisplayName
+	}
+	who = theme.AuthorRender(components.TruncateEnd(who, textWidth))
+
+	return []string{
+		marker + components.TruncateEnd(head, textWidth),
+		marker + summary,
+		marker + who,
+		"",
+	}
+}

--- a/pkg/tui/views/kanban_test.go
+++ b/pkg/tui/views/kanban_test.go
@@ -1,0 +1,431 @@
+package views
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/textfuel/lazyjira/v2/pkg/jira"
+)
+
+const (
+	kbKey1 = "P-1"
+	kbKey2 = "P-2"
+	kbKey3 = "P-3"
+	kbKey4 = "P-4"
+)
+
+var (
+	kbTodo       = jira.Status{ID: "1", Name: "To Do", CategoryKey: "new"}
+	kbInProgress = jira.Status{ID: "3", Name: "In Progress", CategoryKey: "indeterminate"}
+	kbDone       = jira.Status{ID: "5", Name: "Done", CategoryKey: "done"}
+
+	kbAlice = &jira.User{AccountID: "u1", DisplayName: "Alice"}
+	kbBob   = &jira.User{AccountID: "u2", DisplayName: "Bob"}
+)
+
+func kbStatuses() []jira.Status {
+	return []jira.Status{kbTodo, kbInProgress, kbDone}
+}
+
+func kbIssues() []jira.Issue {
+	status := func(s jira.Status) *jira.Status { return &s }
+	return []jira.Issue{
+		{Key: kbKey1, Summary: "First", Status: status(kbTodo), Assignee: kbAlice},
+		{Key: kbKey2, Summary: "Second", Status: status(kbTodo), Assignee: kbBob},
+		{Key: kbKey3, Summary: "Third", Status: status(kbInProgress), Assignee: kbAlice},
+		{Key: kbKey4, Summary: "Fourth", Status: status(kbDone)}, // unassigned
+	}
+}
+
+func newTestKanban() *KanbanView {
+	k := NewKanbanView()
+	k.SetProjectKey("P")
+	k.SetSize(120, 20)
+	k.SetData(kbStatuses(), kbIssues())
+	return k
+}
+
+func columnKeys(k *KanbanView, index int) []string {
+	issues := k.Columns()[index].Issues
+	keys := make([]string, 0, len(issues))
+	for _, issue := range issues {
+		keys = append(keys, issue.Key)
+	}
+	return keys
+}
+
+func TestKanbanGroupsIssuesByStatus(t *testing.T) {
+	t.Parallel()
+	k := newTestKanban()
+
+	if len(k.Columns()) != 3 {
+		t.Fatalf("columns = %d, want 3", len(k.Columns()))
+	}
+	if got := columnKeys(k, 0); strings.Join(got, ",") != "P-1,P-2" {
+		t.Errorf("To Do column = %v", got)
+	}
+	if got := columnKeys(k, 2); strings.Join(got, ",") != kbKey4 {
+		t.Errorf("Done column = %v", got)
+	}
+}
+
+func TestKanbanKeepsEmptyColumns(t *testing.T) {
+	t.Parallel()
+	k := NewKanbanView()
+	k.SetSize(120, 20)
+	k.SetData(kbStatuses(), []jira.Issue{{Key: kbKey1, Status: &jira.Status{ID: "1", Name: "To Do", CategoryKey: "new"}}})
+
+	if len(k.Columns()) != 3 {
+		t.Fatalf("columns = %d, want the full status set even when empty", len(k.Columns()))
+	}
+	if len(k.Columns()[1].Issues) != 0 {
+		t.Errorf("In Progress should be empty, got %d", len(k.Columns()[1].Issues))
+	}
+}
+
+func TestKanbanDerivesColumnsWhenStatusesMissing(t *testing.T) {
+	t.Parallel()
+	k := NewKanbanView()
+	k.SetSize(120, 20)
+	k.SetData(nil, kbIssues())
+
+	if len(k.Columns()) != 3 {
+		t.Fatalf("columns = %d, want 3 derived from the issues", len(k.Columns()))
+	}
+	want := []string{"To Do", "In Progress", "Done"}
+	for i, name := range want {
+		if k.Columns()[i].Name != name {
+			t.Errorf("column %d = %q, want %q (category order)", i, k.Columns()[i].Name, name)
+		}
+	}
+}
+
+func TestKanbanAssigneeFilter(t *testing.T) {
+	t.Parallel()
+	k := newTestKanban()
+	k.SetAssigneeFilter(map[string]bool{"u1": true}, "Alice")
+
+	if got := columnKeys(k, 0); strings.Join(got, ",") != kbKey1 {
+		t.Errorf("To Do column = %v, want only Alice's issue", got)
+	}
+	if got := columnKeys(k, 2); len(got) != 0 {
+		t.Errorf("Done column = %v, want empty (P-4 is unassigned)", got)
+	}
+	if k.FilterLabel() != "Alice" {
+		t.Errorf("FilterLabel = %q", k.FilterLabel())
+	}
+}
+
+func TestKanbanFilterMatchesUnassigned(t *testing.T) {
+	t.Parallel()
+	k := newTestKanban()
+	k.SetAssigneeFilter(map[string]bool{UnassignedFilterID: true}, "Unassigned")
+
+	if got := columnKeys(k, 2); strings.Join(got, ",") != kbKey4 {
+		t.Errorf("Done column = %v, want the unassigned issue", got)
+	}
+	if got := columnKeys(k, 0); len(got) != 0 {
+		t.Errorf("To Do column = %v, want empty", got)
+	}
+}
+
+func TestKanbanEmptyFilterShowsEverything(t *testing.T) {
+	t.Parallel()
+	k := newTestKanban()
+	k.SetAssigneeFilter(map[string]bool{"u1": true}, "Alice")
+	k.SetAssigneeFilter(nil, "")
+
+	total := 0
+	for i := range k.Columns() {
+		total += len(k.Columns()[i].Issues)
+	}
+	if total != 4 {
+		t.Errorf("visible issues = %d, want all 4 after clearing the filter", total)
+	}
+}
+
+func TestKanbanCursorMovement(t *testing.T) {
+	t.Parallel()
+	k := newTestKanban()
+
+	if got := k.SelectedIssue(); got == nil || got.Key != kbKey1 {
+		t.Fatalf("initial selection = %v, want P-1", got)
+	}
+	k.Move(0, 1)
+	if got := k.SelectedIssue(); got.Key != kbKey2 {
+		t.Errorf("after down = %s, want P-2", got.Key)
+	}
+	k.Move(1, 0)
+	if got := k.SelectedIssue(); got.Key != kbKey3 {
+		t.Errorf("after right = %s, want P-3 (row clamped to the shorter column)", got.Key)
+	}
+	k.Move(1, 0)
+	if got := k.SelectedIssue(); got.Key != kbKey4 {
+		t.Errorf("after right = %s, want P-4", got.Key)
+	}
+	k.Move(1, 0) // past the last column
+	if got := k.SelectedIssue(); got.Key != kbKey4 {
+		t.Errorf("cursor escaped the board: %s", got.Key)
+	}
+	k.Move(-2, 0)
+	if got := k.SelectedIssue(); got.Key != kbKey1 {
+		t.Errorf("after two lefts = %s, want P-1", got.Key)
+	}
+	k.Move(0, -1) // above the first card
+	if got := k.SelectedIssue(); got.Key != kbKey1 {
+		t.Errorf("cursor escaped upwards: %s", got.Key)
+	}
+}
+
+func TestKanbanCursorSkipsEmptyColumnOnRebuild(t *testing.T) {
+	t.Parallel()
+	k := newTestKanban()
+	k.Move(2, 0) // Done column
+	k.SetAssigneeFilter(map[string]bool{"u1": true}, "Alice")
+
+	got := k.SelectedIssue()
+	if got == nil {
+		t.Fatal("selection is nil after the filter emptied the current column")
+	}
+	if got.Key != kbKey1 {
+		t.Errorf("selection = %s, want the first column that still has cards", got.Key)
+	}
+}
+
+func TestKanbanSelectedIssueNilWhenBoardEmpty(t *testing.T) {
+	t.Parallel()
+	k := NewKanbanView()
+	k.SetSize(80, 20)
+	k.SetData(kbStatuses(), nil)
+
+	if got := k.SelectedIssue(); got != nil {
+		t.Errorf("SelectedIssue = %v, want nil on an empty board", got)
+	}
+	if view := k.View(); view == "" {
+		t.Error("View is empty; an empty board should still render its columns")
+	}
+}
+
+func TestKanbanSelectByKey(t *testing.T) {
+	t.Parallel()
+	k := newTestKanban()
+
+	if !k.SelectByKey(kbKey3) {
+		t.Fatal("SelectByKey(P-3) = false")
+	}
+	if got := k.SelectedIssue(); got.Key != kbKey3 {
+		t.Errorf("selection = %s", got.Key)
+	}
+	if k.SelectByKey("NOPE-1") {
+		t.Error("SelectByKey matched an issue that is not on the board")
+	}
+}
+
+func TestKanbanViewRendersStatusesAndCards(t *testing.T) {
+	t.Parallel()
+	view := newTestKanban().View()
+
+	for _, want := range []string{"To Do", "In Progress", "Done", kbKey1, "First", "Alice"} {
+		if !strings.Contains(view, want) {
+			t.Errorf("view is missing %q:\n%s", want, view)
+		}
+	}
+	if !strings.Contains(view, "(2)") {
+		t.Errorf("view is missing the To Do card count:\n%s", view)
+	}
+}
+
+func TestKanbanViewNarrowTerminalShowsSubsetOfColumns(t *testing.T) {
+	t.Parallel()
+	k := newTestKanban()
+	k.SetSize(40, 20) // room for two columns at most
+
+	view := k.View()
+	if !strings.Contains(view, "of 3") {
+		t.Errorf("narrow view should report hidden columns:\n%s", view)
+	}
+	for _, line := range strings.Split(view, "\n") {
+		if got := lipgloss.Width(line); got > 40 {
+			t.Errorf("line overflows the 40-column panel (%d columns): %q", got, line)
+		}
+	}
+}
+
+func TestKanbanViewScrollsColumnsToFollowCursor(t *testing.T) {
+	t.Parallel()
+	k := newTestKanban()
+	k.SetSize(40, 20)
+
+	k.Move(2, 0) // Done is the third column, off-screen at this width
+	view := k.View()
+	if !strings.Contains(view, "Done") {
+		t.Errorf("board did not scroll to the selected column:\n%s", view)
+	}
+}
+
+func TestKanbanTitleIncludesProjectAndFilter(t *testing.T) {
+	t.Parallel()
+	k := newTestKanban()
+	if got := k.Title(); got != "[0] Kanban: P" {
+		t.Errorf("Title = %q", got)
+	}
+	k.SetAssigneeFilter(map[string]bool{"u1": true}, "Alice")
+	if got := k.Title(); !strings.Contains(got, "Alice") {
+		t.Errorf("Title = %q, want the filter label", got)
+	}
+}
+
+func TestBoardLayoutGroupsSeveralStatusesInOneColumn(t *testing.T) {
+	t.Parallel()
+	k := NewKanbanView()
+	k.SetSize(120, 20)
+	k.SetData(kbStatuses(), kbIssues())
+
+	k.SetBoardLayout([]jira.BoardColumn{
+		{Name: "Backlog", StatusIDs: []string{"1"}},
+		{Name: "Doing", StatusIDs: []string{"3", "5"}},
+	}, kbStatuses())
+
+	cols := k.Columns()
+	if len(cols) != 2 {
+		t.Fatalf("columns = %d, want the board's own two", len(cols))
+	}
+	if cols[0].Name != "Backlog" || len(cols[0].Issues) != 2 {
+		t.Errorf("Backlog = %q with %d cards", cols[0].Name, len(cols[0].Issues))
+	}
+	// In Progress and Done collapse into one column.
+	if cols[1].Name != "Doing" || len(cols[1].Issues) != 2 {
+		t.Errorf("Doing = %q with %d cards, want the two merged statuses", cols[1].Name, len(cols[1].Issues))
+	}
+}
+
+func TestBoardLayoutColoursHeadersFromTheStatusCategory(t *testing.T) {
+	t.Parallel()
+	k := NewKanbanView()
+	k.SetSize(120, 20)
+	k.SetData(kbStatuses(), kbIssues())
+
+	k.SetBoardLayout([]jira.BoardColumn{{Name: "Shipped", StatusIDs: []string{"5"}}}, kbStatuses())
+
+	if got := k.Columns()[0].CategoryKey; got != "done" {
+		t.Errorf("CategoryKey = %q, want the category of the mapped status", got)
+	}
+}
+
+func TestBoardLayoutDropsIssuesOutsideItsColumns(t *testing.T) {
+	t.Parallel()
+	k := NewKanbanView()
+	k.SetSize(120, 20)
+	k.SetData(kbStatuses(), kbIssues())
+
+	// A board that only maps To Do leaves the other issues off the board, as
+	// Jira does for issues outside the board's columns.
+	k.SetBoardLayout([]jira.BoardColumn{{Name: "Only todo", StatusIDs: []string{"1"}}}, kbStatuses())
+
+	total := 0
+	for _, c := range k.Columns() {
+		total += len(c.Issues)
+	}
+	if total != 2 {
+		t.Errorf("cards = %d, want only the two mapped ones", total)
+	}
+}
+
+func TestSetIssuesKeepsTheBoardLayout(t *testing.T) {
+	t.Parallel()
+	k := NewKanbanView()
+	k.SetSize(120, 20)
+	k.SetData(kbStatuses(), kbIssues())
+	k.SetBoardLayout([]jira.BoardColumn{{Name: "Doing", StatusIDs: []string{"3", "5"}}}, kbStatuses())
+
+	k.SetIssues(kbIssues())
+
+	cols := k.Columns()
+	if len(cols) != 1 || cols[0].Name != "Doing" {
+		t.Errorf("columns = %+v, want the layout preserved across new cards", cols)
+	}
+}
+
+func TestBoardTabsAppearInTheTitle(t *testing.T) {
+	t.Parallel()
+	k := newTestKanban()
+
+	k.SetBoardTabs([]string{"Delivery", "Bugs"}, 1)
+
+	got := k.Title()
+	if !strings.Contains(got, "Delivery") || !strings.Contains(got, "[Bugs]") {
+		t.Errorf("Title = %q, want both boards with the active one marked", got)
+	}
+}
+
+func TestSingleBoardIsNotShownAsTabs(t *testing.T) {
+	t.Parallel()
+	k := newTestKanban()
+
+	k.SetBoardTabs(nil, 0)
+
+	if got := k.Title(); got != "[0] Kanban: P" {
+		t.Errorf("Title = %q, want no tab strip for a single board", got)
+	}
+}
+
+func TestScopeRestrictsTheBoardToTheGivenKeys(t *testing.T) {
+	t.Parallel()
+	k := newTestKanban()
+
+	k.SetScope(map[string]bool{kbKey1: true, kbKey3: true})
+
+	total := 0
+	for _, c := range k.Columns() {
+		total += len(c.Issues)
+	}
+	if total != 2 {
+		t.Errorf("cards = %d, want only the two scoped keys", total)
+	}
+	if got := columnKeys(k, 0); strings.Join(got, ",") != kbKey1 {
+		t.Errorf("To Do column = %v", got)
+	}
+}
+
+// nil means "no restriction"; an empty non-nil set means the list is showing
+// nothing, and the board has to agree.
+func TestNilScopeIsNotAnEmptyScope(t *testing.T) {
+	t.Parallel()
+	k := newTestKanban()
+
+	k.SetScope(map[string]bool{})
+	total := 0
+	for _, c := range k.Columns() {
+		total += len(c.Issues)
+	}
+	if total != 0 {
+		t.Errorf("cards = %d, want none for an empty scope", total)
+	}
+
+	k.SetScope(nil)
+	total = 0
+	for _, c := range k.Columns() {
+		total += len(c.Issues)
+	}
+	if total != 4 {
+		t.Errorf("cards = %d, want every card back once the scope is lifted", total)
+	}
+}
+
+func TestScopeAndAssigneeFilterCompose(t *testing.T) {
+	t.Parallel()
+	k := newTestKanban()
+
+	k.SetScope(map[string]bool{kbKey1: true, kbKey2: true})
+	k.SetAssigneeFilter(map[string]bool{"u1": true}, "Alice")
+
+	total := 0
+	for _, c := range k.Columns() {
+		total += len(c.Issues)
+	}
+	if total != 1 {
+		t.Errorf("cards = %d, want the intersection of scope and assignee", total)
+	}
+}


### PR DESCRIPTION
## Summary
- When a project is selected but no issue is open, shows a kanban board built from the project's agile board columns instead of an empty panel.
- Projects with more than one agile board can be cycled through with the existing tab keys.
- The board can be filtered by assignee, and mirrors whatever the issue list currently has visible (tab and search filters included).
- Projects without an agile board fall back to columns derived from status categories.

## Test plan
- `make check` passes.
- Added unit tests for board layout selection, board switching, assignee filtering, and scope mirroring against the issue list.

Closes #124