### PR TITLE
fix(tui): mark the active issue tab

### DIFF
--- a/pkg/tui/views/issues.go
+++ b/pkg/tui/views/issues.go
@@ -494,87 +494,104 @@ func (m *IssuesList) View() string {
 	return components.RenderPanelFull(title, footer, content, m.Width, visible, m.Focused, scroll)
 }
 
-// ClickTabAt handles clicks on the title bar to switch tabs and returns true if the tab changed
-func (m *IssuesList) ClickTabAt(x int) bool {
-	if len(m.tabs) == 0 {
-		return false
+const issueTabPrefix = "[2] "
+
+type issueTabLayout struct {
+	prefix string
+	sep    string
+	tabs   []issueTabLayoutEntry
+}
+
+type issueTabLayoutEntry struct {
+	index int
+	label string
+	width int
+	start int
+	end   int
+}
+
+func (l issueTabLayout) title() string {
+	parts := make([]string, len(l.tabs))
+	for i, tab := range l.tabs {
+		parts[i] = tab.label
 	}
-	prefix := 4
-	sepW := 3
-	pos := prefix
-	for i, t := range m.tabs {
-		labelW := len(t.Name)
-		var zoneEnd int
-		if i < len(m.tabs)-1 {
-			zoneEnd = pos + labelW + sepW
-		} else {
-			zoneEnd = pos + labelW + 10
+	return l.prefix + strings.Join(parts, l.sep)
+}
+
+// ClickTabAt handles clicks on the visible title-bar tabs and returns true if
+// the tab changed. Separators belong to the tab immediately before them.
+func (m *IssuesList) ClickTabAt(x int) bool {
+	layout := m.issueTabLayout(m.titleMaxWidth())
+	for _, tab := range layout.tabs {
+		if x < tab.start || x >= tab.end {
+			continue
 		}
-		if x >= pos && x < zoneEnd {
-			if m.tab != i {
-				m.tab = i
-				m.applyFilter()
-				return true
-			}
-			return false
+		if m.tab != tab.index {
+			m.tab = tab.index
+			m.loadFromCache()
+			return true
 		}
-		pos = zoneEnd
+		return false
 	}
 	return false
 }
 
-// buildTitle builds the tab bar title for the issues panel. When all tabs fit
-// within maxTitleW the full list is shown. When they don't, a contiguous
-// sliding window that always contains the active tab is displayed, preserving
-// the original tab order. The window expands leftward first (showing context
-// before the active tab), then fills any remaining budget rightward.
-func (m *IssuesList) buildTitle(maxTitleW int) string {
+func (m *IssuesList) titleMaxWidth() int {
+	contentWidth, _ := components.PanelDimensions(m.Width, m.Height)
+	return contentWidth - 1
+}
+
+// issueTabLayout is the single source of truth for issue-tab labels, their
+// visible sliding window, and click regions. The active label uses an ASCII
+// marker so selection remains clear even when terminal colors are unavailable.
+func (m *IssuesList) issueTabLayout(maxTitleW int) issueTabLayout {
+	if len(m.tabs) == 0 {
+		return issueTabLayout{prefix: "[2] Issues"}
+	}
+
 	activeStyle := lipgloss.NewStyle().Foreground(theme.ColorGreen).Bold(true)
 	inactiveStyle := lipgloss.NewStyle().Foreground(theme.ColorWhite)
 	sep := lipgloss.NewStyle().Foreground(theme.ColorGray).Render(" - ")
 	sepW := lipgloss.Width(sep)
-
-	if len(m.tabs) == 0 {
-		return "[2] Issues"
-	}
+	prefixW := lipgloss.Width(issueTabPrefix)
 
 	labels := make([]string, len(m.tabs))
-	labelW := make([]int, len(m.tabs))
-	for i, t := range m.tabs {
+	widths := make([]int, len(m.tabs))
+	for i, tab := range m.tabs {
 		if i == m.tab {
-			labels[i] = activeStyle.Render(t.Name)
+			labels[i] = activeStyle.Render("[" + tab.Name + "]")
 		} else {
-			labels[i] = inactiveStyle.Render(t.Name)
+			labels[i] = inactiveStyle.Render(tab.Name)
 		}
-		labelW[i] = lipgloss.Width(labels[i])
+		widths[i] = lipgloss.Width(labels[i])
 	}
 
-	const prefix = "[2] "
-	prefixW := lipgloss.Width(prefix)
-
-	fullTitle := prefix + strings.Join(labels, sep)
-	if maxTitleW <= 0 || lipgloss.Width(fullTitle) <= maxTitleW {
-		return fullTitle
+	fullWidth := prefixW + (len(labels)-1)*sepW
+	for _, width := range widths {
+		fullWidth += width
+	}
+	if maxTitleW <= 0 || fullWidth <= maxTitleW {
+		return issueTabWindow(issueTabPrefix, sep, labels, widths, 0, len(labels)-1)
 	}
 
 	// Overflow: find a contiguous sliding window that always contains the
 	// active tab. Expand left first (preserving context), then fill right.
 	budget := maxTitleW - prefixW
-
-	// If the active tab label alone exceeds the budget, truncate it so the
-	// title never returns wider than maxTitleW regardless of label length.
-	if budget > 0 && labelW[m.tab] > budget {
-		truncated := components.TruncateEnd(m.tabs[m.tab].Name, budget)
-		labels[m.tab] = activeStyle.Render(truncated)
-		labelW[m.tab] = lipgloss.Width(labels[m.tab])
+	const activeMarkerWidth = 2 // "[" + "]"
+	if budget >= activeMarkerWidth && widths[m.tab] > budget {
+		nameBudget := budget - activeMarkerWidth
+		name := ""
+		if nameBudget > 0 {
+			name = components.TruncateEnd(m.tabs[m.tab].Name, nameBudget)
+		}
+		labels[m.tab] = activeStyle.Render("[" + name + "]")
+		widths[m.tab] = lipgloss.Width(labels[m.tab])
 	}
 
-	start := m.tab
-	end := m.tab
-	used := labelW[m.tab]
-
+	start, end := m.tab, m.tab
+	used := widths[m.tab]
 	for start > 0 {
-		cost := labelW[start-1] + sepW
+		cost := widths[start-1] + sepW
 		if used+cost > budget {
 			break
 		}
@@ -582,7 +599,7 @@ func (m *IssuesList) buildTitle(maxTitleW int) string {
 		used += cost
 	}
 	for end < len(m.tabs)-1 {
-		cost := labelW[end+1] + sepW
+		cost := widths[end+1] + sepW
 		if used+cost > budget {
 			break
 		}
@@ -590,11 +607,33 @@ func (m *IssuesList) buildTitle(maxTitleW int) string {
 		used += cost
 	}
 
-	var parts []string
+	return issueTabWindow(issueTabPrefix, sep, labels, widths, start, end)
+}
+
+func issueTabWindow(prefix, sep string, labels []string, widths []int, start, end int) issueTabLayout {
+	layout := issueTabLayout{prefix: prefix, sep: sep}
+	pos := lipgloss.Width(prefix)
+	sepW := lipgloss.Width(sep)
 	for i := start; i <= end; i++ {
-		parts = append(parts, labels[i])
+		entry := issueTabLayoutEntry{
+			index: i,
+			label: labels[i],
+			width: widths[i],
+			start: pos,
+			end:   pos + widths[i],
+		}
+		if i < end {
+			entry.end += sepW
+		}
+		layout.tabs = append(layout.tabs, entry)
+		pos = entry.end
 	}
-	return prefix + strings.Join(parts, sep)
+	return layout
+}
+
+// buildTitle builds the tab bar title for the issues panel.
+func (m *IssuesList) buildTitle(maxTitleW int) string {
+	return m.issueTabLayout(maxTitleW).title()
 }
 
 func (m *IssuesList) renderIssueRow(issue jira.Issue, width int, selected bool) string {

--- a/pkg/tui/views/issues_render_test.go
+++ b/pkg/tui/views/issues_render_test.go
@@ -150,11 +150,34 @@ func TestIssuesList_ClickTabAt_SwitchesTab(t *testing.T) {
 	)
 	list.SetIssues([]jira.Issue{{Key: testKey}})
 	list.SetSize(80, 24)
-	switched := list.ClickTabAt(10)
+	// The active "All" label is rendered as "[All]" (five columns),
+	// followed by the three-column separator; Mine starts at column 12.
+	// Column 10 is still inside the marker-expanded All click region.
+	if list.ClickTabAt(10) {
+		t.Error("marker-expanded active tab region switched to Mine")
+	}
+	switched := list.ClickTabAt(12)
 	if !switched {
 		t.Error("ClickTabAt on second tab should switch")
 	}
 	testkit.AssertEqual(t, "tab index", list.GetTabIndex(), 1)
+}
+
+func TestIssuesList_ClickTabAt_IgnoresHiddenOverflowTabs(t *testing.T) {
+	t.Parallel()
+	list := listWithTabs(
+		config.IssueTabConfig{Name: "First", JQL: "first"},
+		config.IssueTabConfig{Name: "Second", JQL: "second"},
+		config.IssueTabConfig{Name: "Third", JQL: "third"},
+	)
+	list.SetSize(30, 24)
+
+	// At this width only [First] and Second are visible. Column 22 is where
+	// the old full-list hit testing would have started Third.
+	if list.ClickTabAt(22) {
+		t.Error("click on hidden tab region switched tabs")
+	}
+	testkit.AssertEqual(t, "active tab remains visible tab", list.GetTabIndex(), 0)
 }
 
 func TestIssuesList_ClickTabAt_SameTabNoSwitch(t *testing.T) {

--- a/pkg/tui/views/issues_tab_title_test.go
+++ b/pkg/tui/views/issues_tab_title_test.go
@@ -28,6 +28,19 @@ func makeIssuesListWithTabs(width, height int, tabNames ...string) *IssuesList {
 	return m
 }
 
+func TestIssuesList_TitleMarksOnlyActiveTab(t *testing.T) {
+	t.Parallel()
+	m := makeIssuesListWithTabs(50, 8, "My Issues", "Done")
+
+	plain := stripANSI(topBorderLine(m))
+	if !strings.Contains(plain, "[My Issues]") {
+		t.Errorf("title = %q, want active marker around My Issues", plain)
+	}
+	if strings.Contains(plain, "[Done]") {
+		t.Errorf("title = %q, must not mark inactive tab Done", plain)
+	}
+}
+
 func TestIssuesList_TopBorderWidth_FewTabs(t *testing.T) {
 	t.Parallel()
 	const width = 50
@@ -155,6 +168,10 @@ func TestIssuesList_ActiveTabTruncated_WhenLabelExceedsBudget(t *testing.T) {
 	m := makeIssuesListWithTabs(width, 8, "A Very Long Tab Name")
 
 	line := topBorderLine(m)
+	plain := stripANSI(line)
+	if !strings.Contains(plain, "[A Very Lon…]") {
+		t.Errorf("title = %q, want active marker with truncated label", plain)
+	}
 	got := lipgloss.Width(line)
 	if got != width {
 		t.Errorf("top border width = %d, want %d (label overflowed border)\nline: %q", got, width, line)


### PR DESCRIPTION
## What

Marks the active issue-list tab with brackets, such as `[All]`, in addition to its existing color.

Uses the same visible-tab layout for title rendering and mouse hit regions. Clicks can only select tabs currently shown in the sliding overflow window.

## Why

Color alone can make the active tab difficult to distinguish in some themes and terminals.

Issue-tab titles use a sliding window when they exceed the panel width. Mouse hit-testing still assumed the full tab list was visible, so clicking after the last visible tab could select a hidden one.

## How to test

1. Configure several issue tabs and narrow the terminal until some tabs are hidden.
2. Switch tabs with `[` and `]`; confirm only the active tab is wrapped in brackets.
3. Click each visible tab and confirm the matching tab becomes active.
4. Click after the final visible tab and confirm no hidden tab is selected.
5. Run `make check`.