### PR TITLE
docs: fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,11 +219,11 @@ Press `?` inside the app for all keybindings.
 
 ## Star History
 
-<a href="https://www.star-history.com/?repos=textfuel%2Flazyjira&type=date&legend=top-left">
+<a href="https://star-history.dera.page/#textfuel/lazyjira&type=date&legend=top-left">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/image?repos=textfuel/lazyjira&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/image?repos=textfuel/lazyjira&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/image?repos=textfuel/lazyjira&type=date&legend=top-left" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/image?repos=textfuel/lazyjira&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/image?repos=textfuel/lazyjira&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/image?repos=textfuel/lazyjira&type=date&legend=top-left" />
  </picture>
 </a>
 


### PR DESCRIPTION
The star history chart on the README is currently broken and no longer renders. This change points the chart to the star-history.dera.page domain, which serves both the chart image and the wrapping link on the same domain, so the chart displays correctly again.