### PR TITLE
Copy issue key

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -102,6 +102,7 @@ keybinding:
         browser: o
         urlPicker: u
         copyURL: "y"
+        copyKey: "ctrl+y"
         closeJQLTab: x
         createBranch: b
     projects:

--- a/docs/Keybindings.md
+++ b/docs/Keybindings.md
@@ -38,6 +38,7 @@ Detail scroll keys (`J`/`K`/`ctrl+f`/`ctrl+b`) can be remapped via `keybinding.d
 | `o` | Open in browser |
 | `u` | Pick URL from description |
 | `y` | Copy issue URL |
+| `ctrl+y` | Copy issue key |
 | `b` | Create branch from issue |
 | `s` | JQL search |
 | `x` | Close JQL tab |

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -162,6 +162,7 @@ type IssueKeys struct {
 	Browser       string `yaml:"browser"`
 	URLPicker     string `yaml:"urlPicker"`
 	CopyURL       string `yaml:"copyURL"`
+	CopyKey       string `yaml:"copyKey"`
 	CloseJQLTab   string `yaml:"closeJQLTab"`
 	CreateBranch  string `yaml:"createBranch"`
 	CreateIssue   string `yaml:"createIssue"`

--- a/pkg/tui/handlers_keys.go
+++ b/pkg/tui/handlers_keys.go
@@ -378,6 +378,14 @@ func (a *App) handleIssueAction(action Action) (tea.Model, tea.Cmd, bool) {
 	case ActCopyURL:
 		if cur := a.currentIssue(); cur != nil {
 			copyToClipboard(a.cfg.Jira.Host + "/browse/" + cur.Key)
+			a.helpBar.SetStatusMsg("Copied URL for " + cur.Key)
+		}
+		return a, nil, true
+
+	case ActCopyKey:
+		if cur := a.currentIssue(); cur != nil {
+			copyToClipboard(cur.Key)
+			a.helpBar.SetStatusMsg("Copied " + cur.Key)
 		}
 		return a, nil, true
 

--- a/pkg/tui/handlers_keys_test.go
+++ b/pkg/tui/handlers_keys_test.go
@@ -1,9 +1,11 @@
 package tui
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/textfuel/lazyjira/v2/pkg/config"
+	"github.com/textfuel/lazyjira/v2/pkg/internal/testkit"
 	"github.com/textfuel/lazyjira/v2/pkg/jira"
 	"github.com/textfuel/lazyjira/v2/pkg/jira/jiratest"
 )
@@ -175,5 +177,51 @@ func TestHandleIssueAction_Comments(t *testing.T) {
 	}
 	if cmd == nil {
 		t.Error("expected fetch command for uncached issue")
+	}
+}
+
+func TestHandleIssueAction_CopyKey(t *testing.T) {
+	t.Parallel()
+	var captured string
+	original := runExternalCommand
+	t.Cleanup(func() { runExternalCommand = original })
+	runExternalCommand = func(input string, waitForExit bool, name string, args ...string) {
+		captured = input
+	}
+
+	app := focusApp(t)
+	app.issuesList.SetIssues([]jira.Issue{{Key: testKey}})
+	app.previewKey = testKey
+	app.issueCache[testKey] = &jira.Issue{Key: testKey}
+
+	_, _, ok := app.handleIssueAction(ActCopyKey)
+
+	if !ok {
+		t.Fatal("ActCopyKey should be handled")
+	}
+	testkit.AssertEqual(t, "clipboard payload", captured, testKey)
+	if !strings.Contains(app.helpBar.View(), testKey) {
+		t.Errorf("help bar should show status message containing %q, got %q", testKey, app.helpBar.View())
+	}
+}
+
+func TestHandleIssueAction_CopyKey_NoIssueIsNoop(t *testing.T) {
+	t.Parallel()
+	var called bool
+	original := runExternalCommand
+	t.Cleanup(func() { runExternalCommand = original })
+	runExternalCommand = func(input string, waitForExit bool, name string, args ...string) {
+		called = true
+	}
+
+	app := focusApp(t)
+
+	_, _, ok := app.handleIssueAction(ActCopyKey)
+
+	if !ok {
+		t.Fatal("ActCopyKey should report handled even with no issue")
+	}
+	if called {
+		t.Error("clipboard should not be touched when no issue is selected")
 	}
 }

--- a/pkg/tui/keybindings.go
+++ b/pkg/tui/keybindings.go
@@ -67,6 +67,8 @@ func (a *App) ContextBindings() []Binding {
 			a.bind(ActAssignee, "change assignee"),
 			a.bind(ActBrowser, "open issue in browser"),
 			a.bind(ActURLPicker, "open URL picker"),
+			a.bind(ActCopyURL, "copy issue URL"),
+			a.bind(ActCopyKey, "copy issue key"),
 			a.bind(ActCreateBranch, "create branch"),
 			a.bind(ActNew, "create issue"),
 			a.bind(ActDuplicateIssue, "duplicate issue"),
@@ -86,6 +88,8 @@ func (a *App) ContextBindings() []Binding {
 			a.bind(ActAssignee, "change assignee"),
 			a.bind(ActBrowser, "open issue in browser"),
 			a.bind(ActURLPicker, "open URL picker"),
+			a.bind(ActCopyURL, "copy issue URL"),
+			a.bind(ActCopyKey, "copy issue key"),
 			a.bind(ActFocusRight, "next panel"),
 			a.bind(ActFocusLeft, "previous panel"),
 		)
@@ -117,6 +121,8 @@ func (a *App) ContextBindings() []Binding {
 			a.bind(ActAssignee, "change assignee"),
 			a.bind(ActBrowser, "open in browser"),
 			a.bind(ActURLPicker, "open URL picker"),
+			a.bind(ActCopyURL, "copy issue URL"),
+			a.bind(ActCopyKey, "copy issue key"),
 		)
 		if a.detailView.ActiveTab() == views.TabComments {
 			bindings = append(bindings,

--- a/pkg/tui/keybindings_test.go
+++ b/pkg/tui/keybindings_test.go
@@ -90,6 +90,26 @@ func TestContextBindings_DetailCommentsIncludesEdit(t *testing.T) {
 	}
 }
 
+func TestContextBindings_IssuesIncludesCopyKey(t *testing.T) {
+	t.Parallel()
+	app := appForKeybindings(t)
+	app.side = sideLeft
+	app.leftFocus = focusIssues
+
+	bindings := app.ContextBindings()
+
+	found := false
+	for _, binding := range bindings {
+		if binding.Description == "copy issue key" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("copy issue key binding missing from issues context")
+	}
+}
+
 func TestHelpBarItems_NotEmpty(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/tui/keymap.go
+++ b/pkg/tui/keymap.go
@@ -28,6 +28,7 @@ const (
 	ActFocusInfo      Action = "focusInfo"
 	ActFocusProj      Action = "focusProjects"
 	ActCopyURL        Action = "copyURL"
+	ActCopyKey        Action = "copyKey"
 	ActBrowser        Action = "browser"
 	ActURLPicker      Action = "urlPicker"
 	ActTransition     Action = "transition"
@@ -82,6 +83,7 @@ func DefaultKeymap() Keymap {
 		ActFocusInfo:      {"3"},
 		ActFocusProj:      {"4"},
 		ActCopyURL:        {"y"},
+		ActCopyKey:        {"ctrl+y"},
 		ActBrowser:        {"o"},
 		ActURLPicker:      {"u"},
 		ActTransition:     {"t"},
@@ -146,6 +148,7 @@ func KeymapFromConfig(kcfg config.KeybindingConfig) Keymap {
 	set(ActBrowser, kcfg.Issues.Browser)
 	set(ActURLPicker, kcfg.Issues.URLPicker)
 	set(ActCopyURL, kcfg.Issues.CopyURL)
+	set(ActCopyKey, kcfg.Issues.CopyKey)
 	set(ActCloseJQLTab, kcfg.Issues.CloseJQLTab)
 	set(ActCreateBranch, kcfg.Issues.CreateBranch)
 	set(ActCreateIssue, kcfg.Issues.CreateIssue)

--- a/pkg/tui/keymap_test.go
+++ b/pkg/tui/keymap_test.go
@@ -39,3 +39,23 @@ func TestKeymap_MatchUnknownReturnsEmpty(t *testing.T) {
 	testkit.AssertEqual(t, "unknown key", keymap.Match("this-key-is-unbound"), Action(""))
 	testkit.AssertEqual(t, "unknown nav key", keymap.MatchNav("this-key-is-unbound"), components.NavNone)
 }
+
+func TestDefaultKeymap_CopyKeyBoundToCtrlY(t *testing.T) {
+	t.Parallel()
+
+	keymap := DefaultKeymap()
+
+	testkit.AssertEqual(t, "copyKey resolves ctrl+y", keymap.Match("ctrl+y"), ActCopyKey)
+}
+
+func TestKeymapFromConfig_CopyKeyOverride(t *testing.T) {
+	t.Parallel()
+
+	var keybindingConfig config.KeybindingConfig
+	keybindingConfig.Issues.CopyKey = "Y"
+
+	keymap := KeymapFromConfig(keybindingConfig)
+
+	testkit.AssertSliceEqual(t, "copyKey binding overridden", keymap[ActCopyKey], []string{"Y"})
+	testkit.AssertEqual(t, "Match resolves override", keymap.Match("Y"), ActCopyKey)
+}


### PR DESCRIPTION
## What

Add a key binding to copy just the issue key with <Ctrl+y>.
Add help text for existing copy issue URL and new copy issue key.

## Why

F.e.: If you wanna manually create a branch with just the key.

## How to test

Open lazyjira, go to the issue pane and press <Ctrl+y> to copy the issue key.

## Screenshot

<img width="1191" height="1179" alt="bettershot_1786356555940" src="https://github.com/user-attachments/assets/6925f9d2-8498-49d5-bbec-54c43d27c72c" />
